### PR TITLE
Added indication of the label name

### DIFF
--- a/map_label.patch
+++ b/map_label.patch
@@ -1,0 +1,44 @@
+diff --git a/resources/views/fields/map.blade.php b/resources/views/fields/map.blade.php
+index b0e354a5..6592b450 100644
+--- a/resources/views/fields/map.blade.php
++++ b/resources/views/fields/map.blade.php
+@@ -8,7 +8,7 @@
+         </div>
+         <div class="row mt-3">
+             <div class="col-md">
+-                <label for="{{$name}}[lat]">{{ __('Latitude') }}</label>
++                <label for="{{$name}}[lat]">{{ __($labelLatitude) }}</label>
+                 <input class="form-control"
+                        id="marker__latitude"
+                        data-target="fields--map.lat"
+@@ -17,7 +17,7 @@
+                        value="{{ $value['lat'] ?? '' }}"/>
+             </div>
+             <div class="col-md">
+-                <label for="{{$name}}[lng]">{{ __('Longitude') }}</label>
++                <label for="{{$name}}[lng]">{{ __($labelLatitude) }}</label>
+                 <input class="form-control"
+                        id="marker__longitude"
+ 
+diff --git a/src/Screen/Fields/Map.php b/src/Screen/Fields/Map.php
+index 33d207f3..496fbabf 100644
+--- a/src/Screen/Fields/Map.php
++++ b/src/Screen/Fields/Map.php
+@@ -10,6 +10,8 @@ use Orchid\Screen\Field;
+  * Class Map.
+  *
+  * @method Map name(string $value = null)
++ * @method Map labelLatitude(string $value = 'Latitude')
++ * @method Map labelLongitude(string $value = 'Longitude')
+  * @method Map value($value = true)
+  * @method Map help(string $value = null)
+  * @method Map popover(string $value = null)
+@@ -33,6 +35,8 @@ class Map extends Field
+     protected $attributes = [
+         'zoom'   => 14,
+         'height' => '300px',
++        'labelLatitude' => 'Latitude',
++        'labelLongitude' => 'Longitude',
+     ];
+ 
+     /**

--- a/resources/views/fields/map.blade.php
+++ b/resources/views/fields/map.blade.php
@@ -8,7 +8,7 @@
         </div>
         <div class="row mt-3">
             <div class="col-md">
-                <label for="{{$name}}[lat]">{{ __('Latitude') }}</label>
+                <label for="{{$name}}[lat]">{{ __($labelLatitude) }}</label>
                 <input class="form-control"
                        id="marker__latitude"
                        data-target="fields--map.lat"
@@ -17,7 +17,7 @@
                        value="{{ $value['lat'] ?? '' }}"/>
             </div>
             <div class="col-md">
-                <label for="{{$name}}[lng]">{{ __('Longitude') }}</label>
+                <label for="{{$name}}[lng]">{{ __($labelLatitude) }}</label>
                 <input class="form-control"
                        id="marker__longitude"
 

--- a/src/Screen/Fields/Map.php
+++ b/src/Screen/Fields/Map.php
@@ -10,6 +10,8 @@ use Orchid\Screen\Field;
  * Class Map.
  *
  * @method Map name(string $value = null)
+ * @method Map labelLatitude(string $value = 'Latitude')
+ * @method Map labelLongitude(string $value = 'Longitude')
  * @method Map value($value = true)
  * @method Map help(string $value = null)
  * @method Map popover(string $value = null)
@@ -33,6 +35,8 @@ class Map extends Field
     protected $attributes = [
         'zoom'   => 14,
         'height' => '300px',
+        'labelLatitude' => 'Latitude',
+        'labelLongitude' => 'Longitude',
     ];
 
     /**


### PR DESCRIPTION
Added instructions for the name label, not all use translation by key, `resources/lang/{lang}.json`, violates the integrity of the project if there are a lot of languages in the project
`resources/lang/{lang}/platform.php`
