### PR TITLE
Fix wiping user roles when updating user via oneAsyncModal

### DIFF
--- a/stubs/app/Orchid/Screens/User/UserListScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserListScreen.php
@@ -104,7 +104,6 @@ class UserListScreen extends Screen
         ]);
 
         $user->fill($request->input('user'))
-            ->replaceRoles($request->input('user.roles'))
             ->save();
 
         Toast::info(__('User was saved.'));


### PR DESCRIPTION
Fixes the issue: when updating a user via oneAsyncModal all user roles were deleted.

<img width="1173" alt="image" src="https://user-images.githubusercontent.com/451007/105481604-56818a00-5cb8-11eb-9773-1b52923ddeb8.png">
