### PR TITLE
Fix javascript error in TinyMCE

### DIFF
--- a/resources/views/fields/tinymce.blade.php
+++ b/resources/views/fields/tinymce.blade.php
@@ -58,7 +58,7 @@ $(function () {
 
             axios.post('/dashboard/systems/files', data)
                 .then(function (response) {
-                    success('/storage/' + response.data.path + response.data.name + '.' + response.data.extension,);
+                    success('/storage/' + response.data.path + response.data.name + '.' + response.data.extension);
                 })
                 .catch(function (error) {
                     console.log(error);


### PR DESCRIPTION
Javascript Error:  Uncaught SyntaxError: Unexpected token )

У меня почему-то не работает TinyMCE с этой запятой.

