### PR TITLE
## 9.0.2 - 2020-10-02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 9.0.2 - 2020-10-02
+
+### Fixed
+- Use route arguments when generating an active link
+- Wait for a call to the breadcrumbs service before your ad.
+
 ## 9.0.1 - 2020-10-01
 
 ### Changed

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -17,7 +17,7 @@ class Dashboard
     /**
      * ORCHID Version.
      */
-    public const VERSION = '9.0.1';
+    public const VERSION = '9.0.2';
 
     /**
      * The Dashboard configuration options.

--- a/src/Platform/ItemMenu.php
+++ b/src/Platform/ItemMenu.php
@@ -183,7 +183,7 @@ class ItemMenu
     {
         $this->route = route($name, $parameters, $absolute);
 
-        $this->active([$name, $this->route.'/*']);
+        $this->active([$this->route, $this->route.'/*']);
 
         return $this;
     }

--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -22,6 +22,7 @@ use Orchid\Platform\Commands\ScreenCommand;
 use Orchid\Platform\Commands\SelectionCommand;
 use Orchid\Platform\Commands\TableCommand;
 use Orchid\Platform\Dashboard;
+use Tabuna\Breadcrumbs\BreadcrumbsServiceProvider;
 use Watson\Active\ActiveServiceProvider;
 
 /**
@@ -174,6 +175,7 @@ class FoundationServiceProvider extends ServiceProvider
             ScoutServiceProvider::class,
             ActiveServiceProvider::class,
             IconServiceProvider::class,
+            BreadcrumbsServiceProvider::class,
             RouteServiceProvider::class,
             EventServiceProvider::class,
             PlatformServiceProvider::class,


### PR DESCRIPTION
## Proposed Changes

### Fixed
- Use route arguments when generating an active link
- Wait for a call to the breadcrumbs service before your ad.