### PR TITLE
fix trait AsSource, avoid conflicts with private and protected class attributes

### DIFF
--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -20,6 +20,6 @@ trait AsSource
     {
         return Arr::get($this->toArray(), $field)
             ?? Arr::get($this->getRelations(), $field)
-            ?? $this->$field;
+            ?? $this->getAttribute($field);
     }
 }


### PR DESCRIPTION
Since trait AsSource methods runs directly from model class, accessing attributes like $this->attributeName is dangerous, because class specific properties private and protected are returned instead.