### PR TITLE
[Feature] Support for minlength

### DIFF
--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -25,6 +25,7 @@ use Orchid\Screen\Field;
  * @method Input max(int $value)
  * @method Input maxlength(int $value)
  * @method Input min(int $value)
+ * @method Input minlength(int $value)
  * @method Input name(string $value = null)
  * @method Input pattern($value = true)
  * @method Input placeholder(string $value = null)
@@ -82,6 +83,7 @@ class Input extends Field
         'max',
         'maxlength',
         'min',
+        'minlength',
         'name',
         'pattern',
         'placeholder',

--- a/tests/Unit/Screen/Fields/InputTest.php
+++ b/tests/Unit/Screen/Fields/InputTest.php
@@ -110,4 +110,11 @@ class InputTest extends TestFieldsUnitCase
         $this->assertStringContainsString('Lorem ipsum dolor sit amet', self::renderField($input));
         $this->assertStringNotContainsString('</label>', self::renderField($input));
     }
+
+    public function testAddMinLengthAttribute(): void
+    {
+        $input = (string) Input::make('name')->minlength(3);
+
+        $this->assertStringContainsString('minlength="3"', $input);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Add support for minimum length validation for Input fields

### Context
 I have a text field where I need to validate the minimum and maximum value.
Example:
```php
Input::make('name')
    ->type('text')
    ->help('Minimum 3 characters and maximum 14 characters.')
    ->maxlength(14)
    ->required()
    ->title(__('Name'))
```

The `maxlength` method does exist so add the `minlength` method.
