### PR TITLE
Add custom controls to Quill toolbar

### DIFF
--- a/resources/js/controllers/fields/quill_controller.js
+++ b/resources/js/controllers/fields/quill_controller.js
@@ -77,20 +77,20 @@ export default class extends Controller {
     }
 
     containerCustomToolbar() {
-        const groups = JSON.parse(this.data.get("toolbar"));
+        const controlsGroup = {
+            "text":   ['bold', 'italic', 'underline', 'strike', 'link', 'clean'],
+            "color":  [{color: this.colors()}, {background: this.colors()}],
+            "header": [{header: '1'}, {header: '2'}],
+            "list":   [{list: 'ordered'}, {list: 'bullet'}],
+            "format": [{indent: '-1'}, {indent: '+1'}, {align: []}],
+            "media":  ['image', 'video'],
+        }
         let container = [];
-        if (groups.includes('text'))
-            container.push(['bold', 'italic', 'underline', 'strike', 'link', 'clean'])
-        if (groups.includes('color'))
-            container.push([{color: this.colors()}, {background: this.colors()}])
-        if (groups.includes('header'))
-            container.push([{header: '1'}, {header: '2'}])
-        if (groups.includes('list'))
-            container.push([{list: 'ordered'}, {list: 'bullet'}])
-        if (groups.includes('format'))
-            container.push([{indent: '-1'}, {indent: '+1'}, {align: []}])
-        if (groups.includes('media'))
-            container.push(['image', 'video'])
+
+        JSON.parse(this.data.get("toolbar")).forEach(function (element) {
+            if (element in controlsGroup)
+                container.push(controlsGroup[element])
+        });
 
         return container
     }

--- a/resources/js/controllers/fields/quill_controller.js
+++ b/resources/js/controllers/fields/quill_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
             theme: 'snow',
             modules: {
                 toolbar: {
-                    container: this.data.get('toolbar') ? this.containerCustomToolbar() : this.containerToolbar(),
+                    container: this.containerToolbar(),
                 },
             },
         });
@@ -67,32 +67,18 @@ export default class extends Controller {
     }
 
     containerToolbar() {
-        return [
-            ['bold', 'italic', 'underline', 'strike'],
-            [{color: this.colors()}, {background: this.colors()}],
-            [{header: '1'}, {header: '2'}, 'blockquote', 'code-block'],
-            [{list: 'ordered'}, {list: 'bullet'}, {indent: '-1'}, {indent: '+1'}, {align: []}],
-            ['link', 'image', 'video', 'clean'],
-        ];
-    }
-
-    containerCustomToolbar() {
         const controlsGroup = {
             "text":   ['bold', 'italic', 'underline', 'strike', 'link', 'clean'],
+            "quote":  ['blockquote', 'code-block'],
             "color":  [{color: this.colors()}, {background: this.colors()}],
             "header": [{header: '1'}, {header: '2'}],
             "list":   [{list: 'ordered'}, {list: 'bullet'}],
             "format": [{indent: '-1'}, {indent: '+1'}, {align: []}],
             "media":  ['image', 'video'],
         }
-        let container = [];
 
-        JSON.parse(this.data.get("toolbar")).forEach(function (element) {
-            if (element in controlsGroup)
-                container.push(controlsGroup[element])
-        });
-
-        return container
+        return JSON.parse(this.data.get("toolbar"))
+            .map(tool => controlsGroup[tool]);
     }
 
     /**

--- a/resources/js/controllers/fields/quill_controller.js
+++ b/resources/js/controllers/fields/quill_controller.js
@@ -15,7 +15,7 @@ export default class extends Controller {
             theme: 'snow',
             modules: {
                 toolbar: {
-                    container: this.containerToolbar(),
+                    container: this.data.get('toolbar') ? this.containerCustomToolbar() : this.containerToolbar(),
                 },
             },
         });
@@ -74,6 +74,25 @@ export default class extends Controller {
             [{list: 'ordered'}, {list: 'bullet'}, {indent: '-1'}, {indent: '+1'}, {align: []}],
             ['link', 'image', 'video', 'clean'],
         ];
+    }
+
+    containerCustomToolbar() {
+        const groups = JSON.parse(this.data.get("toolbar"));
+        let container = [];
+        if (groups.includes('text'))
+            container.push(['bold', 'italic', 'underline', 'strike', 'link', 'clean'])
+        if (groups.includes('color'))
+            container.push([{color: this.colors()}, {background: this.colors()}])
+        if (groups.includes('header'))
+            container.push([{header: '1'}, {header: '2'}])
+        if (groups.includes('list'))
+            container.push([{list: 'ordered'}, {list: 'bullet'}])
+        if (groups.includes('format'))
+            container.push([{indent: '-1'}, {indent: '+1'}, {align: []}])
+        if (groups.includes('media'))
+            container.push(['image', 'video'])
+
+        return container
     }
 
     /**

--- a/resources/views/fields/quill.blade.php
+++ b/resources/views/fields/quill.blade.php
@@ -1,5 +1,7 @@
 @component($typeForm, get_defined_vars())
-    <div data-controller="fields--quill" data-theme="{{$theme ?? 'inlite'}}">
+    <div data-controller="fields--quill"
+         data-fields--quill-toolbar="{{$toolbar}}"
+         data-theme="{{$theme ?? 'inlite'}}">
         <div id="toolbar"></div>
         <div class="quill p-3 position-relative" id="quill-wrapper-{{$id}}"
              style="min-height: {{ $attributes['height'] }}">

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -27,6 +27,7 @@ use Orchid\Screen\Field;
  * @method Quill height($value = '300px')
  * @method Quill title(string $value = null)
  * @method Quill popover(string $value = null)
+ * @method Quill toolbar(array $options)
  */
 class Quill extends Field
 {
@@ -42,7 +43,7 @@ class Quill extends Field
      */
     protected $attributes = [
         'value'   => null,
-        'toolbar' => null,
+        'toolbar' => ["text", "color", "quote", "header", "list", "format", "media"],
         'height'  => '300px',
     ];
 
@@ -74,14 +75,13 @@ class Quill extends Field
     ];
 
     /**
-     * The given options will be add to the Toolbar.
-     *
-     * @return self
+     * Quill constructor.
      */
-    public function toolbar(array $options): self
+    public function __construct()
     {
-        $this->set('toolbar', json_encode($options));
-
-        return $this;
+        $this->addBeforeRender(function () {
+            $toolbar = $this->get('toolbar');
+            $this->set('toolbar', json_encode($toolbar));
+        });
     }
 }

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -41,8 +41,9 @@ class Quill extends Field
      * @var array
      */
     protected $attributes = [
-        'value'  => null,
-        'height' => '300px',
+        'value'   => null,
+        'toolbar' => null,
+        'height'  => '300px',
     ];
 
     /**
@@ -71,4 +72,15 @@ class Quill extends Field
         'value',
         'height',
     ];
+
+    /**
+     * The given options will be add to the Toolbar.
+     *
+     * @return self
+     */
+    public function toolbar(array $options): self
+    {
+        $this->set('toolbar', json_encode($options));
+        return $this;
+    }
 }

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -81,6 +81,7 @@ class Quill extends Field
     public function toolbar(array $options): self
     {
         $this->set('toolbar', json_encode($options));
+
         return $this;
     }
 }


### PR DESCRIPTION
## The problem

is not possible to change the Quill toolbar

## Proposed Changes

  - Give the option to add custom controls to Quill toolbar
  - It allows the user to select 6 groups of controls

## Example

```javascript
Quill::make('quill')
    ->title('Quill')
    ->toolbar(["text", "color", "header", "list", "format", "media"])
```

