### PR TITLE
Add a languages scan and sync tool

### DIFF
--- a/lang.php
+++ b/lang.php
@@ -138,7 +138,7 @@ function summary($new_translations, $old_translations)
     foreach ($new_translations as $locale => $new_translation) {
         echo "## $locale: ".PHP_EOL;
         foreach (array_diff_key($old_translations[$locale], $new_translation) as $key => $_) {
-            echo "### $key".PHP_EOL;
+            echo "- $key".PHP_EOL;
         }
         echo PHP_EOL;
     }

--- a/lang.php
+++ b/lang.php
@@ -35,7 +35,7 @@ function find_translation_keys(): array
         "(?P<quote>['\"])".                             // Match " or ' and store in {quote}
         "(?P<string>(?:\\\k{quote}|(?!\k{quote}).)*)".  // Match any string that can be {quote} escaped
         "\k{quote}".                                    // Match " or ' previously matched
-        "[^\w]*;";                                            // End with ";"
+        "[^\w]*;";                                      // End with ";"
 
     $keys = [];
 
@@ -144,6 +144,7 @@ function summary($new_translations, $old_translations)
     }
 }
 
+
 function main()
 {
     $old_translations = read_locale_from_resources();
@@ -157,5 +158,6 @@ function main()
 
     summary($new_translations, $old_translations);
 }
+
 
 main();

--- a/lang.php
+++ b/lang.php
@@ -45,6 +45,8 @@ function find_translation_keys(): array
     return $keys;
 }
 
+
+# https://gist.github.com/UziTech/3b65b2543cee57cd6d2ecfcccf846f20
 function glob_recursive($base, $pattern, $flags = 0): array
 {
     if (substr($base, -1) !== DIRECTORY_SEPARATOR) {
@@ -79,6 +81,7 @@ function read_locale_from_resources(): array
     return $locales;
 }
 
+
 function sync_translations($translations, $keys): array
 {
     $new_translations = [];
@@ -97,16 +100,41 @@ function sync_translations($translations, $keys): array
 }
 
 
+function summary($new_translations, $old_translations)
+{
+    echo "# Missing keys:".PHP_EOL;
+    foreach ($new_translations as $locale => $new_translation) {
+        echo "## $locale: ".PHP_EOL;
+        foreach (array_diff_key($new_translation, $old_translations[$locale]) as $key => $_) {
+            echo "### $key" . PHP_EOL;
+        }
+        echo PHP_EOL;
+    }
+
+    echo PHP_EOL;
+
+    echo "# Deleted keys:".PHP_EOL;
+    foreach ($new_translations as $locale => $new_translation) {
+        echo "## $locale: ".PHP_EOL;
+        foreach (array_diff_key($old_translations[$locale], $new_translation) as $key => $_) {
+            echo "### $key" . PHP_EOL;
+        }
+        echo PHP_EOL;
+    }
+}
+
 function main()
 {
-    $translations = read_locale_from_resources();
+    $old_translations = read_locale_from_resources();
     $keys = find_translation_keys();
-    $new_translations = sync_translations($translations, $keys);
+    $new_translations = sync_translations($old_translations, $keys);
 
     foreach ($new_translations as $locale => $translation) {
         file_put_contents("./resources/lang/".$locale.'.json',
         json_encode($translation, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
     }
+
+    summary($new_translations, $old_translations);
 }
 
 main();

--- a/lang.php
+++ b/lang.php
@@ -1,0 +1,73 @@
+<?php
+
+
+require "vendor/autoload.php";
+
+function findTranslations($files)
+{
+    $functions = [
+        '__',
+    ];
+
+    $stringPattern =                                    // See https://regex101.com/r/WEJqdL/6
+        "[^\w]".                                        // Must not have an alphanum before real method
+        '('.implode('|', $functions).')'.               // Must start with one of the functions
+        "\(\s*".                                        // Match opening parenthesis
+        "(?P<quote>['\"])".                             // Match " or ' and store in {quote}
+        "(?P<string>(?:\\\k{quote}|(?!\k{quote}).)*)".  // Match any string that can be {quote} escaped
+        "\k{quote}".                                    // Match " or ' previously matched
+        "\s*[\),]";                                     // Close parentheses or new parameter
+
+
+    $keys = [];
+
+    foreach ($files as $file) {
+        if (preg_match_all("/$stringPattern/siU", file_get_contents($file), $matches)) {
+            // Get all matches
+            foreach ($matches["string"] as $key) {
+                $keys[] = $key;
+            }
+        }
+    }
+
+    $keys = array_unique($keys);
+    sort($keys);
+
+    return $keys;
+}
+
+// $keys = findTranslations();
+// dump($keys);
+
+function glob_recursive($base, $pattern, $flags = 0)
+{
+    if (substr($base, -1) !== DIRECTORY_SEPARATOR) {
+        $base .= DIRECTORY_SEPARATOR;
+    }
+
+    $files = glob($base.$pattern, $flags);
+    if ($files === false) {
+        $files = [];
+    }
+
+    foreach (glob($base.'*', GLOB_ONLYDIR | GLOB_NOSORT | GLOB_MARK) as $dir) {
+        $dirFiles = glob_recursive($dir, $pattern, $flags);
+        if ($dirFiles !== false) {
+            $files = array_merge($files, $dirFiles);
+        }
+    }
+
+    return $files;
+}
+
+$glob = glob_recursive("./src", "*");
+$glob = array_merge(glob_recursive("./stub", "*"), $glob);
+
+$glob = array_filter($glob, function ($f) {
+    return is_file($f);
+});
+
+dump($glob);
+
+$keys = findTranslations($glob);
+dump($keys);

--- a/lang.php
+++ b/lang.php
@@ -106,7 +106,7 @@ function summary($new_translations, $old_translations)
     foreach ($new_translations as $locale => $new_translation) {
         echo "## $locale: ".PHP_EOL;
         foreach (array_diff_key($new_translation, $old_translations[$locale]) as $key => $_) {
-            echo "### $key" . PHP_EOL;
+            echo "- $key" . PHP_EOL;
         }
         echo PHP_EOL;
     }

--- a/lang.php
+++ b/lang.php
@@ -106,7 +106,7 @@ function summary($new_translations, $old_translations)
     foreach ($new_translations as $locale => $new_translation) {
         echo "## $locale: ".PHP_EOL;
         foreach (array_diff_key($new_translation, $old_translations[$locale]) as $key => $_) {
-            echo "- $key" . PHP_EOL;
+            echo "- $key".PHP_EOL;
         }
         echo PHP_EOL;
     }
@@ -117,7 +117,7 @@ function summary($new_translations, $old_translations)
     foreach ($new_translations as $locale => $new_translation) {
         echo "## $locale: ".PHP_EOL;
         foreach (array_diff_key($old_translations[$locale], $new_translation) as $key => $_) {
-            echo "### $key" . PHP_EOL;
+            echo "### $key".PHP_EOL;
         }
         echo PHP_EOL;
     }


### PR DESCRIPTION
# Add a languages scan and sync tool

## Proposed Changes

  - scan `src, stubs, resources/views` for `__()`
  - scan translatable field from XxxScreen,  `$name`, `$description`
  - loads resources/lang/*.json
  - order translations by key
  - when existing key not included in some json translation, `[*].$key` is for translation, which indicates further translation needed.

