### PR TITLE
## 9.4.2 - 2020-10-13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 9.4.2 - 2020-10-13
+
+### Fixed
+- Allow passing `null` in Menu permission
+
 ## 9.4.1 - 2020-10-11
 
 ### Fixed

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -17,7 +17,7 @@ class Dashboard
     /**
      * ORCHID Version.
      */
-    public const VERSION = '9.4.1';
+    public const VERSION = '9.4.2';
 
     /**
      * The Dashboard configuration options.

--- a/src/Platform/ItemMenu.php
+++ b/src/Platform/ItemMenu.php
@@ -67,7 +67,7 @@ class ItemMenu
     public $active = [];
 
     /**
-     * @var string
+     * @var string|null
      */
     public $permission;
 
@@ -82,11 +82,11 @@ class ItemMenu
     public $place;
 
     /**
-     * @param string $permission
+     * @param string|null $permission
      *
      * @return ItemMenu
      */
-    public function permission(string $permission): self
+    public function permission(?string $permission): self
     {
         $this->permission = $permission;
 


### PR DESCRIPTION
## 9.4.2 - 2020-10-13

### Fixed
- Allow passing `null` in Menu permission