### PR TITLE
Hide file download link for non-public storage

### DIFF
--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -85,6 +85,7 @@
                                 </div>
 
 
+                                @if($visibility === 'public')
                                 <div class="form-group">
                                     <a href="#" data-action="click->fields--upload#openLink">
                                         <small>
@@ -94,6 +95,7 @@
                                         </small>
                                     </a>
                                 </div>
+                                @endif
 
 
                             </div>

--- a/src/Screen/Fields/Upload.php
+++ b/src/Screen/Fields/Upload.php
@@ -24,7 +24,6 @@ use Orchid\Support\Init;
  * @method Upload placeholder(string $value = null)
  * @method Upload value($value = true)
  * @method Upload help(string $value = null)
- * @method Upload storage($value = true)
  * @method Upload parallelUploads($value = true)
  * @method Upload maxFileSize($value = true)
  * @method Upload maxFiles($value = true)
@@ -64,6 +63,7 @@ class Upload extends Field
         'resizeHeight'    => null,
         'media'           => false,
         'closeOnAdd'      => false,
+        'visibility'      => 'public',
     ];
 
     /**
@@ -130,4 +130,26 @@ class Upload extends Field
             $this->set('value', $value);
         });
     }
+    
+    /**
+     * @param string $storage
+     *
+     * @return $this
+     * @throws \Throwable
+     */
+    public function storage(string $storage): self
+    {
+        $disk = config("filesystems.disks." . $storage);
+
+        throw_if(
+            $disk === null,
+            \Exception::class,
+            'The selected storage was not found'
+        );
+
+        return $this
+            ->set('storage', $storage)
+            ->set('visibility', $disk['visibility'] ?? null);
+    }
+
 }

--- a/tests/Unit/Screen/Fields/UploadTest.php
+++ b/tests/Unit/Screen/Fields/UploadTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Unit\Screen\Fields;
+
+use Orchid\Support\Init;
+
+use Orchid\Screen\Fields\Upload;
+use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
+
+class UploadTest extends TestFieldsUnitCase
+{
+    public function testStorage(): void
+    {
+        $upload = Upload::make('file');
+        $this->assertSame('public', $upload->getAttributes()['visibility']);
+        
+        $upload = Upload::make('file')->storage('local');
+        $this->assertNull($upload->getAttributes()['visibility']);
+    }
+    
+    public function testExceedMaxServerSize()
+    {
+        $uploadSize = Init::maxFileUpload(Init::MB) + 1;
+        $upload = Upload::make('file')->maxFileSize($uploadSize);
+        
+        $this->expectException(\RuntimeException::class);
+        $upload->render();
+    }
+}


### PR DESCRIPTION
Fixes #1532 

May be better to check filesystem storage properties for [url|visibility]

```
'url' => env('APP_URL').'/storage',
'visibility' => 'public',
```

Not sure if this is used for S3 so feel free to decline merge if this breaks anything and i'll take another look. Another solution posted in the issue.
