### PR TITLE
Fixes #1093 Updates::requestVersion() cache broken

### DIFF
--- a/src/Platform/Updates.php
+++ b/src/Platform/Updates.php
@@ -86,7 +86,7 @@ class Updates
     public function requestVersion(): Collection
     {
         $versions = Cache::remember('check-platform-update', now()->addMinutes($this->cache), function () {
-            $this->getVersion();
+            return $this->getVersion();
         });
 
         return collect($versions)->reverse();


### PR DESCRIPTION
Fixes #1093

Return statement was missing in `Cache::remember()` callback, so cache didn't work (effectively stored null value in cache).

I added the return statement.