### PR TITLE
[Hotfix] Support collection in target table

### DIFF
--- a/resources/views/layouts/table.blade.php
+++ b/resources/views/layouts/table.blade.php
@@ -48,7 +48,7 @@
         </table>
     </div>
 
-    @if(($rows instanceof \Illuminate\Contracts\Pagination\Paginator || $rows instanceof \Illuminate\Contracts\Pagination\CursorPaginator) && $rows->isEmpty())
+    @if(($rows instanceof \Illuminate\Contracts\Pagination\Paginator || $rows instanceof \Illuminate\Contracts\Pagination\CursorPaginator || $rows instanceof \Illuminate\Support\Collection) && $rows->isEmpty())
         <div class="text-center py-5 w-100">
             <h3 class="fw-light">
                 @isset($iconNotFound)

--- a/tests/Unit/Screen/Layouts/TableTest.php
+++ b/tests/Unit/Screen/Layouts/TableTest.php
@@ -123,4 +123,23 @@ class TableTest extends TestUnitCase
 
         $this->assertStringContainsString('table-hover', $html);
     }
+
+    public function testShowTextNotFoundWhenTargetIsEmptyCollection()
+    {
+        $layout = new class extends Table {
+            protected $target = 'target';
+
+            protected function columns(): array
+            {
+                return [];
+            }
+        };
+
+        $html = $layout->build(new Repository([
+            'target'  => collect([]),
+        ]))->render();
+
+        $this->assertStringContainsString('There are no records in this view', $html);
+        $this->assertNotEmpty($html);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

I am currently using Orchid and I am working on displaying the records of a **Query Builder** in a table.

I am using filters on that query and I paginate the results.

The problem happens that when I filter and no results are found.
Then the target goes to make an empty collection and the default message that there are no records is not displayed.
"There are no records in this view"

Example of my screen class - method query
```php
$orders = Order::query()
            ->filters()
            ->filtersApplySelection(MySelection::class)
            ->get();

return [
    'orders' => $orders->isEmpty() ? $orders : $orders->toQuery()->orderBy('orders.created_at', 'desc')->paginate(10),
]
```

And I can't, I can't paginate an empty collection.