### PR TITLE
data-target attribute is deprecated

### DIFF
--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -21,7 +21,7 @@
                   data-form-button-text="{{ __('Loading...') }}"
             >
                 <div class="modal-header">
-                    <h4 class="modal-title text-black fw-light" data-target="modal.title">{{$title}}</h4>
+                    <h4 class="modal-title text-black fw-light" data-modal-target="title">{{$title}}</h4>
                     <button type="button" class="btn-close" title="Close" data-bs-dismiss="modal" aria-label="Close">
                     </button>
                 </div>


### PR DESCRIPTION
This notification will appear when you open the modal:
Please replace data-target="modal.title" with data-modal-target="title". The data-target attribute is deprecated and will be removed in a future version of Stimulus.
