### PR TITLE
adding a name to the reset password route of auth group

### DIFF
--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -10,7 +10,7 @@
           data-action="layouts--form#submit"
           data-layouts--form-button-animate="#button-reset"
           data-layouts--form-button-text="{{ __('Loading...') }}"
-          action="{{ route('platform.password.email') }}">
+          action="{{ route('platform.password.update') }}">
         @csrf
         <div class="form-group">
             <label>{{ __('E-Mail Address') }}</label>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -25,7 +25,7 @@ if (config('platform.auth', true)) {
     $this->router->get('password/reset', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');
     $this->router->post('password/email', [ForgotPasswordController::class, 'sendResetLinkEmail'])->name('password.email');
     $this->router->get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->name('password.reset');
-    $this->router->post('password/reset', [ResetPasswordController::class, 'reset']);
+    $this->router->post('password/reset', [ResetPasswordController::class, 'reset'])->name('password.update');
 
     // Two-Factor Authentication Routes...
     $this->router->get('login/token', [LoginController::class, 'showTokenForm'])->name('login.token');


### PR DESCRIPTION
Adding a name to the route kpagos/password/reset to be used in the reset.blade form action param of the reset password form

Fixes #

when you get the link to your user email with the reset token and orchid displays the reset apssword form, after you correctly fill it and send it     platform redirectyou back again to the reset form and send a new reset pasword token as 

**the previusly action param is set to route('platform.password.email')  insead to a route that runs the reset method of ResetPasswordController**

## Proposed Changes

  -Add a name to the kpagos/password/reset route
  -CHange the post action of the reset form on auth.password.reset.blade
  
