### PR TITLE
Ошибка Uncaught ReferenceError: platform is not defined

### DIFF
--- a/resources/js/controllers/layouts/html_load_controller.js
+++ b/resources/js/controllers/layouts/html_load_controller.js
@@ -9,12 +9,12 @@ export default class extends Controller {
      */
     initialize() {
         Turbolinks.start();
-        Turbolinks.setProgressBarDelay(50);
         window.platform = platform();
 
         document.addEventListener("turbolinks:load", () => {
             this.csrf();
         });
+        Turbolinks.setProgressBarDelay(50);
     }
 
     /**


### PR DESCRIPTION
Иногда выдает ошибку (у меня в TinyMCE)
Uncaught ReferenceError: platform is not defined
и 
TypeError: Cannot read property 'setProgressBarDelay' of undefined

если setProgressBarDelay поставить вконец, то если даже выдаст вторую ошибку то window.platform  успеет сработать.

Хотя думаю лучше вообще убрать ` Turbolinks.setProgressBarDelay(50); ` так как он есть по умолчанию (500 мс).