### PR TITLE
Override `sendResetLinkEmail` method to return success message in all cases

### DIFF
--- a/src/Platform/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/Platform/Http/Controllers/Auth/ForgotPasswordController.php
@@ -6,6 +6,8 @@ namespace Orchid\Platform\Http\Controllers\Auth;
 
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
 use Illuminate\View\View;
 use Orchid\Platform\Http\Controllers\Controller;
 
@@ -38,5 +40,25 @@ class ForgotPasswordController extends Controller
     public function showLinkRequestForm()
     {
         return view('platform::auth.passwords.email');
+    }
+
+    /**
+     * Send a reset link to the given user.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    public function sendResetLinkEmail(Request $request)
+    {
+        $this->validateEmail($request);
+
+        // We will send the password reset link to this user.
+        // Success message will appear to the user in all cases
+        // to protect users from login brute force.
+        $this->broker()->sendResetLink(
+            $this->credentials($request)
+        );
+
+        return $this->sendResetLinkResponse($request, Password::PASSWORD_RESET);
     }
 }


### PR DESCRIPTION
This is to further protect against username enumeration by not disclosing if the user exists in the database.

References:
* https://blog.rapid7.com/2017/06/15/about-user-enumeration/
* https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/03-Identity_Management_Testing/04-Testing_for_Account_Enumeration_and_Guessable_User_Account