### PR TITLE
Add static backdrop method to Cropper

### DIFF
--- a/resources/views/fields/cropper.blade.php
+++ b/resources/views/fields/cropper.blade.php
@@ -47,7 +47,7 @@
             @attributes($attributes)
         >
 
-        <div class="modal" role="dialog">
+        <div class="modal" role="dialog" {{$staticBackdrop ? "data-backdrop=static" : ''}}>
             <div class="modal-dialog modal-lg">
                 <div class="modal-content-wrapper">
                     <div class="modal-content">

--- a/src/Screen/Fields/Cropper.php
+++ b/src/Screen/Fields/Cropper.php
@@ -31,6 +31,7 @@ namespace Orchid\Screen\Fields;
  * @method Cropper title(string $value = null)
  * @method Cropper maxFileSize($value = true)
  * @method Cropper storage($value = null)
+ * @method Cropper staticBackdrop($value = false)
  */
 class Cropper extends Picture
 {
@@ -55,6 +56,7 @@ class Cropper extends Picture
         'maxWidth'    => 'Infinity',
         'maxHeight'   => 'Infinity',
         'maxFileSize' => null,
+        'staticBackdrop'=> false,
     ];
 
     /**


### PR DESCRIPTION
## The Issue

It's difficult to crop images if the modal closes when the user clicks outside the modal. I think it's a usability problem.

## Proposed Changes

Add static to backdrop so the modal wouldn't close on click (https://getbootstrap.com/docs/4.4/components/modal/#options)
