### PR TITLE
Fixed display of values with double quotes in text inputs

### DIFF
--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -103,6 +103,10 @@ class Input extends Field
             if (is_array($mask)) {
                 $this->set('mask', json_encode($mask));
             }
+
+		        if(!empty($this->get('value'))) {
+			        $this->set('value', htmlentities($this->get('value')));
+		        }
         });
     }
 }


### PR DESCRIPTION
Values with double quotes were displayed correctly in text inputs.

Example:
![image](https://user-images.githubusercontent.com/8718859/96415279-039ac100-11f7-11eb-882d-1a9af58e62ab.png)