### PR TITLE
Fix PHPDoc return type for Fieldable::get()

### DIFF
--- a/src/Screen/Contracts/Fieldable.php
+++ b/src/Screen/Contracts/Fieldable.php
@@ -17,7 +17,7 @@ interface Fieldable
      * @param string $key
      * @param mixed  $value
      *
-     * @return $this
+     * @return mixed
      */
     public function get(string $key, $value = null);
 


### PR DESCRIPTION
Thanks to PhpStorm highlighted the problem

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/451007/85300554-5f567700-b4af-11ea-8561-eda222edd9b9.png">

