### PR TITLE
Fix old name from request

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -49,7 +49,6 @@
     <env name="SCOUT_DRIVER" value="array"/>
     <env name="SCOUT_QUEUE" value="true"/>
     <env name="QUEUE_DRIVER" value="sync"/>
-    <env name="XDEBUG_MODE" value="coverage"/>
   </php>
   <logging/>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -49,6 +49,7 @@
     <env name="SCOUT_DRIVER" value="array"/>
     <env name="SCOUT_QUEUE" value="true"/>
     <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="XDEBUG_MODE" value="coverage"/>
   </php>
   <logging/>
 </phpunit>

--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -320,7 +320,7 @@ class Field implements Fieldable
     {
         return (string) Str::of($this->get('name'))
             ->replace(['][', '['], '.')
-            ->replace([']'], '');
+            ->replace([']'], '')->rtrim('.');
     }
 
     /**

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -164,4 +164,27 @@ class FieldTest extends TestUnitCase
 
         $this->assertEquals('parent.child.grandchild', $field->getOldName());
     }
+
+    public function testOldNameMatchesLaravelRequestOldPrefixWithErrors()
+    {
+        $field = new Input();
+
+        $field->set('name', 'parent[child][grandchild]');
+
+        $view = $field->render();
+
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertStringContainsString('parent[child][grandchild]', $view->withErrors([])->render());
+
+        $field = new Input();
+
+        $field->set('name', 'parent[child][grandchild][]');
+
+        $view = $field->render();
+
+        $this->assertInstanceOf(View::class, $view);
+
+        $this->assertStringContainsString('parent[child][grandchild][]', $view->withErrors([])->render());
+    }
 }

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -168,23 +168,30 @@ class FieldTest extends TestUnitCase
     public function testOldNameMatchesLaravelRequestOldPrefixWithErrors()
     {
         $field = new Input();
-
         $field->set('name', 'parent[child][grandchild]');
 
         $view = $field->render();
 
-        $this->assertInstanceOf(View::class, $view);
+        $html = $view->withErrors([
+            'parent.child.grandchild' => 'testError'
+        ])->render();
 
-        $this->assertStringContainsString('parent[child][grandchild]', $view->withErrors([])->render());
+        $this->assertInstanceOf(View::class, $view);
+        $this->assertStringContainsString('testError', $html);
+        $this->assertStringContainsString('parent[child][grandchild]', $html);
 
         $field = new Input();
-
         $field->set('name', 'parent[child][grandchild][]');
 
         $view = $field->render();
 
-        $this->assertInstanceOf(View::class, $view);
+        $html = $view->withErrors([
+            'parent.child.grandchild' => 'testError'
+        ])->render();
 
-        $this->assertStringContainsString('parent[child][grandchild][]', $view->withErrors([])->render());
+
+        $this->assertInstanceOf(View::class, $view);
+        $this->assertStringContainsString('testError', $html);
+        $this->assertStringContainsString('parent[child][grandchild][]', $html);
     }
 }

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -149,4 +149,19 @@ class FieldTest extends TestUnitCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    public function testOldNameMatchesLaravelRequestOldPrefix()
+    {
+        $field = new Field();
+
+        $field->set('name', 'parent[child][grandchild]');
+
+        $this->assertEquals('parent.child.grandchild', $field->getOldName());
+
+        $field = new Field();
+
+        $field->set('name', 'parent[child][grandchild][]');
+
+        $this->assertEquals('parent.child.grandchild', $field->getOldName());
+    }
 }


### PR DESCRIPTION
Fixes #

Assume we have a input with name `article[tags][text][]` the `old()` input name should be `article.tags.text` in the current state it returns an extra `.` to the name `article.tags.text.`
