### PR TITLE
Feature/quill base64

### DIFF
--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -32,7 +32,8 @@ export default class extends ApplicationController {
         this.editor = new quill(`#${selector}`, options);
 
         // quill editor add image handler
-        if (this.data.get('base64') === 'false') {
+        let isBase64Format = JSON.parse(this.data.get('base64'));
+        if (! isBase64Format) {
             this.editor.getModule('toolbar').addHandler('image', () => {
                 this.selectLocalImage();
             });

--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -97,8 +97,6 @@ export default class extends ApplicationController {
             .map(tool => controlsGroup[tool]);
     }
 
-
-
     /**
      * Step1. select local image
      *

--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -32,9 +32,11 @@ export default class extends ApplicationController {
         this.editor = new quill(`#${selector}`, options);
 
         // quill editor add image handler
-        this.editor.getModule('toolbar').addHandler('image', () => {
-            this.selectLocalImage();
-        });
+        if (this.data.get('base64') === 'false') {
+            this.editor.getModule('toolbar').addHandler('image', () => {
+                this.selectLocalImage();
+            });
+        }
 
         let value = JSON.parse(this.data.get("value"))
 
@@ -94,6 +96,8 @@ export default class extends ApplicationController {
         return JSON.parse(this.data.get("toolbar"))
             .map(tool => controlsGroup[tool]);
     }
+
+
 
     /**
      * Step1. select local image

--- a/resources/views/fields/quill.blade.php
+++ b/resources/views/fields/quill.blade.php
@@ -1,7 +1,7 @@
 @component($typeForm, get_defined_vars())
     <div data-controller="quill"
          data-quill-toolbar='@json($toolbar)'
-         data-quill-base64="{{$base64}}"
+         data-quill-base64='@json($base64)'
          data-quill-value='@json($value)'
          data-theme="{{$theme ?? 'inlite'}}"
     >

--- a/resources/views/fields/quill.blade.php
+++ b/resources/views/fields/quill.blade.php
@@ -1,6 +1,7 @@
 @component($typeForm, get_defined_vars())
     <div data-controller="quill"
          data-quill-toolbar='@json($toolbar)'
+         data-quill-base64="{{$base64}}"
          data-quill-value='@json($value)'
          data-theme="{{$theme ?? 'inlite'}}"
     >

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -28,6 +28,7 @@ use Orchid\Screen\Field;
  * @method Quill title(string $value = null)
  * @method Quill popover(string $value = null)
  * @method Quill toolbar(array $options)
+ * @method Quill base64(bool $value = true)
  */
 class Quill extends Field
 {
@@ -45,6 +46,7 @@ class Quill extends Field
         'value'   => null,
         'toolbar' => ['text', 'color', 'quote', 'header', 'list', 'format', 'media'],
         'height'  => '300px',
+        'base64'  => 'false',
     ];
 
     /**

--- a/src/Screen/Fields/Quill.php
+++ b/src/Screen/Fields/Quill.php
@@ -46,7 +46,7 @@ class Quill extends Field
         'value'   => null,
         'toolbar' => ['text', 'color', 'quote', 'header', 'list', 'format', 'media'],
         'height'  => '300px',
-        'base64'  => 'false',
+        'base64'  => false,
     ];
 
     /**


### PR DESCRIPTION
Доброго времени суток!

Добавил возможность вернуть базовый функционал Quill сохранения изображений в base64 формате.

Для того чтобы всем не менять свои настройки для поля Quill в Layouts сделал от обратного:

- стандартное поведение без опции ->base64() для поля Quill - грузит картинки в локальное хранилище
- с опцией ->base64() для поля Quill - конвертирует картинку в base64 формат и сохраняет в тексте

Буду рад если примите) нам очень полезная вещь