### PR TITLE
Add model key to config/platform.php for overriding the authentication models

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -1,5 +1,8 @@
 <?php
 
+use Orchid\Platform\Models\Role;
+use Orchid\Platform\Models\User;
+
 return [
 
     /*
@@ -50,6 +53,23 @@ return [
     'middleware' => [
         'public'  => ['web'],
         'private' => ['web', 'platform'],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Models
+    |--------------------------------------------------------------------------
+    |
+    | The models array contains the models used for authentication by the
+    | platform. The defaults should work for most installations but if
+    | you need to use custom User or Role class, simply override them here.
+    |
+    |
+    */
+
+    'models' => [
+        'user' => User::class,
+        'role' => Role::class,
     ],
 
     /*

--- a/src/Access/UserAccess.php
+++ b/src/Access/UserAccess.php
@@ -37,7 +37,9 @@ trait UserAccess
      */
     public function roles(): BelongsToMany
     {
-        return $this->belongsToMany(Dashboard::model(Role::class), 'role_users', 'user_id', 'role_id');
+        $roleModel = config('platform.models.role', Role::class);
+
+        return $this->belongsToMany(Dashboard::model($roleModel), 'role_users', 'user_id', 'role_id');
     }
 
     /**

--- a/src/Platform/Commands/AdminCommand.php
+++ b/src/Platform/Commands/AdminCommand.php
@@ -51,7 +51,9 @@ class AdminCommand extends Command
 
     protected function createNewUser(): void
     {
-        Dashboard::modelClass(User::class)
+        $userModel = config('platform.models.user', User::class);
+
+        Dashboard::modelClass($userModel)
             ->createAdmin(
                 $this->argument('name') ?? $this->ask('What is your name?', 'admin'),
                 $this->argument('email') ?? $this->ask('What is your email?', 'admin@admin.com'),
@@ -66,7 +68,9 @@ class AdminCommand extends Command
      */
     protected function updateUserPermissions(string $id): void
     {
-        Dashboard::modelClass(User::class)
+        $userModel = config('platform.models.user', User::class);
+
+        Dashboard::modelClass($userModel)
             ->findOrFail($id)
             ->forceFill([
                 'permissions' => Dashboard::getAllowAllPermission(),


### PR DESCRIPTION
This allows us to easily reference the custom User and Role models if necessary.