### PR TITLE
Changed path constant to a static method

### DIFF
--- a/src/Filters/HttpFilter.php
+++ b/src/Filters/HttpFilter.php
@@ -23,14 +23,17 @@ class HttpFilter
      * @var Request
      */
     protected $request;
+
     /**
      * @var Collection
      */
     protected $filters;
+
     /**
      * @var Collection
      */
     protected $sorts;
+
     /**
      * Model options and allowed params.
      *
@@ -126,7 +129,7 @@ class HttpFilter
      *
      * @return Builder
      */
-    protected function filtersExact(Builder $query, $value, string $property)
+    protected function filtersExact(Builder $query, $value, string $property): Builder
     {
         $property = self::sanitize($property);
 
@@ -167,7 +170,7 @@ class HttpFilter
      *
      * @return bool
      */
-    public function isSort($property = null)
+    public function isSort(string $property = null): bool
     {
         if (is_null($property)) {
             return $this->sorts->isEmpty();
@@ -187,9 +190,9 @@ class HttpFilter
     /**
      * @param string $property
      *
-     * @return mixed
+     * @return string
      */
-    public function revertSort($property)
+    public function revertSort(string $property): string
     {
         if ($this->getSort($property) === 'asc') {
             return '-'.$property;
@@ -203,7 +206,7 @@ class HttpFilter
      *
      * @return string
      */
-    public function getSort($property)
+    public function getSort(string $property): string
     {
         if ($this->sorts->search($property, true) !== false) {
             return 'asc';
@@ -217,7 +220,7 @@ class HttpFilter
      *
      * @return mixed
      */
-    public function getFilter($property)
+    public function getFilter(string $property)
     {
         return Arr::get($this->filters, $property);
     }

--- a/src/Platform/Commands/ChartCommand.php
+++ b/src/Platform/Commands/ChartCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class ChartCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class ChartCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/chart.stub';
+        return Dashboard::path('resources/stubs/chart.stub');
     }
 
     /**

--- a/src/Platform/Commands/FilterCommand.php
+++ b/src/Platform/Commands/FilterCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class FilterCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class FilterCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/filters.stub';
+        return Dashboard::path('resources/stubs/filters.stub');
     }
 
     /**

--- a/src/Platform/Commands/InstallCommand.php
+++ b/src/Platform/Commands/InstallCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Orchid\Platform\Commands;
 
 use Orchid\Platform\Updates;
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\Command;
 use Orchid\Platform\Events\InstallEvent;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -51,7 +52,7 @@ class InstallCommand extends Command
              | |  | | |  _  /  | |      |  __  |   | |   | |  | |
              | |__| | | | \ \  | |____  | |  | |  _| |_  | |__| |
               \____/  |_|  \_\  \_____| |_|  |_| |_____| |_____/
-                             
+
                              Installation started. Please wait...
                              Version: $updates->currentVersion
         ________________________________________________________________
@@ -131,7 +132,7 @@ class InstallCommand extends Command
             return;
         }
 
-        $user = file_get_contents(PLATFORM_PATH.'/install-stubs/User.stub');
+        $user = file_get_contents(Dashboard::path('install-stubs/User.stub'));
         file_put_contents(app_path('User.php'), $user);
     }
 
@@ -164,7 +165,7 @@ class InstallCommand extends Command
         $confirm = $this->confirm('The platform has already been installed, do you really want to repeat?');
 
         if (! $confirm) {
-            die();
+            exit(0);
         }
 
         return $this;

--- a/src/Platform/Commands/MetricsCommand.php
+++ b/src/Platform/Commands/MetricsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class MetricsCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class MetricsCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/metrics.stub';
+        return Dashboard::path('resources/stubs/metrics.stub');
     }
 
     /**

--- a/src/Platform/Commands/RowsCommand.php
+++ b/src/Platform/Commands/RowsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class RowsCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class RowsCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/rows.stub';
+        return Dashboard::path('resources/stubs/rows.stub');
     }
 
     /**

--- a/src/Platform/Commands/ScreenCommand.php
+++ b/src/Platform/Commands/ScreenCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class ScreenCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class ScreenCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/screen.stub';
+        return Dashboard::path('resources/stubs/screen.stub');
     }
 
     /**

--- a/src/Platform/Commands/SelectionCommand.php
+++ b/src/Platform/Commands/SelectionCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class SelectionCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class SelectionCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/selection.stub';
+        return Dashboard::path('resources/stubs/selection.stub');
     }
 
     /**

--- a/src/Platform/Commands/TableCommand.php
+++ b/src/Platform/Commands/TableCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Console\GeneratorCommand;
 
 class TableCommand extends GeneratorCommand
@@ -36,7 +37,7 @@ class TableCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return PLATFORM_PATH.'/resources/stubs/table.stub';
+        return Dashboard::path('resources/stubs/table.stub');
     }
 
     /**

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -136,11 +136,11 @@ class Dashboard
      * Get the class name for a given Dashboard model.
      *
      * @param string      $key
-     * @param null|string $default
+     * @param string|null $default
      *
      * @return string
      */
-    public static function model(string $key, string $default = null)
+    public static function model(string $key, string $default = null): string
     {
         return Arr::get(static::$options, 'models.'.$key, $default ?? $key);
     }
@@ -162,6 +162,18 @@ class Dashboard
     public static function checkUpdate(): bool
     {
         return (new Updates())->check();
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return string
+     */
+    public static function path(string $path = ''): string
+    {
+        $current = dirname(__DIR__, 2);
+
+        return realpath($current.($path ? DIRECTORY_SEPARATOR.$path : $path));
     }
 
     /**

--- a/src/Platform/Http/Screens/SearchScreen.php
+++ b/src/Platform/Http/Screens/SearchScreen.php
@@ -123,7 +123,7 @@ class SearchScreen extends Screen
                 $result = $model->searchQuery($query)->paginate(3);
                 $label = $model->searchLabel();
 
-                if ($result->total() == 0) {
+                if ($result->total() === 0) {
                     return;
                 }
 

--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -70,7 +70,7 @@ class FoundationServiceProvider extends ServiceProvider
      */
     protected function registerDatabase(): self
     {
-        $path = realpath(PLATFORM_PATH.'/database/migrations');
+        $path = Dashboard::path('database/migrations');
 
         $this->loadMigrationsFrom($path);
 
@@ -88,7 +88,7 @@ class FoundationServiceProvider extends ServiceProvider
      */
     public function registerTranslations(): self
     {
-        $this->loadJsonTranslationsFrom(realpath(PLATFORM_PATH.'/resources/lang/'));
+        $this->loadJsonTranslationsFrom(Dashboard::path('resources/lang/'));
 
         return $this;
     }
@@ -101,7 +101,7 @@ class FoundationServiceProvider extends ServiceProvider
     protected function registerConfig(): self
     {
         $this->publishes([
-            realpath(PLATFORM_PATH.'/config/platform.php') => config_path('platform.php'),
+            Dashboard::path('config/platform.php') => config_path('platform.php'),
         ], 'config');
 
         return $this;
@@ -115,8 +115,8 @@ class FoundationServiceProvider extends ServiceProvider
     protected function registerOrchid(): self
     {
         $this->publishes([
-            realpath(PLATFORM_PATH.'/install-stubs/routes/') => base_path('routes'),
-            realpath(PLATFORM_PATH.'/install-stubs/Orchid/') => app_path('Orchid'),
+            Dashboard::path('install-stubs/routes/') => base_path('routes'),
+            Dashboard::path('install-stubs/Orchid/') => app_path('Orchid'),
         ], 'orchid-stubs');
 
         return $this;
@@ -130,8 +130,8 @@ class FoundationServiceProvider extends ServiceProvider
     protected function registerAssets(): self
     {
         $this->publishes([
-            realpath(PLATFORM_PATH.'/resources/js')   => resource_path('js/orchid'),
-            realpath(PLATFORM_PATH.'/resources/sass') => resource_path('sass/orchid'),
+            Dashboard::path('resources/js')   => resource_path('js/orchid'),
+            Dashboard::path('resources/sass') => resource_path('sass/orchid'),
         ], 'orchid-assets');
 
         return $this;
@@ -144,7 +144,7 @@ class FoundationServiceProvider extends ServiceProvider
      */
     public function registerViews(): self
     {
-        $path = realpath(PLATFORM_PATH.'/resources/views');
+        $path = Dashboard::path('resources/views');
 
         $this->loadViewsFrom($path, 'platform');
 
@@ -202,13 +202,15 @@ class FoundationServiceProvider extends ServiceProvider
 
         if (! defined('PLATFORM_PATH')) {
             /*
+             * @deprecated
+             *
              * Get the path to the ORCHID Platform folder.
              */
-            define('PLATFORM_PATH', realpath(__DIR__.'/../../../'));
+            define('PLATFORM_PATH', Dashboard::path());
         }
 
         $this->mergeConfigFrom(
-            realpath(PLATFORM_PATH.'/config/platform.php'), 'platform'
+            Dashboard::path('config/platform.php'), 'platform'
         );
 
         /*

--- a/src/Platform/Providers/PlatformServiceProvider.php
+++ b/src/Platform/Providers/PlatformServiceProvider.php
@@ -37,7 +37,7 @@ class PlatformServiceProvider extends ServiceProvider
                 ->registerResource('scripts', config('platform.resource.scripts', null))
                 ->registerPermissions($this->registerPermissionsMain())
                 ->registerPermissions($this->registerPermissionsSystems())
-                ->addPublicDirectory('orchid', PLATFORM_PATH.'/public/');
+                ->addPublicDirectory('orchid', Dashboard::path('public/'));
         });
     }
 

--- a/src/Platform/Providers/RouteServiceProvider.php
+++ b/src/Platform/Providers/RouteServiceProvider.php
@@ -25,7 +25,7 @@ class RouteServiceProvider extends ServiceProvider
 
         $this->binding();
 
-        require PLATFORM_PATH.'/routes/breadcrumbs.php';
+        require Dashboard::path('routes/breadcrumbs.php');
 
         parent::boot();
     }
@@ -57,7 +57,7 @@ class RouteServiceProvider extends ServiceProvider
         Route::domain((string) config('platform.domain'))
             ->prefix(Dashboard::prefix('/'))
             ->as('platform.')
-            ->group(realpath(PLATFORM_PATH.'/routes/public.php'));
+            ->group(Dashboard::path('routes/public.php'));
 
         /*
          * Dashboard
@@ -66,7 +66,7 @@ class RouteServiceProvider extends ServiceProvider
             ->prefix(Dashboard::prefix('/'))
             ->as('platform.')
             ->middleware(config('platform.middleware.private'))
-            ->group(realpath(PLATFORM_PATH.'/routes/dashboard.php'));
+            ->group(Dashboard::path('routes/dashboard.php'));
 
         /*
          * Auth
@@ -75,7 +75,7 @@ class RouteServiceProvider extends ServiceProvider
             ->prefix(Dashboard::prefix('/'))
             ->as('platform.')
             ->middleware(config('platform.middleware.public'))
-            ->group(realpath(PLATFORM_PATH.'/routes/auth.php'));
+            ->group(Dashboard::path('routes/auth.php'));
 
         /*
          * Systems
@@ -84,7 +84,7 @@ class RouteServiceProvider extends ServiceProvider
             ->prefix(Dashboard::prefix('/systems'))
             ->as('platform.')
             ->middleware(config('platform.middleware.private'))
-            ->group(realpath(PLATFORM_PATH.'/routes/systems.php'));
+            ->group(Dashboard::path('routes/systems.php'));
 
         /*
          * Application

--- a/src/Presets/Source.php
+++ b/src/Presets/Source.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Presets;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Foundation\Console\Presets\Preset as ConsolePreset;
 
 class Source extends ConsolePreset
@@ -37,7 +38,9 @@ class Source extends ConsolePreset
      */
     protected static function updatePackageArray(array $packages, $configurationKey)
     {
-        $orchidPackages = json_decode(file_get_contents(PLATFORM_PATH.'/package.json'), true);
+        $path = Dashboard::path('package.json');
+
+        $orchidPackages = json_decode(file_get_contents($path), true);
 
         return $orchidPackages[$configurationKey] + $packages;
     }
@@ -62,7 +65,7 @@ class Source extends ConsolePreset
      */
     protected static function addBabelConfiguration()
     {
-        copy(PLATFORM_PATH.'/.babelrc', base_path('.babelrc'));
+        copy(Dashboard::path('.babelrc'), base_path('.babelrc'));
     }
 
     /**
@@ -74,7 +77,7 @@ class Source extends ConsolePreset
      */
     protected static function orchidConfig(): string
     {
-        $orchidConfig = file_get_contents(PLATFORM_PATH.'/webpack.mix.js');
+        $orchidConfig = file_get_contents(Dashboard::path('webpack.mix.js'));
         preg_match(self::ORCHID_MIX_CONFIG_PATTERN, $orchidConfig, $matches);
 
         $transformedConfig = count($matches) === 2 ? $matches[1] : '';

--- a/src/Screen/Fields/ViewField.php
+++ b/src/Screen/Fields/ViewField.php
@@ -15,64 +15,11 @@ use Orchid\Screen\Field;
 class ViewField extends Field
 {
     /**
-     * Required Attributes.
-     *
-     * @var array
-     */
-    protected $required = [
-        'view',
-    ];
-
-    /**
-     * Default attributes value.
-     *
-     * @var array
-     */
-    protected $attributes = [];
-
-    /**
-     * Attributes available for a particular tag.
-     *
-     * @var array
-     */
-    protected $inlineAttributes = [
-        'accept',
-        'accesskey',
-        'autocomplete',
-        'autofocus',
-        'checked',
-        'disabled',
-        'form',
-        'formaction',
-        'formenctype',
-        'formmethod',
-        'formnovalidate',
-        'formtarget',
-        'language',
-        'lineNumbers',
-        'list',
-        'max',
-        'maxlength',
-        'min',
-        'name',
-        'pattern',
-        'placeholder',
-        'readonly',
-        'required',
-        'size',
-        'src',
-        'step',
-        'tabindex',
-        'type',
-        'value',
-    ];
-
-    /**
      * @param string $view
      *
-     * @return self
+     * @return ViewField
      */
-    public function view(string $view)
+    public function view(string $view): self
     {
         $this->view = $view;
 

--- a/src/Screen/TD.php
+++ b/src/Screen/TD.php
@@ -98,8 +98,8 @@ class TD
     }
 
     /**
-     * @param string $name
-     * @param string $title
+     * @param string      $name
+     * @param string|null $title
      *
      * @return TD
      */
@@ -175,9 +175,9 @@ class TD
     /**
      * @deprecated Use Link class
      *
-     * @param string $route
-     * @param mixed  $options
-     * @param string $text
+     * @param string      $route
+     * @param mixed       $options
+     * @param string|null $text
      *
      * @return TD
      */
@@ -233,7 +233,7 @@ class TD
      *
      * @return TD
      */
-    public function loadModalAsync(string $modal, $method, $options, string $text = null): self
+    public function loadModalAsync(string $modal, string $method, $options, string $text = null): self
     {
         $this->render(function ($datum) use ($modal, $method, $options, $text) {
             $attributes = [];

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -18,7 +18,7 @@ if (! function_exists('alert')) {
      *
      * @return Alert
      */
-    function alert($message = null, $level = 'info')
+    function alert(string $message = null, $level = 'info'): Alert
     {
         $notifier = app(Alert::class);
 
@@ -46,11 +46,11 @@ if (! function_exists('setting')) {
 if (! function_exists('is_sort')) {
 
     /**
-     * @param null $property
+     * @param string $property
      *
      * @return bool
      */
-    function is_sort($property = null)
+    function is_sort(string $property): bool
     {
         $filter = new HttpFilter();
 
@@ -65,7 +65,7 @@ if (! function_exists('get_sort')) {
      *
      * @return string
      */
-    function get_sort($property)
+    function get_sort($property): string
     {
         $filter = new HttpFilter();
 
@@ -76,11 +76,11 @@ if (! function_exists('get_sort')) {
 if (! function_exists('get_filter')) {
 
     /**
-     * @param null|string $property
+     * @param string $property
      *
      * @return string|array
      */
-    function get_filter($property)
+    function get_filter(string $property)
     {
         $filter = new HttpFilter();
 
@@ -91,11 +91,11 @@ if (! function_exists('get_filter')) {
 if (! function_exists('get_filter_string')) {
 
     /**
-     * @param null|string $property
+     * @param string $property
      *
      * @return string
      */
-    function get_filter_string($property)
+    function get_filter_string(string $property): ?string
     {
         $filter = get_filter($property);
 
@@ -110,11 +110,11 @@ if (! function_exists('get_filter_string')) {
 if (! function_exists('revert_sort')) {
 
     /**
-     * @param null|string $property
+     * @param string $property
      *
      * @return string
      */
-    function revert_sort($property)
+    function revert_sort(string $property): string
     {
         $filter = new HttpFilter();
 

--- a/tests/Environment.php
+++ b/tests/Environment.php
@@ -31,7 +31,7 @@ trait Environment
         $this->loadMigrationsFrom(realpath('./database/migrations'));
         $this->artisan('migrate', ['--database' => 'orchid']);
 
-        $this->withFactories(realpath(PLATFORM_PATH.'/database/factories'));
+        $this->withFactories(Dashboard::path('database/factories'));
 
         $this->artisan('db:seed', [
             '--class' => OrchidDatabaseSeeder::class,

--- a/tests/Exemplar/ExemplarServiceProvider.php
+++ b/tests/Exemplar/ExemplarServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Tests\Exemplar;
 
+use Orchid\Platform\Dashboard;
 use Illuminate\Support\ServiceProvider;
 
 class ExemplarServiceProvider extends ServiceProvider
@@ -13,6 +14,6 @@ class ExemplarServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        $this->loadViewsFrom(PLATFORM_PATH.'/tests/Exemplar/views', 'exemplar');
+        $this->loadViewsFrom(Dashboard::path('tests/Exemplar/views'), 'exemplar');
     }
 }


### PR DESCRIPTION
Added a new appeal:

```php
use Orchid\Platform\Dashboard;

// base usage
Dashboard::path();

// path to file
Dashboard::path('config/platform.php');
```

Handling through a constant is deprecated:

```php
$config = PLATFORM_PATH.'/config/platform.php';
```