### PR TITLE
добавление обертки для iframe при вставке видео

### DIFF
--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -1,6 +1,8 @@
 import ApplicationController from "./application_controller";
 import Quill from 'quill';
 
+let videoResponsiveRegistered = false;
+
 export default class extends ApplicationController {
     /**
      *
@@ -8,6 +10,7 @@ export default class extends ApplicationController {
     connect() {
         const selector = this.element.querySelector('.quill').id;
         const input = this.element.querySelector('input');
+        this.videoResponsive();
 
         this.editor = new Quill(`#${selector}`, {
             placeholder: input.placeholder,
@@ -137,5 +140,48 @@ export default class extends ApplicationController {
         // push image url to rich editor.
         const range = this.editor.getSelection();
         this.editor.insertEmbed(range.index, 'image', url);
+    }
+
+    videoResponsive() {
+        if(videoResponsiveRegistered) return;
+
+        const BlockEmbed = Quill.import("blots/block/embed");
+        const Link = Quill.import("formats/link");
+
+        class VideoResponsive extends BlockEmbed {
+
+            static blotName = "video";
+            static tagName = "div";
+
+            static create(value) {
+                const node = super.create(value);
+                node.classList.add("ql-video-wrapper");
+
+                const innerChild = document.createElement("div");
+                innerChild.classList.add("ql-video-inner");
+                node.appendChild(innerChild);
+
+                const child = document.createElement("iframe");
+                child.setAttribute('frameborder', '0');
+                child.setAttribute('allowfullscreen', true);
+                child.setAttribute('src', this.sanitize(value));
+                innerChild.appendChild(child);
+
+                return node;
+            }
+
+            static sanitize(url) {
+                return Link.sanitize(url);
+            }
+
+            static value(domNode) {
+                const iframe = domNode.querySelector('iframe');
+                return iframe.getAttribute('src');
+            }
+        }
+
+        Quill.register(VideoResponsive);
+
+        videoResponsiveRegistered = true;
     }
 }

--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -1,7 +1,6 @@
 import ApplicationController from "./application_controller";
+import QuillFormatsVideo from "./quill_formats_video";
 import Quill from 'quill';
-
-let currentQuill;
 
 export default class extends ApplicationController {
     /**
@@ -10,8 +9,6 @@ export default class extends ApplicationController {
     connect() {
         const selector = this.element.querySelector('.quill').id;
         const input = this.element.querySelector('input');
-
-        Quill.register(this.videoResponsive());
 
         this.editor = new Quill(`#${selector}`, {
             placeholder: input.placeholder,
@@ -24,10 +21,7 @@ export default class extends ApplicationController {
             },
         });
 
-        // we can now access the current editor to get dataset
-        setTimeout(() => this.element.getElementsByClassName('ql-editor')[0].addEventListener('focus', () => {
-            currentQuill = this.element;
-        }),0);
+        setTimeout(Quill.register(QuillFormatsVideo(this.element)), 0);
 
         // quill editor add image handler
         this.editor.getModule('toolbar').addHandler('image', () => {
@@ -146,61 +140,5 @@ export default class extends ApplicationController {
         // push image url to rich editor.
         const range = this.editor.getSelection();
         this.editor.insertEmbed(range.index, 'image', url);
-    }
-
-    videoResponsive() {
-        const BlockEmbed = Quill.import("blots/block/embed");
-        const Link = Quill.import("formats/link");
-
-        class VideoResponsive extends BlockEmbed {
-
-            static blotName = "video";
-            static tagName = "div";
-            static wrapVideo = false;
-
-            static create(value) {
-                this.wrapVideo = currentQuill.dataset.wrapVideo === '1';
-
-                if(this.wrapVideo) {
-                    const node = super.create(value);
-                    node.classList.add("ql-video-wrapper");
-
-                    const innerChild = document.createElement("div");
-                    innerChild.classList.add("ql-video-inner");
-                    node.appendChild(innerChild);
-
-                    const child = document.createElement("iframe");
-                    this.setIframe(child, value)
-                    innerChild.appendChild(child);
-
-                    return node;
-                }
-
-                this.tagName = 'iframe';
-
-                const node = super.create(value);
-                this.setIframe(node, value);
-
-                return node;
-            }
-
-            static setIframe(iFrame, url) {
-                iFrame.setAttribute('frameborder', '0');
-                iFrame.setAttribute('allowfullscreen', true);
-                iFrame.setAttribute('src', this.sanitize(url));
-                iFrame.classList.add('ql-video');
-            }
-
-            static sanitize(url) {
-                return Link.sanitize(url);
-            }
-
-            static value(domNode) {
-                const iframe = this.wrapVideo ? domNode.querySelector('iframe') : domNode;
-                return iframe.getAttribute('src');
-            }
-        }
-
-        return VideoResponsive;
     }
 }

--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -161,8 +161,6 @@ export default class extends ApplicationController {
             static create(value) {
                 this.wrapVideo = currentQuill.dataset.wrapVideo === '1';
 
-                console.log(this.wrapVideo);
-
                 if(this.wrapVideo) {
                     const node = super.create(value);
                     node.classList.add("ql-video-wrapper");

--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -1,5 +1,5 @@
 import ApplicationController from "./application_controller";
-import QuillFormatsVideo from "./quill_formats_video";
+import QuillFormatsVideo from "./../quill_formats_video";
 import Quill from 'quill';
 
 export default class extends ApplicationController {

--- a/resources/js/controllers/quill_formats_video.js
+++ b/resources/js/controllers/quill_formats_video.js
@@ -1,0 +1,71 @@
+import Quill from "quill";
+/**
+ * Created by mavsan on 04.08.2021.
+ * Author: Maksim Klimenko
+ * Email: mavsan@gmail.com
+ */
+
+let currentQuill;
+const BlockEmbed = Quill.import("blots/block/embed");
+const Link = Quill.import("formats/link");
+
+class VideoResponsive extends BlockEmbed {
+  static blotName = "video";
+  static tagName = "div";
+  static wrapVideo = false;
+
+  static create(value) {
+    let node;
+    this.wrapVideo = currentQuill.dataset.wrapVideo === '1';
+
+    if(this.wrapVideo) {
+      node = this.setWrapVideo(value);
+    } else {
+      this.tagName = 'iframe';
+      node = super.create(value);
+      this.setIframe(node, value);
+    }
+
+    return node;
+  }
+
+  static setWrapVideo(value) {
+    const node = super.create(value);
+    node.classList.add("ql-video-wrapper");
+
+    const innerChild = document.createElement("div");
+    innerChild.classList.add("ql-video-inner");
+    node.appendChild(innerChild);
+
+    const child = document.createElement("iframe");
+    this.setIframe(child, value)
+    innerChild.appendChild(child);
+
+    return node;
+  }
+
+  static setIframe(iFrame, url) {
+    iFrame.setAttribute('frameborder', '0');
+    iFrame.setAttribute('allowfullscreen', true);
+    iFrame.setAttribute('src', this.sanitize(url));
+    iFrame.classList.add('ql-video');
+  }
+
+  static sanitize(url) {
+    return Link.sanitize(url);
+  }
+
+  static value(domNode) {
+    const iframe = this.wrapVideo ? domNode.querySelector('iframe') : domNode;
+    return iframe.getAttribute('src');
+  }
+}
+
+export default (quillElement) => {
+
+  quillElement.getElementsByClassName('ql-editor')[0].addEventListener('focus', () => {
+    currentQuill = quillElement;
+  });
+
+  return VideoResponsive;
+}

--- a/resources/js/quill_formats_video.js
+++ b/resources/js/quill_formats_video.js
@@ -1,9 +1,4 @@
 import Quill from "quill";
-/**
- * Created by mavsan on 04.08.2021.
- * Author: Maksim Klimenko
- * Email: mavsan@gmail.com
- */
 
 let currentQuill;
 const BlockEmbed = Quill.import("blots/block/embed");
@@ -16,7 +11,7 @@ class VideoResponsive extends BlockEmbed {
 
   static create(value) {
     let node;
-    this.wrapVideo = currentQuill.dataset.wrapVideo === '1';
+    this.wrapVideo = currentQuill.dataset.wrapVideo == '1';
 
     if(this.wrapVideo) {
       node = this.setWrapVideo(value);

--- a/resources/views/fields/quill.blade.php
+++ b/resources/views/fields/quill.blade.php
@@ -3,6 +3,7 @@
          data-quill-toolbar='@json($toolbar)'
          data-quill-value='@json($value)'
          data-theme="{{$theme ?? 'inlite'}}"
+         data-wrap-video="{{ $wrapVideo ?? '0' }}"
     >
         <div id="toolbar"></div>
         <div class="quill p-3 position-relative" id="quill-wrapper-{{$id}}"

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -28,6 +28,7 @@ use Orchid\Screen\Field;
  * @method Quill title(string $value = null)
  * @method Quill popover(string $value = null)
  * @method Quill toolbar(array $options)
+ * @method Quill wrapVideo($value = true)
  */
 class Quill extends Field
 {
@@ -45,6 +46,7 @@ class Quill extends Field
         'value'   => null,
         'toolbar' => ['text', 'color', 'quote', 'header', 'list', 'format', 'media'],
         'height'  => '300px',
+        'wrapVideo' => null
     ];
 
     /**


### PR DESCRIPTION
При вставке видео (WYSIWYG Quill)  в код вставляется iframe, который нельзя сделать адаптивным. Напрашиваются 2 варианта:

1. view composer, где регуляркой искать этот iframe и оборачивать нужным образом;
2. оборачивать в самом Quill при вставке (как раз то, что я предлагаю).

Код был честно украден вот здесь [https://github.com/pblobp/quill-video-responsive](https://github.com/pblobp/quill-video-responsive). После того, как видео будет вставлено получится вот такая структура:

`<div class='ql-video-wrapper'><div class='ql-video-inner'><iframe ...></iframe></div></div>`

Хотя, по-мне - достаточно одно div, но так у автора. Стили для этого дела должны быть такие (для фронтэнда):

```
.ql-video-wrapper {
	width: 100%;
	margin: auto;
}

.ql-video-inner {
        // от этого значения зависит "высота" блока, конкретно здесь значение для видео формата 16:9 (9 / 16 = 0,5625)
	padding-top:56.25%;
	position:relative;
	height:0;
}

.ql-video-inner iframe,
.ql-video-inner object,
.ql-video-inner embed {
	position: absolute;
	top: 0;
	left: 0;
	width: 100%;
	height: 100%;
}
```
