### PR TITLE
Fix tabs not working on the same page if using same key

### DIFF
--- a/resources/views/layouts/tabs.blade.php
+++ b/resources/views/layouts/tabs.blade.php
@@ -12,7 +12,7 @@
                        id="button-tab-{{\Illuminate\Support\Str::slug($name)}}"
                        role="tab"
                        data-toggle="tab">
-                        {!! $name !!}
+                        {!! $titles[$loop->index] ?? $name !!}
                     </a>
                 </li>
             @endforeach

--- a/src/Screen/LayoutFactory.php
+++ b/src/Screen/LayoutFactory.php
@@ -132,12 +132,13 @@ class LayoutFactory
 
     /**
      * @param array $layouts
+     * @param string[] $titles
      *
      * @return Tabs
      */
-    public static function tabs(array $layouts): Tabs
+    public static function tabs(array $layouts, array $titles = []): Tabs
     {
-        return new class($layouts) extends Tabs {
+        return new class($layouts, $titles) extends Tabs {
         };
     }
 

--- a/src/Screen/Layouts/Tabs.php
+++ b/src/Screen/Layouts/Tabs.php
@@ -17,14 +17,30 @@ abstract class Tabs extends Layout
      */
     public $template = 'platform::layouts.tabs';
 
+    protected $titles = [];
+
     /**
      * Layout constructor.
      *
      * @param Layout[] $layouts
+     * @param string[] $titles
      */
-    public function __construct(array $layouts = [])
+    public function __construct(array $layouts = [], array $titles = [])
     {
         $this->layouts = $layouts;
+        $this->titles = $titles;
+    }
+
+    /**
+     * @param array $titles
+     *
+     * @return Tabs
+     */
+    public function titles(array $titles = [])
+    {
+        $this->titles = $titles;
+
+        return $this;
     }
 
     /**
@@ -34,6 +50,8 @@ abstract class Tabs extends Layout
      */
     public function build(Repository $repository)
     {
-        return $this->buildAsDeep($repository);
+        return $this->buildAsDeep($repository)->with([
+            'titles' => $this->titles,
+        ]);
     }
 }

--- a/src/Support/Facades/Layout.php
+++ b/src/Support/Facades/Layout.php
@@ -29,7 +29,7 @@ use Orchid\Screen\Layouts\Wrapper;
  * @method static Rows rows(array $fields)
  * @method static Table table(string $target, array $columns)
  * @method static Columns columns(BaseLayout[] $layouts)
- * @method static Tabs tabs(BaseLayout[] $layouts)
+ * @method static Tabs tabs(BaseLayout[] $layouts, string[] $titles)
  * @method static Modal modal(string $key, string[]|string|BaseLayout $layouts)
  * @method static Blank blank(BaseLayout[] $layouts)
  * @method static Collapse collapse(array $fields)


### PR DESCRIPTION
Fixes that tabs are not switching correctly if multiple same keys on the same page.  

Fixed by adding a titles option, where you can enter the displayed name of the tabs. Keys should still be unique for each Tab-Layout.

Usage:
```php
Layout::tabs([
  'cz_1' => Layout::rows([
      // Your layout here
  ]),
  'de_1' => Layout::rows([
      // Your layout here
  ]),
], ["CZ", "DE"]), // This is what will be displayed
Layout::tabs([
    'cz_2' => Layout::rows([
        // Your layout here
    ]),
    'de_2' => Layout::rows([
        // Your layout here
    ]),
])->titles(["CZ", "DE]"), // This is what will be displayed
```

**Incorrect behavior:**
![wrong](https://user-images.githubusercontent.com/80975637/111817196-013fae80-88de-11eb-80c0-01317521658c.gif)

**Fixed behaviour:**
![right](https://user-images.githubusercontent.com/80975637/111817193-00a71800-88de-11eb-82ad-e5d20aa4b563.gif)