### PR TITLE
Исправил удаление permission в Dashboard

### DIFF
--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -278,8 +278,8 @@ class Dashboard
 
         return $all->map(static function ($group) use ($removed) {
             foreach ($group[key($group)] as $key => $item) {
-                if ($removed->contains($item['slug'])) {
-                    unset($group[key($group)][$key]);
+                if ($removed->contains($item)) {
+                    unset($group[key($group)]);
                 }
             }
 

--- a/tests/Unit/PermissionTest.php
+++ b/tests/Unit/PermissionTest.php
@@ -91,6 +91,19 @@ class PermissionTest extends TestUnitCase
         $this->assertEquals($dashboard->getPermission()->count(), 1);
     }
 
+    /**
+     * Dashboard remove permission
+     */
+    public function testIsWasRemovedPermission()
+    {
+        $dashboard = new Dashboard();
+        $permission = ItemPermission::group('Test')
+            ->addPermission('test', 'Test Description');
+        $dashboard->registerPermissions($permission);
+        $dashboard->removePermission('test');
+        $this->assertEmpty($dashboard->getPermission()->get('Test'));
+    }
+
     public function testReplasePermission()
     {
         $user = $this->createUser();


### PR DESCRIPTION
Добавил тест подтверждающий это

Fixes #
Исправил удаление permission в Dashboard
Как я предпологал из этого [issue](https://github.com/orchidsoftware/platform/issues/634)
Удаляется просто permission

Может так же есть смысл, удалять все группу?