### PR TITLE
Fixed rendering of attribute style in td view

### DIFF
--- a/resources/views/partials/layouts/td.blade.php
+++ b/resources/views/partials/layouts/td.blade.php
@@ -1,5 +1,5 @@
 <td class="text-{{$align}} @if(!$width) text-truncate @endif" data-column="{{ $slug }}" colspan="{{ $colspan }}">
-    <div style="width:{{ ctype_digit($width) ? $width . 'px' : $width }}">
+    <div @empty(!$width)style="width:{{ ctype_digit($width) ? $width . 'px' : $width }}"@endempty>
         @isset($render)
             {!! $value !!}
         @else

--- a/tests/Unit/Screen/TDForTableTest.php
+++ b/tests/Unit/Screen/TDForTableTest.php
@@ -23,7 +23,7 @@ class TDForTableTest extends TestUnitCase
 
         $view = TD::set('name')->width($width)->buildTd(new Repository(['name' => 'value']));
 
-        $this->assertStringContainsString('<div style="width:' . $width . '"', $view);
+        $this->assertStringContainsString('<div style="width:'.$width.'"', $view);
     }
 
     public function testTdWithoutWidth(): void

--- a/tests/Unit/Screen/TDForTableTest.php
+++ b/tests/Unit/Screen/TDForTableTest.php
@@ -2,6 +2,7 @@
 
 namespace Orchid\Tests\Unit\Screen;
 
+use Orchid\Screen\Repository;
 use Orchid\Screen\TD;
 use Orchid\Tests\TestUnitCase;
 
@@ -14,5 +15,21 @@ class TDForTableTest extends TestUnitCase
         $view = TD::set('name')->popover($popover)->buildTh();
 
         $this->assertStringContainsString($popover, $view);
+    }
+
+    public function testTdWidth(): void
+    {
+        $width = '100px';
+
+        $view = TD::set('name')->width($width)->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringContainsString('<div style="width:' . $width . '"', $view);
+    }
+
+    public function testTdWithoutWidth(): void
+    {
+        $view = TD::set('name')->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringNotContainsString('div style="width:"', $view);
     }
 }


### PR DESCRIPTION
### Fixed
  - Redundant rendering of attribute `style` with an empty value `width` when `width` is empty in the template `td`
