### PR TITLE
Removed the restriction of the length of the name in the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 7.0.2 - 2020-03-16
+
+### Fixed
+- Removed the restriction of the length of the name in the screen [#1066](https://github.com/orchidsoftware/platform/pull/1066)
+
 ## 7.0.1 - 2020-03-15
 
 ### Fixed
-- Dont open modal after validation [#1065](https://github.com/orchidsoftware/platform/pull/1065)
+- Don't open modal after validation [#1065](https://github.com/orchidsoftware/platform/pull/1065)
 
 ## 7.0.0 - 2020-03-12
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -44,11 +44,11 @@
 @section('body-right')
     <div class="wrapper mt-md-4 @hasSection('navbar') @else d-none d-md-block @endif">
         <div class="v-md-center">
-            <div class="d-none d-md-block col-xs-12 col-md-4 no-padder">
+            <div class="d-none d-md-block col-xs-12 col-md no-padder">
                 <h1 class="m-n font-thin h3 text-black">@yield('title')</h1>
-                <small class="text-muted text-ellipsis" title="@yield('description')">@yield('description')</small>
+                <small class="text-muted" title="@yield('description')">@yield('description')</small>
             </div>
-            <div class="col-xs-12 col-md-8 no-padder">
+            <div class="col-xs-12 col-md-auto ml-auto no-padder">
                 <ul class="nav command-bar justify-content-sm-end justify-content-start v-center">
                     @yield('navbar')
                 </ul>

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -16,7 +16,7 @@ class Dashboard
     /**
      * ORCHID Version.
      */
-    public const VERSION = '7.0.1';
+    public const VERSION = '7.0.2';
 
     /**
      * The Dashboard configuration options.


### PR DESCRIPTION
Fixed the behavior setting the maximum width for the name and description of the screen properties. Even if there are no buttons in the `CommandBar`, the name could not take its place.

![image](https://user-images.githubusercontent.com/5102591/76767761-279eab80-67ab-11ea-8b57-02f9383a1c8f.png)
