### PR TITLE
BugFix Trait AsSource

### DIFF
--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -18,8 +18,9 @@ trait AsSource
      */
     public function getContent(string $field)
     {
-        return Arr::get($this->toArray(), $field)
-            ?? Arr::get($this->getRelations(), $field)
-            ?? $this->$field;
+        if ($this->isRelation($field) && !$this->relationLoaded($field)) {
+            return null;
+        }
+        return $this->getAttribute($field);
     }
 }


### PR DESCRIPTION
The trait is part of the model class, so can access also to private and protected members.

For example if we use this trait on a model with a nullable database field called "visible" 

Arr::get($this->toArray(), $field) ---> is null
Arr::get($this->getRelations(), $field) ---> is null
$this->$field ---> refear to "protected $visible = []"

with this commit the problem is solved, and anso bring a performance improvement:
->toArray() force the execution of all casts and accessors, but only one filed is requested.

Fixes #

## Proposed Changes

  -
  -
  -
