### PR TITLE
Fix attachment generator file name SHA-1

### DIFF
--- a/src/Attachment/Engines/Generator.php
+++ b/src/Attachment/Engines/Generator.php
@@ -27,6 +27,11 @@ class Generator implements Engine
     protected $mimes;
 
     /**
+     * @var string
+     */
+    protected $uniqueId;
+
+    /**
      * Generator constructor.
      *
      * @param UploadedFile $file
@@ -36,6 +41,7 @@ class Generator implements Engine
         $this->file = $file;
         $this->time = time();
         $this->mimes = new MimeTypes();
+        $this->uniqueId = uniqid('', true);
     }
 
     /**
@@ -46,7 +52,7 @@ class Generator implements Engine
      */
     public function name(): string
     {
-        return sha1($this->time.$this->file->getClientOriginalName());
+        return sha1($this->uniqueId.$this->file->getClientOriginalName());
     }
 
     /**


### PR DESCRIPTION
Fixed a possible issue where, while uploading files via the console, the time() function may return the same value, and at the same time you have two different files, but with the same name.
In this case, the Generator's method name() generates the same SHA-1 hash for two different files, overwriting existing file in the storage folder.