### PR TITLE
corrected searchColumns grouping

### DIFF
--- a/src/Platform/Http/Controllers/RelationController.php
+++ b/src/Platform/Http/Controllers/RelationController.php
@@ -85,13 +85,14 @@ class RelationController extends Controller
             return $model->take($chunk)->pluck($append ?? $name, $key);
         }
 
-        $model = $model->where($name, 'like', '%'.$search.'%');
-
-        if ($searchColumns !== null) {
-            foreach ($searchColumns as $column) {
-                $model->orWhere($column, 'like', '%'.$search.'%');
+        $model = $model->where(function($query) use ($name, $search, $searchColumns){
+            $query->where($name, 'like', '%'.$search.'%');
+            if ($searchColumns !== null) {
+                foreach ($searchColumns as $column) {
+                    $query->orWhere($column, 'like', '%'.$search.'%');
+                }
             }
-        }
+        });
 
         return $model
             ->limit($chunk)


### PR DESCRIPTION
Fixes #2006 

## Proposed Changes
Search columns are grouped together correctly and separated from scope conditions
from
```sql
select * from `locations` where (`TG` = ? and `name` like ? or `code` like ?)
```
to
```sql
select * from `locations` where `TG` = ?  and (`name` like ? or `code` like ?)
```