### PR TITLE
Issue with attachment group definition

### DIFF
--- a/src/Platform/Traits/AttachTrait.php
+++ b/src/Platform/Traits/AttachTrait.php
@@ -28,7 +28,7 @@ trait AttachTrait
         );
 
         if (! is_null($group)) {
-            $query->where('attachmentable_group', $group);
+            $query->where('group', $group);
         }
 
         return $query


### PR DESCRIPTION
```SQLSTATE[42S22]: Column not found: 1054 Unknown column 'attachmentable_group' in 'where clause' (SQL: select `attachments`.*, `attachmentable`.`attachmentable_id` as `pivot_attachmentable_id`, `attachmentable`.`attachment_id` as `pivot_attachment_id`, `attachmentable`.`attachmentable_type` as `pivot_attachmentable_type` from `attachments` inner join `attachmentable` on `attachments`.`id` = `attachmentable`.`attachment_id` where `attachmentable`.`attachmentable_id` = 1 and `attachmentable`.`attachmentable_type` = App\Models\Customer and `attachmentable_group` = document order by `sort` asc)```

Fixes 

## Proposed Changes

  - Fix the naming of the field in where clause.