### PR TITLE
Corrected Users listing heading label. Changed heading label from ID …

### DIFF
--- a/stubs/app/Orchid/Layouts/User/UserListLayout.php
+++ b/stubs/app/Orchid/Layouts/User/UserListLayout.php
@@ -54,7 +54,7 @@ class UserListLayout extends Table
                     return $user->updated_at->toDateTimeString();
                 }),
 
-            TD::set('id', 'ID')
+            TD::set('actions', 'Actions')
                 ->align(TD::ALIGN_CENTER)
                 ->width('100px')
                 ->render(function (User $user) {

--- a/stubs/app/Orchid/Layouts/User/UserListLayout.php
+++ b/stubs/app/Orchid/Layouts/User/UserListLayout.php
@@ -54,7 +54,7 @@ class UserListLayout extends Table
                     return $user->updated_at->toDateTimeString();
                 }),
 
-            TD::set('actions', 'Actions')
+            TD::set(__('Actions'))
                 ->align(TD::ALIGN_CENTER)
                 ->width('100px')
                 ->render(function (User $user) {


### PR DESCRIPTION
Corrected Users listing heading label. Changed heading label from ID to Actions

Fixes #
  - User List: Column "id" doesn't contain the user id (wrong label or content)

Issue #1273
