### PR TITLE
Passing search input to scope as last parameter

### DIFF
--- a/src/Platform/Http/Controllers/RelationController.php
+++ b/src/Platform/Http/Controllers/RelationController.php
@@ -74,7 +74,7 @@ class RelationController extends Controller
     ) {
         if ($scope !== null) {
             /** @var Collection|array $model */
-            $model = $model->{$scope['name']}(...$scope['parameters']);
+            $model = $model->{$scope['name']}(...array_merge($scope['parameters'] ?? [], [$search]));
         }
 
         if (is_array($model)) {


### PR DESCRIPTION
## Proposed Changes

Pass search input string to model scope.
Passing as last argument to prevent breaking existing scopes. 

Might cause problems, if scope is using unpacking of parameters (scope($builder, ...$inputParametrs)). In this case the search will leak into $inputParameters.