### PR TITLE
Fix changelog: Laravel 6.0 -> 7.0 typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## 6.12.0 - 2020-03-04
 
 ### Added
-- Support Laravel 6.0
+- Support Laravel 7.0
 
 ### Fixed
 - Not found resource for Windows [#1056](https://github.com/orchidsoftware/platform/pull/1056)


### PR DESCRIPTION
## Proposed Changes

  - Support Laravel 7.0 instead of 6.0 typo