### PR TITLE
Add a custom event orchid:listener:post-render

### DIFF
--- a/resources/js/controllers/listener_controller.js
+++ b/resources/js/controllers/listener_controller.js
@@ -46,7 +46,7 @@ export default class extends ApplicationController {
 
         this.asyncLoadData(params).then(() => {
             document.dispatchEvent(
-                new CustomEvent("orchid:listener:post-render", {
+                new CustomEvent("orchid:listener:after-render", {
                     detail: {
                         params: params,
                     },

--- a/resources/js/controllers/listener_controller.js
+++ b/resources/js/controllers/listener_controller.js
@@ -44,7 +44,15 @@ export default class extends ApplicationController {
                 }
             }));
 
-        this.asyncLoadData(params);
+        this.asyncLoadData(params).then(() => {
+            document.dispatchEvent(
+                new CustomEvent("orchid:listener:post-render", {
+                    detail: {
+                        params: params,
+                    },
+                })
+            );
+        });
     }
 
     /**
@@ -57,7 +65,7 @@ export default class extends ApplicationController {
             return;
         }
 
-        window.axios.post(this.data.get('async-route'), params, {
+        return window.axios.post(this.data.get('async-route'), params, {
             headers: {
                 'ORCHID-ASYNC-REFERER': window.location.href,
             },


### PR DESCRIPTION
Add a custom event triggered when listener has finished updating the elements

Fixes it is possible to run js after a lister has updated the elements, for example it's possible to rehydrate Livewire components with

```js
document.addEventListener("orchid:listener:post-render", () => {
    Livewire.start();
});
```