### PR TITLE
Fixing listener to trigger event multiple times when the field is not included in the listener to be rebuilt

### DIFF
--- a/resources/js/controllers/listener_controller.js
+++ b/resources/js/controllers/listener_controller.js
@@ -1,6 +1,7 @@
 import ApplicationController from "./application_controller";
 
 export default class extends ApplicationController {
+    listenerEvent = () => this.render();
 
     /**
      *
@@ -16,7 +17,7 @@ export default class extends ApplicationController {
         this.targets.forEach(name => {
             document.querySelectorAll(`[name="${name}"]`)
                 .forEach((field) =>
-                    field.addEventListener('change', () => this.render(), {
+                    field.addEventListener('change', this.listenerEvent, {
                         once: true
                     })
                 );


### PR DESCRIPTION
When a field is part of trigger but it doesn't get rebuilt by listener, it will keep dispatching same event over and over due to the event listener callback being an anonymous method. With this change, the callback method is changed to be a known identified method so it gets dispatched to the same element only once and would prevent unlimited http requests being made for 1 field change.

This issue is replicable by creating a listener which listens on couple of fields but in the layout of the listener, that field which are listened to are not generated and they are generated through another layout in the page.

Fixes #

Listener field triggering the change event and make same http requests many times and keeps increasing.

## Proposed Changes

The callback method of the event listener should be identified as a reference so we can reference it to prevent being applied as an anonymous function. This would then prevent same event being attached to the same element over and over and it would be added only once. 
