### PR TITLE
Update modal.blade.php

### DIFF
--- a/resources/views/actions/modal.blade.php
+++ b/resources/views/actions/modal.blade.php
@@ -4,6 +4,7 @@
             data-action="screen--base#targetModal"
             data-modal-title="{{ $title ?? '' }}"
             data-modal-key="{{ $modal ?? '' }}"
+            data-modal-params="@json($asyncParams)"
             data-modal-action="{{ $action }}">
         <i class="{{ $icon ?? '' }} m-r-xs"></i>{{ $name ?? '' }}
     </button>


### PR DESCRIPTION
This ensures params or options given to ModalToggle::loadModalAsync() are available in the request used to load the async modal.

Fixes #
Issue with options/params given to ModalToggle::loadModalAsync() not showing in the request 