### PR TITLE
Update modal.blade.php

### DIFF
--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -16,7 +16,7 @@
                       enctype="multipart/form-data"
                       data-controller="layouts--form"
                       data-action="layouts--form#submit"
-                      data-layouts--form-button-animate="#screen-modal-{{$key}}"
+                      data-layouts--form-button-animate="#submit-modal-{{$key}}"
                       data-layouts--form-button-text="{{ __('Loading...') }}"
                 >
                     <div class="modal-header">
@@ -26,7 +26,7 @@
                     </div>
                     <div class="modal-body">
                         <div data-async>
-                            @foreach($manyForms as $key => $modal)
+                            @foreach($manyForms as $formKey => $modal)
                                 @foreach($modal as $item)
                                     {!! $item ?? '' !!}
                                 @endforeach


### PR DESCRIPTION
Fixes #
Issue where the submit button in the modal does not show a spinning animation when clicked and the form is being submitted

## Proposed Changes

Specify correct key for element to animate when form is being submitted or form submit button is clicked

Change loop key so it does not interfere with the key variable for the submit button key (without this the id of the submit button is `submit-modal-0`  instead of `submit-button-modalName`)

