### PR TITLE
[Draft] Engine for attachment upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 7.4.0 - 2020-05-18
+
+### Added
+- The class that contains the strategy for determining attachment
+
 ## 7.3.0 - 2020-05-17
 
 ## Added

--- a/config/platform.php
+++ b/config/platform.php
@@ -114,7 +114,7 @@ return [
     */
 
     'attachment' => [
-        'disk'   => 'public',
+        'disk'      => 'public',
         'generator' => \Orchid\Attachment\Engines\Generator::class,
     ],
 

--- a/config/platform.php
+++ b/config/platform.php
@@ -66,6 +66,7 @@ return [
     | it will be opened by users when they enter or click on logos and links.
     |
     */
+
     'index' => 'platform.main',
 
     /*
@@ -101,6 +102,20 @@ return [
     'template' => [
         'header' => null,
         'footer' => null,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default configuration for attachments.
+    |--------------------------------------------------------------------------
+    |
+    | Strategy properties for the file and storage used.
+    |
+    */
+
+    'attachment' => [
+        'disk'   => 'public',
+        'generator' => \Orchid\Attachment\Engines\Generator::class,
     ],
 
 ];

--- a/src/Attachment/Attachable.php
+++ b/src/Attachment/Attachable.php
@@ -28,7 +28,7 @@ trait Attachable
             'attachment_id'
         );
 
-        if (! is_null($group)) {
+        if ($group !== null) {
             $query->where('group', $group);
         }
 

--- a/src/Attachment/Contracts/Engine.php
+++ b/src/Attachment/Contracts/Engine.php
@@ -16,37 +16,61 @@ interface Engine
     public function __construct(UploadedFile $file);
 
     /**
+     * Returns name to create a real file on disk and write to the database.
+     * Specified any string without extension.
+     * Please note that some characters are prohibited on different operating systems.
+     *
+     * For example "calc"
+     *
      * @return string
      */
     public function name(): string;
 
     /**
+     * Returns name to create a file with extension
+     *
+     * For example "calc.exe"
+     *
      * @return string
      */
     public function fullName(): string;
 
     /**
+     * Returns the relative file path
+     *
      * @return string
      */
     public function path(): string;
 
     /**
+     * Returns file hash string that will indicate
+     * that the same file has already been downloaded
+     *
      * @return string
      */
     public function hash(): string;
 
     /**
+     * Return a Unix file upload timestamp
+     *
      * @return int
      */
     public function time(): int;
 
     /**
+     * Returns file extension
+     *
+     * For example `jpg`
+     *
+     * @return string
+     */
+    public function extension(): string;
+
+    /**
+     * Returns the file mime type.
+     *
      * @return string
      */
     public function mime(): string;
 
-    /**
-     * @return string
-     */
-    public function getClientOriginalExtension(): string;
 }

--- a/src/Attachment/Contracts/Engine.php
+++ b/src/Attachment/Contracts/Engine.php
@@ -27,7 +27,7 @@ interface Engine
     public function name(): string;
 
     /**
-     * Returns name to create a file with extension
+     * Returns name to create a file with extension.
      *
      * For example "calc.exe"
      *
@@ -36,7 +36,7 @@ interface Engine
     public function fullName(): string;
 
     /**
-     * Returns the relative file path
+     * Returns the relative file path.
      *
      * @return string
      */
@@ -44,21 +44,21 @@ interface Engine
 
     /**
      * Returns file hash string that will indicate
-     * that the same file has already been downloaded
+     * that the same file has already been downloaded.
      *
      * @return string
      */
     public function hash(): string;
 
     /**
-     * Return a Unix file upload timestamp
+     * Return a Unix file upload timestamp.
      *
      * @return int
      */
     public function time(): int;
 
     /**
-     * Returns file extension
+     * Returns file extension.
      *
      * For example `jpg`
      *
@@ -72,5 +72,4 @@ interface Engine
      * @return string
      */
     public function mime(): string;
-
 }

--- a/src/Attachment/Contracts/Engine.php
+++ b/src/Attachment/Contracts/Engine.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Attachment\Contracts;
+
+use Illuminate\Http\UploadedFile;
+
+interface Engine
+{
+    /**
+     * Engine constructor.
+     *
+     * @param UploadedFile $file
+     */
+    public function __construct(UploadedFile $file);
+
+    /**
+     * @return string
+     */
+    public function name(): string;
+
+    /**
+     * @return string
+     */
+    public function fullName(): string;
+
+    /**
+     * @return string
+     */
+    public function path(): string;
+
+    /**
+     * @return string
+     */
+    public function hash(): string;
+
+    /**
+     * @return int
+     */
+    public function time(): int;
+
+    /**
+     * @return string
+     */
+    public function mime(): string;
+
+    /**
+     * @return string
+     */
+    public function getClientOriginalExtension(): string;
+}

--- a/src/Attachment/Engines/Generator.php
+++ b/src/Attachment/Engines/Generator.php
@@ -39,6 +39,9 @@ class Generator implements Engine
     }
 
     /**
+     * Returns name to create a real file on disk and write to the database.
+     * Specified any string without extension.
+     *
      * @return string
      */
     public function name(): string
@@ -47,14 +50,18 @@ class Generator implements Engine
     }
 
     /**
+     * Returns name to create a file with extension
+     *
      * @return string
      */
     public function fullName(): string
     {
-        return Str::finish($this->name(), '.') . $this->getClientOriginalExtension();
+        return Str::finish($this->name(), '.') . $this->extension();
     }
 
     /**
+     * Returns the relative file path
+     *
      * @return string
      */
     public function path(): string
@@ -63,6 +70,9 @@ class Generator implements Engine
     }
 
     /**
+     * Returns file hash string that will indicate
+     * that the same file has already been downloaded
+     *
      * @return string
      */
     public function hash(): string
@@ -71,6 +81,8 @@ class Generator implements Engine
     }
 
     /**
+     * Return a Unix file upload timestamp
+     *
      * @return int
      */
     public function time(): int
@@ -79,9 +91,11 @@ class Generator implements Engine
     }
 
     /**
+     * Returns file extension
+     *
      * @return string
      */
-    public function getClientOriginalExtension(): string
+    public function extension(): string
     {
         $extension = $this->file->getClientOriginalExtension();
 
@@ -91,11 +105,13 @@ class Generator implements Engine
     }
 
     /**
+     * Returns the file mime type.
+     *
      * @return string
      */
     public function mime(): string
     {
-        return $this->mimes->getMimeType($this->getClientOriginalExtension())
+        return $this->mimes->getMimeType($this->extension())
             ?? $this->mimes->getMimeType($this->file->getClientMimeType())
             ?? 'unknown';
     }

--- a/src/Attachment/Engines/Generator.php
+++ b/src/Attachment/Engines/Generator.php
@@ -46,21 +46,21 @@ class Generator implements Engine
      */
     public function name(): string
     {
-        return sha1($this->time . $this->file->getClientOriginalName());
+        return sha1($this->time.$this->file->getClientOriginalName());
     }
 
     /**
-     * Returns name to create a file with extension
+     * Returns name to create a file with extension.
      *
      * @return string
      */
     public function fullName(): string
     {
-        return Str::finish($this->name(), '.') . $this->extension();
+        return Str::finish($this->name(), '.').$this->extension();
     }
 
     /**
-     * Returns the relative file path
+     * Returns the relative file path.
      *
      * @return string
      */
@@ -71,7 +71,7 @@ class Generator implements Engine
 
     /**
      * Returns file hash string that will indicate
-     * that the same file has already been downloaded
+     * that the same file has already been downloaded.
      *
      * @return string
      */
@@ -81,7 +81,7 @@ class Generator implements Engine
     }
 
     /**
-     * Return a Unix file upload timestamp
+     * Return a Unix file upload timestamp.
      *
      * @return int
      */
@@ -91,7 +91,7 @@ class Generator implements Engine
     }
 
     /**
-     * Returns file extension
+     * Returns file extension.
      *
      * @return string
      */

--- a/src/Attachment/Engines/Generator.php
+++ b/src/Attachment/Engines/Generator.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Attachment\Engines;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Mimey\MimeTypes;
+use Orchid\Attachment\Contracts\Engine;
+
+class Generator implements Engine
+{
+    /**
+     * @var UploadedFile
+     */
+    protected $file;
+
+    /**
+     * @var int
+     */
+    protected $time;
+
+    /**
+     * @var MimeTypes
+     */
+    protected $mimes;
+
+    /**
+     * Generator constructor.
+     *
+     * @param UploadedFile $file
+     */
+    public function __construct(UploadedFile $file)
+    {
+        $this->file = $file;
+        $this->time = time();
+        $this->mimes = new MimeTypes();
+    }
+
+    /**
+     * @return string
+     */
+    public function name(): string
+    {
+        return sha1($this->time . $this->file->getClientOriginalName());
+    }
+
+    /**
+     * @return string
+     */
+    public function fullName(): string
+    {
+        return Str::finish($this->name(), '.') . $this->getClientOriginalExtension();
+    }
+
+    /**
+     * @return string
+     */
+    public function path(): string
+    {
+        return date('Y/m/d', $this->time());
+    }
+
+    /**
+     * @return string
+     */
+    public function hash(): string
+    {
+        return sha1_file($this->file->path());
+    }
+
+    /**
+     * @return int
+     */
+    public function time(): int
+    {
+        return $this->time;
+    }
+
+    /**
+     * @return string
+     */
+    public function getClientOriginalExtension(): string
+    {
+        $extension = $this->file->getClientOriginalExtension();
+
+        return empty($extension)
+            ? $this->mimes->getExtension($this->file->getClientMimeType())
+            : $extension;
+    }
+
+    /**
+     * @return string
+     */
+    public function mime(): string
+    {
+        return $this->mimes->getMimeType($this->getClientOriginalExtension())
+            ?? $this->mimes->getMimeType($this->file->getClientMimeType())
+            ?? 'unknown';
+    }
+}

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -53,14 +53,14 @@ class File
      * @param string       $disk
      * @param string       $group
      */
-    public function __construct(UploadedFile $file, string $disk = 'public', string $group = null)
+    public function __construct(UploadedFile $file, string $disk = null, string $group = null)
     {
         abort_if($file->getSize() === false, 415, 'File failed to load.');
 
         $this->file = $file;
 
-        $this->storage = Storage::disk($disk);
-        $this->disk = $disk;
+        $this->disk = $disk ?? config('platform.attachment.disk');
+        $this->storage = Storage::disk($this->disk);
 
         $generator = config('platform.attachment.generator', Generator::class);
 
@@ -119,7 +119,7 @@ class File
             'name'          => $this->engine->name(),
             'mime'          => $this->engine->mime(),
             'hash'          => $this->engine->hash(),
-            'extension'     => $this->engine->getClientOriginalExtension(),
+            'extension'     => $this->engine->extension(),
             'original_name' => $this->file->getClientOriginalName(),
             'size'          => $this->file->getSize(),
             'path'          => Str::finish($this->engine->path(), '/'),

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -68,7 +68,6 @@ class File
         $this->group = $group;
     }
 
-
     /**
      * @return Model|Attachment
      */
@@ -76,7 +75,7 @@ class File
     {
         $attachment = $this->getMatchesHash();
 
-        if (!$this->storage->has($this->engine->path())) {
+        if (! $this->storage->has($this->engine->path())) {
             $this->storage->makeDirectory($this->engine->path());
         }
 

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -9,7 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
-use Mimey\MimeTypes;
+use Illuminate\Support\Str;
+use Orchid\Attachment\Contracts\Engine;
+use Orchid\Attachment\Engines\Generator;
 use Orchid\Attachment\Models\Attachment;
 use Orchid\Platform\Dashboard;
 use Orchid\Platform\Events\UploadFileEvent;
@@ -20,49 +22,29 @@ use Orchid\Platform\Events\UploadFileEvent;
 class File
 {
     /**
-     * @var int
-     */
-    public $time;
-
-    /**
-     * @var false|string
-     */
-    public $date;
-
-    /**
-     * @var MimeTypes
-     */
-    public $mimes;
-
-    /**
      * @var UploadedFile
      */
-    public $file;
+    protected $file;
 
     /**
      * @var Filesystem
      */
-    public $storage;
+    protected $storage;
 
     /**
      * @var string
      */
-    public $fullPath;
-
-    /**
-     * @var string
-     */
-    private $hash;
-
-    /**
-     * @var string
-     */
-    public $disk;
+    protected $disk;
 
     /**
      * @var string|null
      */
-    public $group;
+    protected $group;
+
+    /**
+     * @var Engine
+     */
+    protected $engine;
 
     /**
      * File constructor.
@@ -75,68 +57,53 @@ class File
     {
         abort_if($file->getSize() === false, 415, 'File failed to load.');
 
-        $this->time = time();
-        $this->date = date('Y/m/d', $this->time);
         $this->file = $file;
-        $this->mimes = new MimeTypes();
-        $this->fullPath = storage_path("app/public/$this->date/");
-        $this->disk = $disk;
-        $this->group = $group;
+
         $this->storage = Storage::disk($disk);
-        $this->loadHashFile();
+        $this->disk = $disk;
+
+        $generator = config('platform.attachment.generator', Generator::class);
+
+        $this->engine = new $generator($file);
+        $this->group = $group;
     }
 
-    /**
-     * @return $this
-     */
-    private function loadHashFile()
-    {
-        $this->hash = $this->getHashFile();
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getHashFile(): string
-    {
-        return sha1_file($this->file->getRealPath());
-    }
 
     /**
      * @return Model|Attachment
      */
     public function load(): Model
     {
-        $file = $this->getMatchesHash();
+        $attachment = $this->getMatchesHash();
 
-        if (! $this->storage->has($this->date)) {
-            $this->storage->makeDirectory($this->date);
+        if (!$this->storage->has($this->engine->path())) {
+            $this->storage->makeDirectory($this->engine->path());
         }
 
-        if (is_null($file)) {
+        if ($attachment === null) {
             return $this->save();
         }
 
-        $file = $file->replicate()->fill([
+        $attachment = $attachment->replicate()->fill([
             'original_name' => $this->file->getClientOriginalName(),
             'sort'          => 0,
             'user_id'       => Auth::id(),
             'group'         => $this->group,
         ]);
 
-        $file->save();
+        $attachment->save();
 
-        return $file;
+        return $attachment;
     }
 
     /**
-     * @return mixed
+     * @return Attachment|null
      */
     private function getMatchesHash()
     {
-        return Dashboard::model(Attachment::class)::where('hash', $this->hash)->where('disk', $this->disk)->first();
+        return Dashboard::model(Attachment::class)::where('hash', $this->engine->hash())
+            ->where('disk', $this->disk)
+            ->first();
     }
 
     /**
@@ -144,50 +111,25 @@ class File
      */
     private function save(): Model
     {
-        $hashName = sha1($this->time.$this->file->getClientOriginalName());
-        $name = $hashName.'.'.$this->getClientOriginalExtension();
-
-        $this->storage->putFileAs($this->date, $this->file, $name, [
-            'mime_type' => $this->getMimeType(),
+        $this->storage->putFileAs($this->engine->path(), $this->file, $this->engine->fullName(), [
+            'mime_type' => $this->engine->mime(),
         ]);
 
-        $attach = Dashboard::model(Attachment::class)::create([
-            'name'          => $hashName,
+        $attachment = Dashboard::model(Attachment::class)::create([
+            'name'          => $this->engine->name(),
+            'mime'          => $this->engine->mime(),
+            'hash'          => $this->engine->hash(),
+            'extension'     => $this->engine->getClientOriginalExtension(),
             'original_name' => $this->file->getClientOriginalName(),
-            'mime'          => $this->getMimeType(),
-            'extension'     => $this->getClientOriginalExtension(),
             'size'          => $this->file->getSize(),
-            'path'          => $this->date.'/',
-            'hash'          => $this->hash,
+            'path'          => Str::finish($this->engine->path(), '/'),
             'disk'          => $this->disk,
             'group'         => $this->group,
             'user_id'       => Auth::id(),
         ]);
 
-        event(new UploadFileEvent($attach, $this->time));
+        event(new UploadFileEvent($attachment, $this->engine->time()));
 
-        return $attach;
-    }
-
-    /**
-     * @return string
-     */
-    private function getClientOriginalExtension()
-    {
-        $extension = $this->file->getClientOriginalExtension();
-
-        return empty($extension)
-            ? $this->mimes->getExtension($this->file->getClientMimeType())
-            : $extension;
-    }
-
-    /**
-     * @return File|string
-     */
-    public function getMimeType()
-    {
-        return $this->mimes->getMimeType($this->getClientOriginalExtension())
-            ?? $this->mimes->getMimeType($this->file->getClientMimeType())
-            ?? 'unknown';
+        return $attachment;
     }
 }

--- a/tests/Unit/AttachmentTest.php
+++ b/tests/Unit/AttachmentTest.php
@@ -47,7 +47,7 @@ class AttachmentTest extends TestUnitCase
         ]);
 
         $this->assertTrue(Storage::disk($this->disk)->exists($upload->physicalPath()));
-        $this->assertStringContainsString($upload->name . '.xml', $upload->url());
+        $this->assertStringContainsString($upload->name.'.xml', $upload->url());
     }
 
     public function testAttachmentCustomEngineFile(): void
@@ -69,7 +69,7 @@ class AttachmentTest extends TestUnitCase
 
         $this->assertTrue(Storage::disk($this->disk)->exists($upload->physicalPath()));
 
-        $path = 'custom/' . $upload->name . '.xml';
+        $path = 'custom/'.$upload->name.'.xml';
 
         $this->assertStringContainsString($path, $upload->physicalPath());
         $this->assertStringContainsString('/storage/'.$path, $upload->url());
@@ -179,7 +179,7 @@ class AttachmentTest extends TestUnitCase
 
         $attachment->original_name = 'blob';
 
-        $this->assertEquals($attachment->name . '.' . $attachment->extension, $attachment->getTitleAttribute());
+        $this->assertEquals($attachment->name.'.'.$attachment->extension, $attachment->getTitleAttribute());
     }
 
     public function testAttachmentTrait(): void

--- a/tests/Unit/Engine/CustomAttachmentGenerator.php
+++ b/tests/Unit/Engine/CustomAttachmentGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Unit\Engine;
+
+use Orchid\Attachment\Engines\Generator;
+
+class CustomAttachmentGenerator extends Generator
+{
+    /**
+     * @return string
+     */
+    public function path(): string
+    {
+        return 'custom';
+    }
+}


### PR DESCRIPTION
This is an offer to add an intermediate class for uploading files. 
They will be responsible for the format of the created path and hash.

This should solve the problem of changing the path.
So, by default, paths are formed according to the schema:

```php
'.../Y/m/d/filename.jpg'
```

Now it is moved to a separate class, with the appropriate method:

```php
<?php

use Orchid\Attachment\Engines\Generator;

class CustomAttachmentGenerator extends Generator
{
    public function path(): string
    {
        return 'custom';
    }
}
```

After applying it, **new** paths will be created as follows:

```php
'.../custom/filename.jpg'
```

Another example of utility can be changing the generation of a hash of a file, for example:

```php
<?php

use Orchid\Attachment\Engines\Generator;

class CustomAttachmentGenerator extends Generator
{
    public function hash(): string
    {
        return md5_file($this->file->path());
    }
}
```

It will also be useful to be able to set a name. By default, the hash of the name of the original file is taken, but this can also be changed:
```php
<?php

use Orchid\Attachment\Engines\Generator;

class CustomAttachmentGenerator extends Generator
{
    public function name(): string
    {
        return $this->file->getClientOriginalName();
    }
}
```