### PR TITLE
Модальное информационное окно.

### DIFF
--- a/resources/views/container/layouts/modals.blade.php
+++ b/resources/views/container/layouts/modals.blade.php
@@ -35,15 +35,15 @@
                         @csrf
                     </div>
                     <div class="modal-footer">
-
                         <button type="button" class="btn btn-link" data-dismiss="modal">
                             {{ $close }}
                         </button>
-
-                        <button type="submit" id="submit-modal-{{$key}}"
-                                class="btn btn-default">
-                            {{ $apply }}
-                        </button>
+                        @if (!is_null($apply))
+                            <button type="submit" id="submit-modal-{{$key}}"
+                                    class="btn btn-default">
+                                {{ $apply }}
+                            </button>
+                        @endif
                     </div>
                 </form>
             </div>

--- a/src/Screen/Layouts/Modals.php
+++ b/src/Screen/Layouts/Modals.php
@@ -56,7 +56,7 @@ abstract class Modals extends Base
      *
      * @return Modals
      */
-    public function applyButton(string $text): self
+    public function applyButton($text): self
     {
         $this->variables['apply'] = $text;
 


### PR DESCRIPTION
#### Это как пример для подумать) - можно не принимать.
Иногда нужно просто показать информационное окно и не нужна кнопка применить.
```php
Layout::modals([
    'exampleModals' => Layout::rows([]),
])
    ->applyButton(null),
```