### PR TITLE
fix contenteditable

### DIFF
--- a/resources/js/controllers/form_controller.js
+++ b/resources/js/controllers/form_controller.js
@@ -163,10 +163,6 @@ export default class extends ApplicationController {
             return true;
         }
 
-        if (event.target.closest('[contenteditable="true"]')) {
-            return true;
-        }
-
         if ((event.keyCode || event.which || event.charCode) !== 13) {
             return true;
         }


### PR DESCRIPTION
When using `content editable`, it was getting in the way of using a listener when hitting enter.