### PR TITLE
Make submenu id equal to the slug

### DIFF
--- a/resources/views/actions/menu.blade.php
+++ b/resources/views/actions/menu.blade.php
@@ -22,7 +22,7 @@
 
 @if(!empty($list))
     <div class="collapse sub-menu ps-2 {{active($active, 'show')}}"
-         id="menu-{{\Illuminate\Support\Str::slug($name)}}"
+         id="menu-{{$slug}}"
          data-bs-parent="#headerMenuCollapse">
         @foreach($list as $item)
             {!!  $item->build($source) !!}

--- a/src/Screen/Actions/Menu.php
+++ b/src/Screen/Actions/Menu.php
@@ -84,7 +84,7 @@ class Menu extends Link
                     return;
                 }
 
-                $slug = $this->get('slug', Str::slug($this->get('name')));
+                $slug = $this->getSlug();
 
                 $this
                     ->set('data-bs-toggle', 'collapse')
@@ -100,6 +100,14 @@ class Menu extends Link
 
                 $this->set('active', $active);
             });
+    }
+    
+    /**
+     * @return string
+     */
+    protected function getSlug(): string
+    {
+        return $this->get('slug', Str::slug($this->get('name')));
     }
 
     /**
@@ -211,4 +219,5 @@ class Menu extends Link
     {
         return $this->set('slug', $slug);
     }
+    
 }


### PR DESCRIPTION
Fixes #
if name and slug are different the dropdown menu does not work
## Proposed Changes

  - use slug for dowpdown menu id