### PR TITLE
Modified guard config for multi login.

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -67,6 +67,7 @@ return [
     */
 
     'guard' => config('auth.defaults.guard', 'web'),
+	'default_guard' => config('auth.defaults.guard', 'web'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Access/UserSwitch.php
+++ b/src/Access/UserSwitch.php
@@ -22,7 +22,7 @@ class UserSwitch
             session()->put(self::SESSION_NAME, self::getAuth()->id());
         }
 
-        self::getAuth()->loginUsingId($user->getKey());
+		Auth::guard(config('platform.default_guard', 'web'))->loginUsingId($user->getKey());
     }
 
     /**

--- a/src/Platform/Commands/AdminCommand.php
+++ b/src/Platform/Commands/AdminCommand.php
@@ -22,9 +22,9 @@ class AdminCommand extends Command
     /**
      * @var string
      */
-    protected $signature = 'orchid:admin {name?} {email?} {password?} {--id=}';
-
-    /**
+    protected $signature = 'orchid:admin {name?} {email?} {password?} {--id=} {--model=}';
+	
+	/**
      * The console command description.
      *
      * @var string
@@ -48,10 +48,14 @@ class AdminCommand extends Command
             $this->error($e->getMessage());
         }
     }
+	
+	private function userModel() {
+		return $this->option('model') ?? User::class;
+	}
 
     protected function createNewUser(): void
     {
-        Dashboard::modelClass(User::class)
+        Dashboard::modelClass($this->userModel())
             ->createAdmin(
                 $this->argument('name') ?? $this->ask('What is your name?', 'admin'),
                 $this->argument('email') ?? $this->ask('What is your email?', 'admin@admin.com'),
@@ -66,7 +70,7 @@ class AdminCommand extends Command
      */
     protected function updateUserPermissions(string $id): void
     {
-        Dashboard::modelClass(User::class)
+        Dashboard::modelClass($this->userModel())
             ->findOrFail($id)
             ->forceFill([
                 'permissions' => Dashboard::getAllowAllPermission(),

--- a/src/Platform/Http/Controllers/LoginController.php
+++ b/src/Platform/Http/Controllers/LoginController.php
@@ -43,7 +43,7 @@ class LoginController extends Controller
     {
         $this->guard = $auth->guard(config('platform.guard'));
 
-        $this->middleware('guest', [
+        $this->middleware('guest:' . config('platform.guard'), [
             'except' => [
                 'logout',
                 'switchLogout',


### PR DESCRIPTION
## Proposed Changes

When created a custom user class for an administrator to perform multi login, there was a problem that it conflicted with the guest middleware of the default at login.
Fixed to be able to use the proper guard.