### PR TITLE
custom model attributes in selects

### DIFF
--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -133,7 +133,7 @@ class Select extends Field
     {
         $key = $key ?? $builder->getModel()->getKeyName();
 
-        return $this->setFromEloquent($builder, $name, $key);
+        return $this->setFromEloquent($builder->get(), $name, $key);
     }
 
     /**

--- a/tests/Unit/Screen/Fields/SelectTest.php
+++ b/tests/Unit/Screen/Fields/SelectTest.php
@@ -1,12 +1,13 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Orchid\Tests\Unit\Screen\Fields;
 
 use Orchid\Platform\Models\Role;
 use Orchid\Screen\Fields\Select;
 use Orchid\Screen\Fields\TextArea;
+use Orchid\Tests\App\EmptyUserModel;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
 
 /**
@@ -143,6 +144,24 @@ class SelectTest extends TestFieldsUnitCase
 
         foreach ($this->roles as $role) {
             $option = $this->stringOption($role->name, $role->id);
+            $this->assertStringContainsString($option, $view);
+        }
+
+        $option = $this->stringOption('empty');
+        $this->assertStringContainsString($option, $view);
+    }
+
+    public function testAttributesCanBeUsed()
+    {
+
+        $select = Select::make('choice')
+            ->empty('empty')
+            ->fromQuery(EmptyUserModel::orderBy('id'), 'full');
+
+        $view = self::minifyRenderField($select);
+
+        foreach (EmptyUserModel::all() as $user) {
+            $option = $this->stringOption($user->full, $user->id);
             $this->assertStringContainsString($option, $view);
         }
 


### PR DESCRIPTION
by executing the query before plucking model attributes can be used as 'name' property

Fixes #
```php
Select::make('category.parent_id')
                ->title('Categoria padre')
                ->fromQuery(Category::byCurrentShop()->orderBy('path'), 'indented_name') // indented_name is magic attribute of Category (getIndentedNameAttribute),
```
## Proposed Changes
- Execute the query and perform the pluck on models
