### PR TITLE
Fix hasOwnProperty dot path

### DIFF
--- a/resources/js/controllers/upload_controller.js
+++ b/resources/js/controllers/upload_controller.js
@@ -264,7 +264,7 @@ export default class extends ApplicationController {
                 });
 
                 this.on('removedfile', file => {
-                    if (file.hasOwnProperty('data.id')) {
+                    if (file.hasOwnProperty('data') && file.data.hasOwnProperty('id')) {
                         $(dropname).find(`.files-${file.data.id}`).remove();
                         !isMediaLibrary && axios
                             .delete(urlDelete + file.data.id, {


### PR DESCRIPTION
Fixes `hasOwnProperty`

`hasOwnProperty` does not check for the specified property in the object's prototype chain.