### PR TITLE
Feature/notfound exception

### DIFF
--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -242,8 +242,6 @@ abstract class Screen extends Controller
         if ($original !== null && is_a($object, UrlRoutable::class)) {
             if (! ($object = $object->resolveRouteBinding($original)) && ! $parameter->isDefaultValueAvailable()) {
                 throw (new ModelNotFoundException())->setModel($class, [$original]);
-            } else {
-                return $parameter->getDefaultValue();
             }
         }
 

--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -239,7 +240,11 @@ abstract class Screen extends Controller
         $object = resolve($class);
 
         if ($original !== null && is_a($object, UrlRoutable::class)) {
-            return $object->resolveRouteBinding($original);
+            if (! ($object = $object->resolveRouteBinding($original)) && ! $parameter->isDefaultValueAvailable()) {
+                throw (new ModelNotFoundException())->setModel($class, [$original]);
+            } else {
+                return $parameter->getDefaultValue();
+            }
         }
 
         return $object;

--- a/tests/App/Screens/QueryWithDefaultValueScreen.php
+++ b/tests/App/Screens/QueryWithDefaultValueScreen.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\App\Screens;
+
+use Orchid\Platform\Models\User;
+use Orchid\Screen\Action;
+use Orchid\Screen\Layout;
+use Orchid\Screen\Screen;
+
+class QueryWithDefaultValueScreen extends Screen
+{
+    /**
+     * Display header name.
+     *
+     * @var string
+     */
+    public $name = 'Test Query With Default Value Screen';
+
+    /**
+     * Query data.
+     *
+     * @return array
+     */
+    public function query(User $user = null): array
+    {
+        return [
+            'user' => $user,
+        ];
+    }
+
+    /**
+     * Button commands.
+     *
+     * @return Action[]
+     */
+    public function commandBar(): array
+    {
+        return [];
+    }
+
+    /**
+     * Views.
+     *
+     * @return Layout[]
+     */
+    public function layout(): array
+    {
+        return [];
+    }
+}

--- a/tests/App/Screens/QueryWithoutDefaultValueScreen.php
+++ b/tests/App/Screens/QueryWithoutDefaultValueScreen.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\App\Screens;
+
+use Orchid\Platform\Models\User;
+use Orchid\Screen\Action;
+use Orchid\Screen\Layout;
+use Orchid\Screen\Screen;
+
+class QueryWithoutDefaultValueScreen extends Screen
+{
+    /**
+     * Display header name.
+     *
+     * @var string
+     */
+    public $name = 'Test Query Without Default Value Screen';
+
+    /**
+     * Query data.
+     *
+     * @return array
+     */
+    public function query(User $user): array
+    {
+        return [
+            'user' => $user,
+        ];
+    }
+
+    /**
+     * Button commands.
+     *
+     * @return Action[]
+     */
+    public function commandBar(): array
+    {
+        return [];
+    }
+
+    /**
+     * Views.
+     *
+     * @return Layout[]
+     */
+    public function layout(): array
+    {
+        return [];
+    }
+}

--- a/tests/Feature/App/ScreenWithDefaultQueryTest.php
+++ b/tests/Feature/App/ScreenWithDefaultQueryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Feature\App;
+
+use Orchid\Platform\Models\User;
+use Orchid\Tests\App\Screens\QueryWithDefaultValueScreen;
+use Orchid\Tests\TestFeatureCase;
+
+/**
+ * Class ScreenWithDefaultQueryTest.
+ */
+class ScreenWithDefaultQueryTest extends TestFeatureCase
+{
+
+    public function testWhenNoParameterIsPassed(): void
+    {
+        $screen = new QueryWithDefaultValueScreen();
+
+        $data = $this->invokeMethod(
+            $screen,
+            'callMethod',
+            ['query']
+        );
+
+        $this->assertInstanceOf(User::class, $data['user']);
+    }
+
+
+    public function testWhenAParameterIsPassedAndTheModelExists(): void
+    {
+        $user = $this->createAdminUser();
+
+        $screen = new QueryWithDefaultValueScreen();
+
+        $data = $this->invokeMethod(
+            $screen,
+            'callMethod',
+            ['query', ['user' => $user->id]]
+        );
+
+        $this->assertSame($user->id, $data['user']->id);
+    }
+
+    public function testWhenAParameterIsPassedAndTheModelDoesNotExist(): void
+    {
+        $screen = new QueryWithDefaultValueScreen();
+
+        $data = $this->invokeMethod(
+            $screen,
+            'callMethod',
+            ['query', ['user' => 0]]
+        );
+
+        $this->assertSame(null, $data['user']);
+    }
+
+    public function invokeMethod(&$object, $methodName, array $parameters = [])
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}

--- a/tests/Feature/App/ScreenWithoutDefaultQueryTest.php
+++ b/tests/Feature/App/ScreenWithoutDefaultQueryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Feature\App;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Orchid\Platform\Models\User;
+use Orchid\Tests\App\Screens\QueryWithoutDefaultValueScreen;
+use Orchid\Tests\TestFeatureCase;
+
+/**
+ * Class ScreenWithoutDefaultQueryTest.
+ */
+class ScreenWithoutDefaultQueryTest extends TestFeatureCase
+{
+
+    public function testWhenNoParameterIsPassed(): void
+    {
+        $screen = new QueryWithoutDefaultValueScreen();
+
+        $data = $this->invokeMethod(
+            $screen,
+            'callMethod',
+            ['query']
+        );
+
+        $this->assertInstanceOf(User::class, $data['user']);
+    }
+
+    public function testWhenAParameterIsPassedAndTheModelExists(): void
+    {
+        $user = $this->createAdminUser();
+
+        $screen = new QueryWithoutDefaultValueScreen();
+
+        $data = $this->invokeMethod(
+            $screen,
+            'callMethod',
+            ['query', ['user' => $user->id]]
+        );
+
+        $this->assertSame($user->id, $data['user']->id);
+    }
+
+    public function testWhenAParameterIsPassedAndTheModelDoesNotExist(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+
+        $screen = new QueryWithoutDefaultValueScreen();
+
+        $this->invokeMethod(
+            $screen,
+            'callMethod',
+            ['query', ['user' => 0]]
+        );
+    }
+
+    public function invokeMethod(&$object, $methodName, array $parameters = [])
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
+}


### PR DESCRIPTION
Fixes

When the model could not be found, an argument error is thrown `Argument #1 ($model) must be of type Model, null given`

## Proposed Changes

  - throw ModelNotFoundException when no model is found