### PR TITLE
Fix: id option in orchid:admin command accepts values (fixes #1571)

### DIFF
--- a/src/Platform/Commands/AdminCommand.php
+++ b/src/Platform/Commands/AdminCommand.php
@@ -22,7 +22,7 @@ class AdminCommand extends Command
     /**
      * @var string
      */
-    protected $signature = 'orchid:admin {name?} {email?} {password?} {--id}';
+    protected $signature = 'orchid:admin {name?} {email?} {password?} {--id=}';
 
     /**
      * The console command description.


### PR DESCRIPTION
## Proposed Changes

  - Make id option in `orchid:admin` command accept values [matching the behavior described in the docs](https://orchid.software/en/docs/access/#admin-creation) (Fixes #1571)

