### PR TITLE
Сохранение разделов

### DIFF
--- a/resources/views/container/systems/category/info.blade.php
+++ b/resources/views/container/systems/category/info.blade.php
@@ -27,7 +27,7 @@
     <div class="form-group m-t-md">
         <label class="control-label">{{trans('dashboard::systems/category.slug')}}</label>
         <input type="text" name="slug"
-               value="{{!$termTaxonomy->exists ? null : optional($termTaxonomy->term)->slug}}"
+               value="{{!$termTaxonomy->exists ? old('slug') : optional($termTaxonomy->term)->slug}}"
                required class="form-control" placeholder="news">
     </div>
     </div>

--- a/src/Platform/Forms/Form.php
+++ b/src/Platform/Forms/Form.php
@@ -85,7 +85,7 @@ abstract class Form implements FormInterface
     {
         $rules = $this->rules() ?: $this->rules;
 
-        $this->validate($this->request, $rules);
+        $this->validate($this->request, $rules, $this->validationMessages(), $this->validationCustomAttributes());
 
         return true;
     }
@@ -96,6 +96,16 @@ abstract class Form implements FormInterface
      * @return array
      */
     public function rules() : array
+    {
+        return [];
+    }
+
+    public function validationMessages() : array
+    {
+        return [];
+    }
+
+    public function validationCustomAttributes() : array
     {
         return [];
     }

--- a/src/Platform/Http/Controllers/Systems/CategoryController.php
+++ b/src/Platform/Http/Controllers/Systems/CategoryController.php
@@ -59,7 +59,7 @@ class CategoryController extends Controller
 
         Alert::success(trans('dashboard::common.alert.success'));
 
-        return back();
+        return redirect()->route('dashboard.systems.category.edit', ['id' => $termTaxonomy->term_id]);
     }
 
     /**

--- a/src/Platform/Http/Forms/Category/CategoryDescForm.php
+++ b/src/Platform/Http/Forms/Category/CategoryDescForm.php
@@ -48,9 +48,16 @@ class CategoryDescForm extends Form
      */
     public function rules() : array
     {
-        return array_merge([
-            'slug' => 'required|max:255|unique:terms,slug,'.$this->request->get('slug').',slug',
-        ], $this->behavior->rules());
+        return $this->behavior->rules();
+    }
+
+    public function validationCustomAttributes() : array
+    {
+        return [
+            'content.*.name' => trans('dashboard::systems/category.fields.name_title'),
+            'content.*.body' => trans('dashboard::systems/category.fields.body_title'),
+            'slug' => trans('dashboard::systems/category.slug'),
+        ];
     }
 
     /**
@@ -84,7 +91,10 @@ class CategoryDescForm extends Form
             $termTaxonomy = new $this->model();
         }
 
-        $termTaxonomy->term->fill($request->all());
+        $data = $request->all();
+        $data['slug'] = str_slug($data['slug']);
+
+        $termTaxonomy->term->fill($data);
         $termTaxonomy->term->save();
     }
 }

--- a/src/Platform/Http/Forms/Category/CategoryMainForm.php
+++ b/src/Platform/Http/Forms/Category/CategoryMainForm.php
@@ -49,7 +49,7 @@ class CategoryMainForm extends Form
                 'required',
                 'max:255',
                 Rule::unique('terms', 'slug')->ignore($this->request->get('term_id'), 'id'),
-            ]
+            ],
         ], (new $category())->rules());
     }
 


### PR DESCRIPTION
## Proposed Changes

  - Form.php добавлены методы `validationMessages() : array` и `validationCustomAttributes() : array`, для передачи в валидатор своих сообщений
  - info.blade.php при ошибке при создании записи не возвращалось введенное значение slug
  - CategoryController в методе `store(...)` вместо `back()` - `redirect()` на страницу редактирования созданной записи
  - CategoryMainForm - исправлены правила валидации добавлена валидация второй формы; наименования атрибутов в валидацию; нормализация slug перед сохранением.
  - CategoryDescForm - исправлены правила валидации убрана проверка уникальности slug, т.к. она выполняется в CategoryMainForm; наименования атрибутов в валидацию; нормализация slug перед сохранением.
