### PR TITLE
Update ItemMenu.php

### DIFF
--- a/src/Platform/ItemMenu.php
+++ b/src/Platform/ItemMenu.php
@@ -44,7 +44,7 @@ class ItemMenu
     /**
      * @var bool
      */
-    public $withChildren = false;
+    public $childs = false;
 
     /**
      * @var int
@@ -231,26 +231,13 @@ class ItemMenu
     }
 
     /**
-     * @deprecated usage `withChildren` method
-     *
-     * @param bool $children
-     *
-     * @return ItemMenu
-     */
-    public function childs(bool $children = true): self
+    * @param bool $childs
+    *
+    * @return ItemMenu
+    */
+    public function childs(bool $childs = true): self
     {
-        return $this->withChildren($children);
-    }
-
-    /**
-     * @param bool $children
-     *
-     * @return $this
-     */
-    public function withChildren(bool $children = true): self
-    {
-        $this->withChildren = $children;
-
+        $this->childs = $childs;
         return $this;
     }
 


### PR DESCRIPTION
After updating Orchid packages via composer to version 9.19.8, I started to get this error in my dashboard  - 
"Undefined variable: childs (View: /var/www/html/resources/views/vendor/platform/partials/mainMenu.blade.php)" 
So after applying these changes in ItemMenu.php it started to work again.

Fixes #

## Proposed Changes

  - Add $childs property to ItemMenu
  - Change childs() function
  -
