### PR TITLE
number format update

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -45,6 +45,9 @@
         <env name="SCOUT_DRIVER" value="array"/>
         <env name="SCOUT_QUEUE" value="true"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <ini name="memory_limit" value="1024M" />
+        <ini name="post_max_size" value="1024M" />
+        <ini name="upload_max_filesize" value="1024M" />
     </php>
     <logging>
          <log type="coverage-clover" target="clover.xml"/>

--- a/src/Support/Init.php
+++ b/src/Support/Init.php
@@ -88,9 +88,9 @@ class Init
     private static function convertBytesTo(string $to, $bytes, $point = 0)
     {
         return [
-            self::KB => number_format($bytes / 1024, $point),
-            self::MB => number_format($bytes / 1048576, $point),
-            self::GB => number_format($bytes / 1073741824, $point),
+            self::KB => number_format($bytes / 1024, $point, '.', ''),
+            self::MB => number_format($bytes / 1048576, $point, '.', ''),
+            self::GB => number_format($bytes / 1073741824, $point, '.', ''),
         ][$to] ?? 0;
     }
 }

--- a/tests/Unit/SupportFormatsTest.php
+++ b/tests/Unit/SupportFormatsTest.php
@@ -1,10 +1,10 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Orchid\Tests\Unit;
 
 use Orchid\Support\Formats;
+use Orchid\Support\Init;
 use Orchid\Tests\TestUnitCase;
 
 class SupportFormatsTest extends TestUnitCase
@@ -22,5 +22,12 @@ class SupportFormatsTest extends TestUnitCase
         $this->assertEquals(Formats::formatBytes(10000000), '9.54 MB');
         $this->assertEquals(Formats::formatBytes(1000000000000), '931.32 GB');
         $this->assertEquals(Formats::formatBytes(10000000000000), '9.09 TB');
+    }
+
+    public function testConvertBytes()
+    {
+        $this->assertEquals(Init::maxFileUpload(Init::KB), 1048576);
+        $this->assertEquals(Init::maxFileUpload(Init::MB), 1024);
+        $this->assertEquals(Init::maxFileUpload(Init::GB), 1);
     }
 }


### PR DESCRIPTION
Fixes #
Убрана запятая в качестве разделителя разрядов из функции number_format(), которая стоит по умолчанию, иначе при привидении к числу, значения после первой запятой отбрасываются