### PR TITLE
added withoutApplyButton to modal based layouts

### DIFF
--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -43,12 +43,14 @@
                         </button>
 
                         @empty($commandBar)
-                            <button type="submit"
-                                    id="submit-modal-{{$key}}"
-                                    data-turbolinks="{{ var_export($turbolinks) }}"
-                                    class="btn btn-default">
-                                {{ $apply }}
-                            </button>
+                            @if($withoutApplyButton)
+                                <button type="submit"
+                                        id="submit-modal-{{$key}}"
+                                        data-turbolinks="{{ var_export($turbolinks) }}"
+                                        class="btn btn-default">
+                                    {{ $apply }}
+                                </button>
+                            @endif
                         @else
                             {!! $commandBar !!}
                         @endempty

--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -38,9 +38,11 @@
                     </div>
                     <div class="modal-footer">
 
-                        <button type="button" class="btn btn-link" data-dismiss="modal">
-                            {{ $close }}
-                        </button>
+                        @if(!$withoutCloseButton)
+                            <button type="button" class="btn btn-link" data-dismiss="modal">
+                                {{ $close }}
+                            </button>
+                        @endif
 
                         @empty($commandBar)
                             @if(!$withoutApplyButton)

--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -43,7 +43,7 @@
                         </button>
 
                         @empty($commandBar)
-                            @if($withoutApplyButton)
+                            @if(!$withoutApplyButton)
                                 <button type="submit"
                                         id="submit-modal-{{$key}}"
                                         data-turbolinks="{{ var_export($turbolinks) }}"

--- a/src/Screen/Layouts/Modal.php
+++ b/src/Screen/Layouts/Modal.php
@@ -96,7 +96,7 @@ class Modal extends Base
     }
 
     /**
-     * Whether to disable the apply button or not
+     * Whether to disable the apply button or not.
      *
      * @param bool $withoutApplayButton
      *

--- a/src/Screen/Layouts/Modal.php
+++ b/src/Screen/Layouts/Modal.php
@@ -50,14 +50,15 @@ class Modal extends Base
     public function __construct(string $key, array $layouts = [])
     {
         $this->variables = [
-            'apply'      => __('Apply'),
-            'close'      => __('Close'),
-            'size'       => '',
-            'type'       => self::TYPE_CENTER,
-            'key'        => $key,
-            'title'      => $key,
-            'turbolinks' => true,
-            'commandBar' => [],
+            'apply'                 => __('Apply'),
+            'close'                 => __('Close'),
+            'size'                  => '',
+            'type'                  => self::TYPE_CENTER,
+            'key'                   => $key,
+            'title'                 => $key,
+            'turbolinks'            => true,
+            'commandBar'            => [],
+            'withoutApplyButton'    => false,
         ];
 
         $this->layouts = $layouts;
@@ -90,6 +91,20 @@ class Modal extends Base
     public function applyButton(string $text): self
     {
         $this->variables['apply'] = $text;
+
+        return $this;
+    }
+
+    /**
+     * Whether to disable the apply button or not
+     *
+     * @param bool $withoutApplayButton
+     *
+     * @return Modal
+     */
+    public function withoutApplyButton(bool $withoutApplayButton = false): self
+    {
+        $this->variables['withoutApplyButton'] = $withoutApplayButton;
 
         return $this;
     }

--- a/src/Screen/Layouts/Modal.php
+++ b/src/Screen/Layouts/Modal.php
@@ -59,6 +59,7 @@ class Modal extends Base
             'turbolinks'            => true,
             'commandBar'            => [],
             'withoutApplyButton'    => false,
+            'withoutCloseButton'    => false,
         ];
 
         $this->layouts = $layouts;
@@ -98,13 +99,27 @@ class Modal extends Base
     /**
      * Whether to disable the apply button or not.
      *
-     * @param bool $withoutApplayButton
+     * @param bool $withoutApplyButton
      *
      * @return Modal
      */
-    public function withoutApplyButton(bool $withoutApplayButton = true): self
+    public function withoutApplyButton(bool $withoutApplyButton = true): self
     {
-        $this->variables['withoutApplyButton'] = $withoutApplayButton;
+        $this->variables['withoutApplyButton'] = $withoutApplyButton;
+
+        return $this;
+    }
+
+    /**
+     * Whether to disable the close button or not.
+     *
+     * @param bool $withoutCloseButton
+     *
+     * @return Modal
+     */
+    public function withoutCloseButton(bool $withoutCloseButton = true): self
+    {
+        $this->variables['withoutCloseButton'] = $withoutCloseButton;
 
         return $this;
     }

--- a/src/Screen/Layouts/Modal.php
+++ b/src/Screen/Layouts/Modal.php
@@ -102,7 +102,7 @@ class Modal extends Base
      *
      * @return Modal
      */
-    public function withoutApplyButton(bool $withoutApplayButton = false): self
+    public function withoutApplyButton(bool $withoutApplayButton = true): self
     {
         $this->variables['withoutApplyButton'] = $withoutApplayButton;
 

--- a/tests/App/Screens/ModalScreenWithoutButtons.php
+++ b/tests/App/Screens/ModalScreenWithoutButtons.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\App\Screens;
+
+use Orchid\Screen\Action;
+use Orchid\Screen\Actions\ModalToggle;
+use Orchid\Screen\Layout;
+use Orchid\Screen\Layouts\Modal;
+use Orchid\Screen\Screen;
+
+class ModalScreenWithoutButtons extends Screen
+{
+    public const TITLE_MODAL = 'Title Modal';
+    public const APPLY_BUTTON = 'Test Apply Button';
+    public const CLOSE_BUTTON = 'Test Close Button';
+
+    /**
+     * Display header name.
+     *
+     * @var string
+     */
+    public $name = 'Test Screen Modals';
+
+    /**
+     * Display header description.
+     *
+     * @var string
+     */
+    public $description = 'Sample Screen Modals';
+
+    /**
+     * Query data.
+     *
+     * @return array
+     */
+    public function query(): array
+    {
+        return [];
+    }
+
+    /**
+     * Button commands.
+     *
+     * @return Action[]
+     */
+    public function commandBar(): array
+    {
+        return [
+            ModalToggle::make('exampleModalsWithoutButtons')
+                ->name('exampleModalsWithoutButtons'),
+        ];
+    }
+
+    /**
+     * Views.
+     *
+     * @throws \Throwable
+     *
+     * @return array
+     */
+    public function layout(): array
+    {
+        return [
+            Layout::modal('exampleOneModalWithoutButtons', [
+                Layout::rows([]),
+            ])
+                ->modal('exampleModalsWithoutButtons')
+                ->title(self::TITLE_MODAL)
+                ->size(Modal::SIZE_LG)
+                ->applyButton(self::APPLY_BUTTON)
+                ->closeButton(self::CLOSE_BUTTON)
+                ->withoutApplyButton()
+                ->withoutCloseButton(),
+        ];
+    }
+}

--- a/tests/App/Screens/ModalScreenWithoutButtons.php
+++ b/tests/App/Screens/ModalScreenWithoutButtons.php
@@ -49,7 +49,8 @@ class ModalScreenWithoutButtons extends Screen
     {
         return [
             ModalToggle::make('exampleModalsWithoutButtons')
-                ->name('exampleModalsWithoutButtons'),
+                ->name('exampleModalsWithoutButtons')
+                ->modal('exampleOneModalWithoutButtons'),
         ];
     }
 
@@ -66,7 +67,6 @@ class ModalScreenWithoutButtons extends Screen
             Layout::modal('exampleOneModalWithoutButtons', [
                 Layout::rows([]),
             ])
-                ->modal('exampleModalsWithoutButtons')
                 ->title(self::TITLE_MODAL)
                 ->size(Modal::SIZE_LG)
                 ->applyButton(self::APPLY_BUTTON)

--- a/tests/Unit/Screen/ModalWithoutButtonTest.php
+++ b/tests/Unit/Screen/ModalWithoutButtonTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Unit\Screen;
+
+use Illuminate\Support\Facades\Validator;
+use Orchid\Screen\Layouts\Modal;
+use Orchid\Tests\App\Screens\ModalScreenWithoutButtons;
+use Orchid\Tests\TestUnitCase;
+
+/**
+ * Class ModalTest.
+ */
+class ModalWithoutButtonTest extends TestUnitCase
+{
+    /**
+     * @throws \Throwable
+     */
+    public function testModalScreenRender()
+    {
+        $screen = new ModalScreenWithoutButtons();
+        $html = $screen->view()->withErrors(Validator::make([], []))->render();
+
+        $this->assertStringNotContainsString($screen->name, $html);
+        $this->assertStringNotContainsString($screen->description, $html);
+
+        $this->assertStringNotContainsString(ModalScreenWithoutButtons::TITLE_MODAL, $html);
+        $this->assertStringNotContainsString(ModalScreenWithoutButtons::APPLY_BUTTON, $html);
+        $this->assertStringNotContainsString(ModalScreenWithoutButtons::CLOSE_BUTTON, $html);
+
+        $this->assertStringNotContainsString(Modal::SIZE_LG, $html);
+    }
+}

--- a/tests/Unit/Screen/ModalWithoutButtonsTest.php
+++ b/tests/Unit/Screen/ModalWithoutButtonsTest.php
@@ -12,7 +12,7 @@ use Orchid\Tests\TestUnitCase;
 /**
  * Class ModalTest.
  */
-class ModalWithoutButtonTest extends TestUnitCase
+class ModalWithoutButtonsTest extends TestUnitCase
 {
     /**
      * @throws \Throwable
@@ -22,10 +22,10 @@ class ModalWithoutButtonTest extends TestUnitCase
         $screen = new ModalScreenWithoutButtons();
         $html = $screen->view()->withErrors(Validator::make([], []))->render();
 
-        $this->assertStringNotContainsString($screen->name, $html);
-        $this->assertStringNotContainsString($screen->description, $html);
+        $this->assertStringContainsString($screen->name, $html);
+        $this->assertStringContainsString($screen->description, $html);
+        $this->assertStringContainsString(ModalScreenWithoutButtons::TITLE_MODAL, $html);
 
-        $this->assertStringNotContainsString(ModalScreenWithoutButtons::TITLE_MODAL, $html);
         $this->assertStringNotContainsString(ModalScreenWithoutButtons::APPLY_BUTTON, $html);
         $this->assertStringNotContainsString(ModalScreenWithoutButtons::CLOSE_BUTTON, $html);
 

--- a/tests/Unit/Screen/ModalWithoutButtonsTest.php
+++ b/tests/Unit/Screen/ModalWithoutButtonsTest.php
@@ -25,10 +25,9 @@ class ModalWithoutButtonsTest extends TestUnitCase
         $this->assertStringContainsString($screen->name, $html);
         $this->assertStringContainsString($screen->description, $html);
         $this->assertStringContainsString(ModalScreenWithoutButtons::TITLE_MODAL, $html);
+        $this->assertStringContainsString(Modal::SIZE_LG, $html);
 
         $this->assertStringNotContainsString(ModalScreenWithoutButtons::APPLY_BUTTON, $html);
         $this->assertStringNotContainsString(ModalScreenWithoutButtons::CLOSE_BUTTON, $html);
-
-        $this->assertStringContainsString(Modal::SIZE_LG, $html);
     }
 }

--- a/tests/Unit/Screen/ModalWithoutButtonsTest.php
+++ b/tests/Unit/Screen/ModalWithoutButtonsTest.php
@@ -29,6 +29,6 @@ class ModalWithoutButtonsTest extends TestUnitCase
         $this->assertStringNotContainsString(ModalScreenWithoutButtons::APPLY_BUTTON, $html);
         $this->assertStringNotContainsString(ModalScreenWithoutButtons::CLOSE_BUTTON, $html);
 
-        $this->assertStringNotContainsString(Modal::SIZE_LG, $html);
+        $this->assertStringContainsString(Modal::SIZE_LG, $html);
     }
 }


### PR DESCRIPTION
## Proposed Changes
Regarding #1095 , this PR adds a new method called `withoutApplyButton()` to `Modal::class` so we can remove the apply button if needed

**update**
@tabuna suggested that it is valid to add this option to the close button too, so we have `withoutCloseButton()` along side `withoutApplyButton()`