### PR TITLE
Added indication of the label name

### DIFF
--- a/resources/views/fields/map.blade.php
+++ b/resources/views/fields/map.blade.php
@@ -8,7 +8,7 @@
         </div>
         <div class="row mt-3">
             <div class="col-md">
-                <label for="{{$name}}[lat]">{{ __('Latitude') }}</label>
+                <label for="{{$name}}[lat]">{{ __($latitude) }}</label>
                 <input class="form-control"
                        id="marker__latitude"
                        data-target="fields--map.lat"
@@ -17,7 +17,7 @@
                        value="{{ $value['lat'] ?? '' }}"/>
             </div>
             <div class="col-md">
-                <label for="{{$name}}[lng]">{{ __('Longitude') }}</label>
+                <label for="{{$name}}[lng]">{{ __($longitude) }}</label>
                 <input class="form-control"
                        id="marker__longitude"
 

--- a/src/Screen/Fields/Map.php
+++ b/src/Screen/Fields/Map.php
@@ -10,6 +10,8 @@ use Orchid\Screen\Field;
  * Class Map.
  *
  * @method Map name(string $value = null)
+ * @method Map latitude(string $value = 'Latitude')
+ * @method Map longitude(string $value = 'Longitude')
  * @method Map value($value = true)
  * @method Map help(string $value = null)
  * @method Map popover(string $value = null)
@@ -33,6 +35,8 @@ class Map extends Field
     protected $attributes = [
         'zoom'   => 14,
         'height' => '300px',
+        'latitude' => 'Latitude',
+        'longitude' => 'Longitude',
     ];
 
     /**

--- a/stubs/app/Orchid/Screens/Examples/ExampleFieldsAdvancedScreen.php
+++ b/stubs/app/Orchid/Screens/Examples/ExampleFieldsAdvancedScreen.php
@@ -232,6 +232,9 @@ class ExampleFieldsAdvancedScreen extends Screen
                     ]),
 
                 Map::make('place')
+                    ->latitude('Latitude')
+                    ->longitude('Longitude')
+                    ->title('Object on the map')
                     ->title('Object on the map')
                     ->help('Enter the coordinates, or use the search'),
 


### PR DESCRIPTION
Added instructions for the name label, not all use translation by key, `resources/lang/{lang}.json`, violates the integrity of the project if there are a lot of languages in the project
`resources/lang/{lang}/platform.php`

```
 Map::make('place')
                    ->latitude(_('admin.map.latitude'))
                    ->longitude(_('admin.map.longitude'))
                    ->title('Object on the map')
                    ->help('Enter the coordinates, or use the search')
```