### PR TITLE
updatin "update password validation rule" and changing "unique validation" for users by Email

### DIFF
--- a/stubs/app/Orchid/Screens/User/UserListScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserListScreen.php
@@ -114,7 +114,7 @@ class UserListScreen extends Screen
         $request->validate([
             'user.email' => [
                 'required',
-                Rule::unique(User::class, 'slug')->ignore($user),
+                Rule::unique(User::class, 'email')->ignore($user),
             ],
         ]);
 

--- a/stubs/app/Orchid/Screens/User/UserProfileScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserProfileScreen.php
@@ -116,8 +116,9 @@ class UserProfileScreen extends Screen
      */
     public function changePassword(Request $request): void
     {
+        $guard = config('platform.guard' , 'web');
         $request->validate([
-            'old_password' => 'required|password:web',
+            'old_password' => 'required|current_password:'.$guard,
             'password'     => 'required|confirmed',
         ]);
 


### PR DESCRIPTION
Fixes #2163

## Proposed Changes

### Email unique validation issue in Orchid\Screens\User\UserListScreen.php @saveUser()
  - change the saveUser() method validation unique rule to find by email instead of slug
  ```PHP
        $request->validate([
            'user.email' => [
                'required',
                // Rule::unique(User::class, 'slug')->ignore($user),
                Rule::unique(User::class, 'email')->ignore($user),
            ],
        ]);
  ```
  ### validationPassword does not exist (laravel 9 upgrade) in Orchid\Screens\User\UserProfileScreen.php @save()
  - change `password` rule to `current_password` rule to match laravel 9  [new rule](https://laravel.com/docs/9.x/validation#rule-current-password)
  - make guard selection dynamic depending on the config in the current_password rule
  ```PHP
        $guard = config('platform.guard' , 'web');
        $request->validate([
            'old_password' => 'required|current_password:'.$guard,
            'password'     => 'required|confirmed',
        ]);
  ```
  
