### PR TITLE
Not found resource for windows

### DIFF
--- a/src/Platform/Http/Controllers/Systems/ResourceController.php
+++ b/src/Platform/Http/Controllers/Systems/ResourceController.php
@@ -69,6 +69,8 @@ class ResourceController
 
         $iterator = tap($resources->getIterator())->rewind();
 
+        $path = DIRECTORY_SEPARATOR === '\\' ? str_replace('/', DIRECTORY_SEPARATOR, $path) : $path;
+
         $this->resource = collect($iterator)
             ->filter(static function (SplFileInfo $file) use ($path) {
                 return $file->getRelativePathname() === $path;


### PR DESCRIPTION
## Fixed
  -  `DIRECTORY_SEPARATOR` in `ResourceController` fix, it will work correctly on Windows

