### PR TITLE
Auto added dot for multiple

### DIFF
--- a/src/Screen/Concerns/Multipliable.php
+++ b/src/Screen/Concerns/Multipliable.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Screen\Concerns;
+
+use Illuminate\Support\Str;
+
+trait Multipliable
+{
+    /**
+     * @return self
+     */
+    public function multiple(): self
+    {
+        $name = Str::finish($this->get('name'), '.');
+
+        $this->set('multiple', 'multiple')
+            ->set('name', $name);
+
+        return $this;
+    }
+}

--- a/src/Screen/Fields/CheckBox.php
+++ b/src/Screen/Fields/CheckBox.php
@@ -71,7 +71,6 @@ class CheckBox extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Code.php
+++ b/src/Screen/Fields/Code.php
@@ -87,7 +87,6 @@ class Code extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Cropper.php
+++ b/src/Screen/Fields/Cropper.php
@@ -23,7 +23,6 @@ namespace Orchid\Screen\Fields;
  * @method Cropper max(int $value)
  * @method Cropper maxlength(int $value)
  * @method Cropper min(int $value)
- * @method Cropper multiple($value = true)
  * @method Cropper name(string $value = null)
  * @method Cropper pattern($value = true)
  * @method Cropper placeholder(string $value = null)
@@ -85,7 +84,6 @@ class Cropper extends Picture
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/DateRange.php
+++ b/src/Screen/Fields/DateRange.php
@@ -68,7 +68,6 @@ class DateRange extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/DateTimer.php
+++ b/src/Screen/Fields/DateTimer.php
@@ -76,7 +76,6 @@ class DateTimer extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Screen\Fields;
 
+use Illuminate\Support\Str;
 use Orchid\Screen\Field;
 
 /**
@@ -24,7 +25,6 @@ use Orchid\Screen\Field;
  * @method Input max(int $value)
  * @method Input maxlength(int $value)
  * @method Input min(int $value)
- * @method Input multiple($value = true)
  * @method Input name(string $value = null)
  * @method Input pattern($value = true)
  * @method Input placeholder(string $value = null)
@@ -112,5 +112,16 @@ class Input extends Field
         });
 
         return $input;
+    }
+
+    /**
+     * @return self
+     */
+    public function multiple(): self
+    {
+        $this->attributes['multiple'] = 'multiple';
+        $this->attributes['name'] = Str::finish($this->get('name'), '.');
+
+        return $this;
     }
 }

--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Screen\Fields;
 
-use Illuminate\Support\Str;
+use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 
 /**
@@ -43,6 +43,8 @@ use Orchid\Screen\Field;
  */
 class Input extends Field
 {
+    use Multipliable;
+
     /**
      * @var string
      */
@@ -112,16 +114,5 @@ class Input extends Field
         });
 
         return $input;
-    }
-
-    /**
-     * @return self
-     */
-    public function multiple(): self
-    {
-        $this->attributes['multiple'] = 'multiple';
-        $this->attributes['name'] = Str::finish($this->get('name'), '.');
-
-        return $this;
     }
 }

--- a/src/Screen/Fields/Map.php
+++ b/src/Screen/Fields/Map.php
@@ -62,7 +62,6 @@ class Map extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Password.php
+++ b/src/Screen/Fields/Password.php
@@ -24,7 +24,6 @@ use Orchid\Screen\Field;
  * @method Password max(int $value)
  * @method Password maxlength(int $value)
  * @method Password min(int $value)
- * @method Password multiple($value = true)
  * @method Password name(string $value = null)
  * @method Password pattern($value = true)
  * @method Password placeholder(string $value = null)
@@ -75,7 +74,6 @@ class Password extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -67,7 +67,6 @@ class Quill extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Radio.php
+++ b/src/Screen/Fields/Radio.php
@@ -68,7 +68,6 @@ class Radio extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/RadioButtons.php
+++ b/src/Screen/Fields/RadioButtons.php
@@ -48,7 +48,6 @@ class RadioButtons extends Field
         'autofocus',
         'disabled',
         'form',
-        'multiple',
         'name',
         'required',
         'size',

--- a/src/Screen/Fields/Relation.php
+++ b/src/Screen/Fields/Relation.php
@@ -7,6 +7,7 @@ namespace Orchid\Screen\Fields;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
 use Orchid\Screen\Field;
 use Orchid\Support\Assert;
 
@@ -87,11 +88,12 @@ class Relation extends Field
     }
 
     /**
-     * @return Relation
+     * @return self
      */
     public function multiple(): self
     {
         $this->attributes['multiple'] = 'multiple';
+        $this->attributes['name'] = Str::finish($this->get('name'), '.');
 
         return $this;
     }

--- a/src/Screen/Fields/Relation.php
+++ b/src/Screen/Fields/Relation.php
@@ -7,7 +7,7 @@ namespace Orchid\Screen\Fields;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Str;
+use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 use Orchid\Support\Assert;
 
@@ -29,6 +29,8 @@ use Orchid\Support\Assert;
  */
 class Relation extends Field
 {
+    use Multipliable;
+
     /**
      * @var string
      */
@@ -85,17 +87,6 @@ class Relation extends Field
     public static function make(string $name = null): self
     {
         return (new static())->name($name);
-    }
-
-    /**
-     * @return self
-     */
-    public function multiple(): self
-    {
-        $this->attributes['multiple'] = 'multiple';
-        $this->attributes['name'] = Str::finish($this->get('name'), '.');
-
-        return $this;
     }
 
     /**

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -6,7 +6,7 @@ namespace Orchid\Screen\Fields;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 
 /**
@@ -27,6 +27,8 @@ use Orchid\Screen\Field;
  */
 class Select extends Field
 {
+    use Multipliable;
+
     /**
      * @var string
      */
@@ -67,17 +69,6 @@ class Select extends Field
     public static function make(string $name = null): self
     {
         return (new static())->name($name);
-    }
-
-    /**
-     * @return self
-     */
-    public function multiple(): self
-    {
-        $this->attributes['multiple'] = 'multiple';
-        $this->attributes['name'] = Str::finish($this->get('name'), '.');
-
-        return $this;
     }
 
     /**

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -6,6 +6,7 @@ namespace Orchid\Screen\Fields;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Orchid\Screen\Field;
 
 /**
@@ -74,6 +75,7 @@ class Select extends Field
     public function multiple(): self
     {
         $this->attributes['multiple'] = 'multiple';
+        $this->attributes['name'] = Str::finish($this->get('name'), '.');
 
         return $this;
     }

--- a/src/Screen/Fields/SimpleMDE.php
+++ b/src/Screen/Fields/SimpleMDE.php
@@ -59,7 +59,6 @@ class SimpleMDE extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Switcher.php
+++ b/src/Screen/Fields/Switcher.php
@@ -20,7 +20,6 @@ use Orchid\Screen\Field;
  * @method Switcher formmethod($value = true)
  * @method Switcher formnovalidate($value = true)
  * @method Switcher formtarget($value = true)
- * @method Switcher multiple($value = true)
  * @method Switcher name(string $value = null)
  * @method Switcher placeholder(string $value = null)
  * @method Switcher readonly($value = true)
@@ -74,7 +73,6 @@ class Switcher extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/TimeZone.php
+++ b/src/Screen/Fields/TimeZone.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Orchid\Screen\Fields;
 
 use DateTimeZone;
+use Illuminate\Support\Str;
 use Orchid\Screen\Field;
 
 /**
@@ -47,7 +48,6 @@ class TimeZone extends Field
         'autofocus',
         'disabled',
         'form',
-        'multiple',
         'name',
         'required',
         'size',
@@ -70,6 +70,7 @@ class TimeZone extends Field
     public function multiple(): self
     {
         $this->attributes['multiple'] = 'multiple';
+        $this->attributes['name'] = Str::finish($this->get('name'), '.');
 
         return $this;
     }

--- a/src/Screen/Fields/TimeZone.php
+++ b/src/Screen/Fields/TimeZone.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Orchid\Screen\Fields;
 
 use DateTimeZone;
-use Illuminate\Support\Str;
+use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 
 /**
@@ -23,6 +23,8 @@ use Orchid\Screen\Field;
  */
 class TimeZone extends Field
 {
+    use Multipliable;
+
     /**
      * @var string
      */
@@ -62,17 +64,6 @@ class TimeZone extends Field
     public static function make(string $name = null): self
     {
         return (new static())->name($name)->listIdentifiers();
-    }
-
-    /**
-     * @return self
-     */
-    public function multiple(): self
-    {
-        $this->attributes['multiple'] = 'multiple';
-        $this->attributes['name'] = Str::finish($this->get('name'), '.');
-
-        return $this;
     }
 
     /**

--- a/src/Screen/Fields/UTM.php
+++ b/src/Screen/Fields/UTM.php
@@ -15,7 +15,6 @@ use Orchid\Screen\Field;
  * @method UTM formmethod($value = true)
  * @method UTM formnovalidate($value = true)
  * @method UTM formtarget($value = true)
- * @method UTM multiple($value = true)
  * @method UTM name(string $value = null)
  * @method UTM placeholder(string $value = null)
  * @method UTM required(bool $value = true)
@@ -65,7 +64,6 @@ class UTM extends Field
         'max',
         'maxlength',
         'min',
-        'multiple',
         'name',
         'pattern',
         'placeholder',

--- a/src/Screen/Fields/Upload.php
+++ b/src/Screen/Fields/Upload.php
@@ -20,7 +20,6 @@ use Orchid\Support\Init;
  * @method Upload formmethod($value = true)
  * @method Upload formnovalidate($value = true)
  * @method Upload formtarget($value = true)
- * @method Upload multiple($value = true)
  * @method Upload name(string $value = null)
  * @method Upload placeholder(string $value = null)
  * @method Upload value($value = true)

--- a/tests/Unit/Screen/Fields/SelectTest.php
+++ b/tests/Unit/Screen/Fields/SelectTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Orchid\Tests\Unit\Screen\Fields;
 
 use Orchid\Platform\Models\Role;
+use Orchid\Screen\Builder;
 use Orchid\Screen\Fields\Select;
 use Orchid\Screen\Fields\TextArea;
+use Orchid\Screen\Repository;
 use Orchid\Tests\App\EmptyUserModel;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
 
@@ -170,10 +172,13 @@ class SelectTest extends TestFieldsUnitCase
 
     public function testNameContainDotForMultiple(): void
     {
-        $select = Select::make('choice')->multiple();
-        $view = self::minifyRenderField($select);
+        $builder = new Builder([
+            Select::make('choice')->multiple()
+        ]);
 
-        $this->assertStringContainsString('choice[]', $view);
+        $html = $builder->generateForm();
+
+        $this->assertStringContainsString('choice[]', $html);
     }
 
     /**

--- a/tests/Unit/Screen/Fields/SelectTest.php
+++ b/tests/Unit/Screen/Fields/SelectTest.php
@@ -8,7 +8,6 @@ use Orchid\Platform\Models\Role;
 use Orchid\Screen\Builder;
 use Orchid\Screen\Fields\Select;
 use Orchid\Screen\Fields\TextArea;
-use Orchid\Screen\Repository;
 use Orchid\Tests\App\EmptyUserModel;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
 
@@ -173,7 +172,7 @@ class SelectTest extends TestFieldsUnitCase
     public function testNameContainDotForMultiple(): void
     {
         $builder = new Builder([
-            Select::make('choice')->multiple()
+            Select::make('choice')->multiple(),
         ]);
 
         $html = $builder->generateForm();

--- a/tests/Unit/Screen/Fields/SelectTest.php
+++ b/tests/Unit/Screen/Fields/SelectTest.php
@@ -168,6 +168,14 @@ class SelectTest extends TestFieldsUnitCase
         $this->assertStringContainsString($option, $view);
     }
 
+    public function testNameContainDotForMultiple(): void
+    {
+        $select = Select::make('choice')->multiple();
+        $view = self::minifyRenderField($select);
+
+        $this->assertStringContainsString('choice[]', $view);
+    }
+
     /**
      * @param        $name
      * @param string $value


### PR DESCRIPTION
This change makes the point at the end of the field name optional for the multiple.

_Before_
```php
Select::make('user.roles.')
    ->fromModel(Role::class, 'name')
    ->multiple()
```

_After_

```php
Select::make('user.roles')
    ->fromModel(Role::class, 'name')
    ->multiple()
```

For those places where there is already a specified dot, the work will be unchanged.
