### PR TITLE
Strict comparison operator

### DIFF
--- a/resources/views/fields/select.blade.php
+++ b/resources/views/fields/select.blade.php
@@ -6,7 +6,7 @@
                         @isset($value)
                         @if (is_array($value) && in_array($key, $value)) selected
                         @elseif (isset($value[$key]) && $value[$key] == $option) selected
-                        @elseif ($key == $value) selected
+                        @elseif ($key === $value) selected
                         @endif
                         @endisset
                 >{{$option}}</option>


### PR DESCRIPTION
Fixes this error:

`Object of class Illuminate\Database\Eloquent\Collection could not be converted to int (View: /Users/ostap/Desktop/smart-logistics/resources/views/vendor/platform/fields/select.blade.php)`

## Proposed Changes

  - Change comparison to strict comparison

## Steps to reproduce

Create some screen, and add this field:

```php
Select::make('delivery.users.')
    ->title(__('Managers'))
    ->options(
        User::all()->pluck('name', 'id')
    )->multiple()
```


