### PR TITLE
Map related User model

### DIFF
--- a/src/Attachment/Models/Attachment.php
+++ b/src/Attachment/Models/Attachment.php
@@ -84,7 +84,7 @@ class Attachment extends Model
      */
     public function user(): BelongsTo
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(Dashboard::model(User::class));
     }
 
     /**


### PR DESCRIPTION
Fixes 

When creating a notification with an overridden platform User model, notifications failed to show. DB had Orchid\Platform\Models\User as type instead of mapped model. e.g

```php
$orchidUser = $event->attachment->user;
$user = \App\Models\User::find($orchidUser->id);
$user->notify(new \App\Notifications\Processed($event));
```

Can now be:

```php
$orchidUser = $event->attachment->user->notify(new \App\Notifications\Processed($event));
```