### PR TITLE
Remove single quote in the example route

### DIFF
--- a/stubs/app/routes/platform.php
+++ b/stubs/app/routes/platform.php
@@ -112,4 +112,4 @@ Route::screen('example-editors', ExampleTextEditorsScreen::class)->name('platfor
 Route::screen('example-cards', ExampleCardsScreen::class)->name('platform.example.cards');
 Route::screen('example-advanced', ExampleFieldsAdvancedScreen::class)->name('platform.example.advanced');
 
-//Route::screen('idea', 'Idea::class','platform.screens.idea');
+//Route::screen('idea', Idea::class, 'platform.screens.idea');


### PR DESCRIPTION
When a class is passed using ::class it doesn't require the class name to be passed as a string. Passing it as a string generate an error

Fixes #

## Proposed Changes

  -
  -
  -
