### PR TITLE
add default to user permissions

### DIFF
--- a/database/migrations/2015_04_12_000000_create_orchid_users_table.php
+++ b/database/migrations/2015_04_12_000000_create_orchid_users_table.php
@@ -13,7 +13,7 @@ class CreateOrchidUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->timestamp('last_login')->nullable();
-            $table->jsonb('permissions')->default('{}')->nullable();
+            $table->jsonb('permissions')->nullable();
         });
     }
 

--- a/database/migrations/2015_04_12_000000_create_orchid_users_table.php
+++ b/database/migrations/2015_04_12_000000_create_orchid_users_table.php
@@ -13,7 +13,7 @@ class CreateOrchidUsersTable extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->timestamp('last_login')->nullable();
-            $table->jsonb('permissions')->nullable();
+            $table->jsonb('permissions')->default('{}')->nullable();
         });
     }
 

--- a/src/Access/UserAccess.php
+++ b/src/Access/UserAccess.php
@@ -71,7 +71,10 @@ trait UserAccess
         if (! $cache || is_null($this->cachePermissions)) {
             $this->cachePermissions = $this->roles()
                 ->pluck('permissions')
-                ->prepend($this->permissions);
+                ->prepend($this->permissions)
+                ->filter(function ($permission){
+                    return is_array($permission);
+                });
         }
 
         return $this->cachePermissions

--- a/tests/Unit/PermissionTest.php
+++ b/tests/Unit/PermissionTest.php
@@ -135,4 +135,18 @@ class PermissionTest extends TestUnitCase
 
         $this->assertFalse($user->inRole($role));
     }
+
+    public function testEmptyPermission(): void
+    {
+        $nullPermission = $this->createUser()
+            ->setAttribute('permissions', null)
+            ->hasAccess('access.to.secret.data');
+
+        $stringPermission = $this->createUser()
+            ->setAttribute('permissions', '')
+            ->hasAccess('access.to.secret.data');
+
+        $this->assertFalse($nullPermission);
+        $this->assertFalse($stringPermission);
+    }
 }


### PR DESCRIPTION


Fixes #
When trying to access the dashboard with an empty permissions field the error below is received, while setting a default ([] or {}) results in a 403 which is the expected behaviour
`Argument 1 passed to Orchid\Platform\Models\User::Orchid\Access\{closure}() must be of the type array, null given`
## Proposed Changes
  - add a default to the column
  - check if `$this->cachePermissions` is null in `src/Access/UserAccess.php:77`
