### PR TITLE
[7.7] Added field group class

### DIFF
--- a/resources/views/partials/fields/groups.blade.php
+++ b/resources/views/partials/fields/groups.blade.php
@@ -1,4 +1,4 @@
-<div class="row align-items-center">
+<div class="row align-items-baseline">
     @foreach($group as $field)
         <div class="{{ $class }} @if (!$loop->last) pr-0 @endif">
             {!! $field !!}

--- a/resources/views/partials/fields/groups.blade.php
+++ b/resources/views/partials/fields/groups.blade.php
@@ -1,11 +1,7 @@
-<div class="row">
-    <div class="container">
-        <div class="row">
-            @foreach($cols as $col)
-                <div class="col-md">
-                    {!! $col !!}
-                </div>
-            @endforeach
+<div class="row align-items-center">
+    @foreach($cols as $col)
+        <div class="col-auto @if (!$loop->last) pr-0 @endif">
+            {!! $col !!}
         </div>
-    </div>
+    @endforeach
 </div>

--- a/resources/views/partials/fields/groups.blade.php
+++ b/resources/views/partials/fields/groups.blade.php
@@ -1,7 +1,7 @@
 <div class="row align-items-center">
-    @foreach($cols as $col)
-        <div class="col-auto @if (!$loop->last) pr-0 @endif">
-            {!! $col !!}
+    @foreach($group as $field)
+        <div class="{{ $class }} @if (!$loop->last) pr-0 @endif">
+            {!! $field !!}
         </div>
     @endforeach
 </div>

--- a/src/Screen/Contracts/Groupable.php
+++ b/src/Screen/Contracts/Groupable.php
@@ -18,5 +18,5 @@ interface Groupable extends Fieldable
      *
      * @return Groupable
      */
-    public function setGroup(array $group = []): Groupable;
+    public function setGroup(array $group = []): self;
 }

--- a/src/Screen/Contracts/Groupable.php
+++ b/src/Screen/Contracts/Groupable.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Screen\Contracts;
+
+use Orchid\Screen\Field;
+
+interface Groupable extends Fieldable
+{
+    /**
+     * @return Field[]
+     */
+    public function getGroup(): array;
+
+    /**
+     * @param array $group
+     *
+     * @return Groupable
+     */
+    public function setGroup(array $group): self;
+}

--- a/src/Screen/Contracts/Groupable.php
+++ b/src/Screen/Contracts/Groupable.php
@@ -18,5 +18,5 @@ interface Groupable extends Fieldable
      *
      * @return Groupable
      */
-    public function setGroup(array $group): self;
+    public function setGroup(array $group = []): self;
 }

--- a/src/Screen/Contracts/Groupable.php
+++ b/src/Screen/Contracts/Groupable.php
@@ -18,5 +18,5 @@ interface Groupable extends Fieldable
      *
      * @return Groupable
      */
-    public function setGroup(array $group = []): self;
+    public function setGroup(array $group = []): Groupable;
 }

--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Illuminate\View\View;
 use Orchid\Screen\Contracts\Fieldable;
 use Orchid\Screen\Exceptions\FieldRequiredAttributeException;
+use Orchid\Screen\Fields\Group;
 use Throwable;
 
 /**
@@ -174,7 +175,7 @@ class Field implements Fieldable
     }
 
     /**
-     *@throws Throwable
+     * @throws Throwable
      *
      * @return Factory|View|mixed
      */
@@ -384,15 +385,17 @@ class Field implements Fieldable
     }
 
     /**
+     * @deprecated
+     *
      * Create a group of the fields.
      *
      * @param Closure|array $group
      *
-     * @return mixed
+     * @return Group
      */
     public static function group($group)
     {
-        return is_callable($group) ? $group() : $group;
+        return Group::make(is_callable($group) ? $group() : $group);
     }
 
     /**

--- a/src/Screen/Fields/Group.php
+++ b/src/Screen/Fields/Group.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Screen\Fields;
+
+use Orchid\Screen\Contracts\Groupable;
+use Orchid\Screen\Field;
+
+class Group extends Field implements Groupable
+{
+    /**
+     * @var Field[]
+     */
+    protected $group = [];
+
+    /**
+     * Default attributes value.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'name' => 'group',
+    ];
+
+    /**
+     * @var string
+     */
+    protected $view = 'platform::partials.fields.groups';
+
+    /**
+     * Group constructor.
+     */
+    public function __construct(array $group = [])
+    {
+        $this->group = $group;
+    }
+
+    /**
+     * @param array $group
+     *
+     * @return static
+     */
+    public static function make(array $group = [])
+    {
+        return new static($group);
+    }
+
+    /**
+     * @return Field[]
+     */
+    public function getGroup(): array
+    {
+        return $this->group;
+    }
+
+    /**
+     * @param array $group
+     *
+     * @return array
+     */
+    public function setGroup(array $group = []): self
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    /**
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
+     */
+    public function render()
+    {
+        return view($this->view, [
+            'cols' => $this->group,
+        ]);
+    }
+}

--- a/src/Screen/Fields/Group.php
+++ b/src/Screen/Fields/Group.php
@@ -10,32 +10,26 @@ use Orchid\Screen\Field;
 class Group extends Field implements Groupable
 {
     /**
-     * @var Field[]
-     */
-    protected $group = [];
-
-    /**
      * Default attributes value.
      *
      * @var array
      */
     protected $attributes = [
-        'name' => 'group',
-        'class'  => 'col',
+        'group' => [],
+        'class' => 'col',
     ];
+
+    /**
+     * Required Attributes.
+     *
+     * @var array
+     */
+    protected $required = [];
 
     /**
      * @var string
      */
     protected $view = 'platform::partials.fields.groups';
-
-    /**
-     * Group constructor.
-     */
-    public function __construct(array $group = [])
-    {
-        $this->group = $group;
-    }
 
     /**
      * @param array $group
@@ -44,7 +38,7 @@ class Group extends Field implements Groupable
      */
     public static function make(array $group = [])
     {
-        return new static($group);
+        return (new static())->setGroup($group);
     }
 
     /**
@@ -52,51 +46,44 @@ class Group extends Field implements Groupable
      */
     public function getGroup(): array
     {
-        return $this->group;
+        return $this->get('group', []);
     }
 
     /**
      * @param array $group
      *
-     * @return array
+     * @return $this
      */
-    public function setGroup(array $group = []): self
+    public function setGroup(array $group = []): Groupable
     {
-        $this->group = $group;
-
-        return $this;
+        return $this->set('group', $group);
     }
 
     /**
-     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
+     * @return \Illuminate\View\View
      */
     public function render()
     {
-        return view($this->view, [
-            'group' => $this->group,
-            'class'   => $this->get('class'),
-        ]);
+        return view($this->view, $this->attributes);
     }
 
-
     /**
+     * Columns only take up as much space as needed.
      *
+     * @return self
      */
     public function autoWidth(): self
     {
-        $this->attributes['class'] = 'col-auto';
-
-
-        return $this;
+        return $this->set('class', 'col-auto');
     }
 
     /**
-     * @return $this
+     * Columns occupy the entire width of the screen.
+     *
+     * @return self
      */
     public function fullWidth(): self
     {
-        $this->attributes['class'] = 'col';
-
-        return $this;
+        return $this->set('class', 'col');
     }
 }

--- a/src/Screen/Fields/Group.php
+++ b/src/Screen/Fields/Group.php
@@ -21,6 +21,7 @@ class Group extends Field implements Groupable
      */
     protected $attributes = [
         'name' => 'group',
+        'class'  => 'col',
     ];
 
     /**
@@ -72,7 +73,30 @@ class Group extends Field implements Groupable
     public function render()
     {
         return view($this->view, [
-            'cols' => $this->group,
+            'group' => $this->group,
+            'class'   => $this->get('class'),
         ]);
+    }
+
+
+    /**
+     *
+     */
+    public function autoWidth(): self
+    {
+        $this->attributes['class'] = 'col-auto';
+
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function fullWidth(): self
+    {
+        $this->attributes['class'] = 'col';
+
+        return $this;
     }
 }


### PR DESCRIPTION
This PR expands the possibilities of creating field groups by adding a new interface to the form builder.

## Usage

**Columns occupy the entire width of the screen.**
```php
Group::make([
    // ...
])->fullWidth();
```
![image](https://user-images.githubusercontent.com/5102591/83269286-8df27200-a1cf-11ea-9a39-f57c27a85c8b.png)

**Columns only take up as much space as needed.**
```php
Group::make([
    // ...
])->autoWidth();
```
![image](https://user-images.githubusercontent.com/5102591/83269356-a5c9f600-a1cf-11ea-9583-556d007a402d.png)




## Deprecated

Since the group is no longer tied to the form builder, it is only one more field that can be inherited or altered completely. That call to the base field class seems a little strange. I propose to declare it obsolete and delete it in the next major version

```php
Field::group([
  // ...
]);
```

## Problem

This breaks the undocumented ability to use an array in field returns, for example:

```php
Layout::rows([
    [
        // fields
    ],
]);
```
