### PR TITLE
Remove buildDd return type in Sight 

### DIFF
--- a/src/Screen/Sight.php
+++ b/src/Screen/Sight.php
@@ -31,7 +31,7 @@ class Sight extends Cell
      *
      * @return string|null
      */
-    public function buildDd($repository): ?string
+    public function buildDd($repository)
     {
         $value = $this->render
             ? $this->handler($repository)


### PR DESCRIPTION
## Proposed Changes

  - Make Sight `buildDd()` function have the same return type (none) as `buildDd()` in `TD` so the render function can have the same behavior.

