### PR TITLE
Fixed generate td css width value

### DIFF
--- a/resources/views/partials/layouts/td.blade.php
+++ b/resources/views/partials/layouts/td.blade.php
@@ -1,5 +1,5 @@
 <td class="text-{{$align}} @if(!$width) text-truncate @endif" data-column="{{ $slug }}" colspan="{{ $colspan }}">
-    <div @empty(!$width)style="width:{{ ctype_digit($width) ? $width . 'px' : $width }}"@endempty>
+    <div @empty(!$width)style="width:{{ is_numeric($width) ? $width . 'px' : $width }}"@endempty>
         @isset($render)
             {!! $value !!}
         @else

--- a/tests/Unit/Screen/TDForTableTest.php
+++ b/tests/Unit/Screen/TDForTableTest.php
@@ -32,4 +32,40 @@ class TDForTableTest extends TestUnitCase
 
         $this->assertStringNotContainsString('div style="width:"', $view);
     }
+
+    public function testTdWidthNumeric(): void
+    {
+        $integer = 100;
+
+        $view = TD::set('name')->width($integer)->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringContainsString('<div style="width:'.$integer.'px"', $view);
+
+        $float = 100.51;
+
+        $view = TD::set('name')->width($float)->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringContainsString('<div style="width:'.$float.'px"', $view);
+    }
+
+    public function testTdWidthString(): void
+    {
+        $stringWithInteger = '100';
+
+        $view = TD::set('name')->width($stringWithInteger)->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringContainsString('<div style="width:'.$stringWithInteger.'px"', $view);
+
+        $stringWithFloat = '100.50';
+
+        $view = TD::set('name')->width($stringWithFloat)->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringContainsString('<div style="width:'.$stringWithFloat.'px"', $view);
+
+        $stringWithNotOnlyNumeric = '100em';
+
+        $view = TD::set('name')->width($stringWithNotOnlyNumeric)->buildTd(new Repository(['name' => 'value']));
+
+        $this->assertStringContainsString('<div style="width:'.$stringWithNotOnlyNumeric.'"', $view);
+    }
 }


### PR DESCRIPTION
### Fixed
  - Use `is_numeric` instead `ctype_digit` to determine if a variable is a number

`ctype_digit` behaves incorrectly when we pass, for example, a value of type `integer` since this method can interpret numbers as `ASCII` characters. Also, the method does not interpret floating values as numbers. 

https://www.php.net/manual/en/function.ctype-digit.php#refsect1-function.ctype-digit-examples

As a result, the value is obtained without the ending `px` and is essentially incorrect.

It is a good idea to use the `is_numeric` method, which is more flexible and correct in determining whether a variable is a number or not.

https://www.php.net/manual/en/function.is-numeric.php#refsect1-function.is-numeric-examples

### Added
  - Test cases
