### PR TITLE
Better filter layout

### DIFF
--- a/resources/views/layouts/filter.blade.php
+++ b/resources/views/layouts/filter.blade.php
@@ -1,18 +1,18 @@
-@if($filters->count() > 0)
+@if ($filters->count() > 0)
     <div class="g-0 bg-white rounded mb-3">
         <div class="row align-items-center p-4" data-controller="filter">
-            @foreach($filters->where('display', true) as $filter)
-                <div class="col-sm-auto mb-3 align-self-start">
+            @foreach ($filters->where('display', true) as $filter)
+                <div class="col-sm-auto col-md mb-3 align-self-start" style="min-width: 200px;">
                     {!! $filter->render() !!}
                 </div>
             @endforeach
             <div class="col-sm-auto ms-auto text-end">
                 <div class="btn-group" role="group">
                     <button data-action="filter#clear" class="btn btn-default">
-                        <x-orchid-icon class="me-1" path="refresh"/> {{ __('Reset') }}
+                        <x-orchid-icon class="me-1" path="refresh" /> {{ __('Reset') }}
                     </button>
                     <button type="submit" form="filters" class="btn btn-default">
-                        <x-orchid-icon class="me-1" path="filter"/> {{ __('Apply') }}
+                        <x-orchid-icon class="me-1" path="filter" /> {{ __('Apply') }}
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
# Fixes
- allows filters to grow if there is space
- makes all filters (selects and inputs) the same size
- adds a minimum width of 200px to prevent tiny inputs
- does not compromise mobile
### Before
![Schermata 2022-01-03 alle 11 01 14](https://user-images.githubusercontent.com/875086/147919717-6433ec82-159a-4b16-915a-f2b78f43a250.png)
### After
![Schermata 2022-01-03 alle 11 00 58](https://user-images.githubusercontent.com/875086/147919720-997beb52-4a7c-454b-8b79-396477966b0f.png)
### Before
![Schermata 2022-01-03 alle 11 16 00](https://user-images.githubusercontent.com/875086/147919707-41e6de92-b7b1-4474-ae90-fb9e79c07331.png)
### After
![Schermata 2022-01-03 alle 11 14 39](https://user-images.githubusercontent.com/875086/147919713-b2c44333-9623-4f25-8b1c-22f7266cd1f4.png)

### Mobile is unchanged
![Schermata 2022-01-03 alle 11 20 52](https://user-images.githubusercontent.com/875086/147920033-aaeb95d1-0978-4236-bb47-ea33d7b7fe89.png)