### PR TITLE
Switch off autocomplete on "email" signin field for security reasons

### DIFF
--- a/resources/views/auth/signin.blade.php
+++ b/resources/views/auth/signin.blade.php
@@ -7,6 +7,7 @@
         ->required()
         ->tabindex(1)
         ->autofocus()
+        ->autocomplete('off')
         ->placeholder(__('Enter your email'))
     !!}
 </div>


### PR DESCRIPTION
## Issue

The login screen allows caching of usernames (emails).

## Impact

Caching usernames in the browser is considered bad practice as it reveals valid usernames to other users of the computer (e.g. when used on hotel public computers etc.)

## Solution

HTML modified to add `autocomplete="off"` attribute on the `email` field on login screen.