### PR TITLE
Update phpDoc in Button class

### DIFF
--- a/src/Screen/Actions/Button.php
+++ b/src/Screen/Actions/Button.php
@@ -48,7 +48,7 @@ class Button extends Action
      *
      * @param string $name
      *
-     * @return Button $name
+     * @return static $name
      */
     public static function make(string $name = ''): self
     {


### PR DESCRIPTION
phpStan (PHP Static Analysis Tool) throws an error  #Call to an undefined method Orchid\\Screen\\Actions\\Button\:\:asyncParameters\(\)#, because phpDoc in method make declares to return Button, but code declares creating static class