### PR TITLE
Screen reader classes are now visually-hidden

### DIFF
--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -146,7 +146,7 @@
                                         </div>
 
                                         <div class="media-loader spinner-border" role="status">
-                                            <span class="sr-only">{{ __('Loading...') }}</span>
+                                            <span class="visually-hidden">{{ __('Loading...') }}</span>
                                         </div>
 
                                         <div class="row media-results m-0"></div>


### PR DESCRIPTION
Renamed .sr-only and .sr-only-focusable to .visually-hidden and .visually-hidden-focusable

See https://getbootstrap.com/docs/5.1/migration/#helpers

