### PR TITLE
Datalist for input

### DIFF
--- a/resources/views/fields/input.blade.php
+++ b/resources/views/fields/input.blade.php
@@ -4,4 +4,12 @@
     >
         <input {{ $attributes }}>
     </div>
+
+    @empty(!$datalist)
+        <datalist id="datalist-{{$name}}">
+            @foreach($datalist as $item)
+                <option value="{{ $item }}">
+            @endforeach
+        </datalist>
+    @endempty
 @endcomponent

--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -53,7 +53,8 @@ class Input extends Field
      * @var array
      */
     protected $attributes = [
-        'class' => 'form-control',
+        'class'    => 'form-control',
+        'datalist' => [],
     ];
 
     /**
@@ -103,6 +104,24 @@ class Input extends Field
             if (is_array($mask)) {
                 $this->set('mask', json_encode($mask));
             }
+        });
+    }
+
+    /**
+     * @param array $datalist
+     *
+     * @return Input
+     */
+    public function datalist(array $datalist = []): self
+    {
+        if (empty($datalist)) {
+            return $this;
+        }
+
+        $this->set('datalist', $datalist);
+
+        return $this->addBeforeRender(function () {
+            $this->set('list', 'datalist-' . $this->get('name'));
         });
     }
 }

--- a/tests/Unit/Screen/Fields/InputTest.php
+++ b/tests/Unit/Screen/Fields/InputTest.php
@@ -6,11 +6,12 @@ namespace Orchid\Tests\Unit\Screen\Fields;
 
 use Orchid\Screen\Fields\Input;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
+use Throwable;
 
 class InputTest extends TestFieldsUnitCase
 {
     /**
-     * @throws \Throwable
+     * @throws Throwable
      */
     public function testShowHr(): void
     {
@@ -81,5 +82,24 @@ class InputTest extends TestFieldsUnitCase
         $input = (string) Input::make('name')->required(false);
 
         $this->assertStringNotContainsString('required', $input);
+    }
+
+    public function testDataListAttribute(): void
+    {
+        $input = (string)Input::make('browser')->datalist([
+            'Opera', 'Edge', 'Firefox',
+            'Chrome', 'Safari',
+        ]);
+
+        $this->assertStringContainsString('Safari', $input);
+        $this->assertStringContainsString('list="datalist-browser"', $input);
+        $this->assertStringContainsString('<datalist id="datalist-browser"', $input);
+
+
+        $input = (string)Input::make('browser')->datalist([]);
+
+        $this->assertStringNotContainsString('list="datalist-browser"', $input);
+        $this->assertStringNotContainsString('<datalist id="datalist-browser"', $input);
+
     }
 }


### PR DESCRIPTION
## Proposed Changes

  - Added `datalist` method for Input field

```php
Input::make('browser')
    ->title('Choose your browser from the list:')
    ->datalist([
        'Opera', 'Edge', 'Firefox',
        'Chrome', 'Safari',
    ]),
```


![2020-11-12 21 45 27](https://user-images.githubusercontent.com/5102591/98982803-fa202280-2530-11eb-8ea3-ddd31450f8bd.jpg)
