### PR TITLE
fix trait AsSource attribute collision bug

### DIFF
--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Screen;
 
-use Illuminate\Support\Arr;
 
 /**
  * Trait AsSource.

--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -17,13 +17,9 @@ trait AsSource
      */
     public function getContent(string $field)
     {
-        if($this->isRelation($field)){
-            if($this->relationLoaded($field)){
-                return $field;
-            }
+        if ($this->isRelation($field) && !$this->relationLoaded($field)) {
             return null;
         }
-        
         return $this->getAttribute($field);
     }
 }

--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -20,6 +20,6 @@ trait AsSource
     {
         return Arr::get($this->toArray(), $field)
             ?? Arr::get($this->getRelations(), $field)
-            ?? $this->$field;
+            ?? $this->getAttribute($field);
     }
 }

--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -18,8 +18,13 @@ trait AsSource
      */
     public function getContent(string $field)
     {
-        return Arr::get($this->toArray(), $field)
-            ?? Arr::get($this->getRelations(), $field)
-            ?? $this->getAttribute($field);
+        if($this->isRelation($field)){
+            if($this->relationLoaded($field)){
+                return $field;
+            }
+            return null;
+        }
+        
+        return $this->getAttribute($field);
     }
 }


### PR DESCRIPTION
trait AsSource's getContent function runs inside the model class, so can access also to private and protected attributes.

Using $this->$field will pick up class specific attributes first, also private and  protected ones.