### PR TITLE
Fix assets compilation

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -13,7 +13,7 @@
 @import "~flatpickr/dist/flatpickr.min";
 @import "~leaflet/dist/leaflet";
 @import "~quill/dist/quill.snow";
-@import "~frappe-charts/dist/frappe-charts.min.css";
+@import "~frappe-charts/dist/frappe-charts.min";
 
 // App
 @import "core/mixins";


### PR DESCRIPTION
During the compilation on a fresh Laravel 8 installation, I ran into a not found error.

This fix the problem.