### PR TITLE
Fixed Menu showing empty space when name, badge, and icon is null

### DIFF
--- a/resources/views/actions/menu.blade.php
+++ b/resources/views/actions/menu.blade.php
@@ -4,6 +4,7 @@
     </li>
 @endisset
 
+@if (!empty($name) || isset($icon) || isset($badge))
 <li class="nav-item {{ active($active) }}">
     <a data-turbo="{{ var_export($turbo) }}"
         {{ $attributes }}
@@ -19,6 +20,7 @@
         @endisset
     </a>
 </li>
+@endif
 
 @if(!empty($list))
     <div class="nav collapse sub-menu ps-2 {{active($active, 'show')}}"

--- a/resources/views/actions/menu.blade.php
+++ b/resources/views/actions/menu.blade.php
@@ -4,7 +4,7 @@
     </li>
 @endisset
 
-@if (!empty($name) || isset($icon) || isset($badge))
+@if (!empty($name))
 <li class="nav-item {{ active($active) }}">
     <a data-turbo="{{ var_export($turbo) }}"
         {{ $attributes }}


### PR DESCRIPTION
There is an issue wherein when the Menu item has null name, icon, and badge, an empty space will still be rendered.
When you mouse hover on this empty space, the "hover animation" is still shown.

Here is an example menu that I want to do:


```
            Menu::make()
                ->title('Settings')
                ->permission([
                    'platform.settings.general',
                    'platform.settings.mail',
                ]),


            Menu::make('General')
                ->icon('settings')
                ->permission('platform.settings.general')
                ->route('platform.settings.general'),

            Menu::make('Mail')
                ->icon('envelope')
                ->permission('platform.settings.mail')
                ->route('platform.settings.mail'),
```

In the code above, I only want to display the "title" without the fuss of animations / empty spaces so that I can "group" the Mail and General menus.
I think this would be useful if you want to group together multiple Menus that have different permissions.