### PR TITLE
Custom storage path feature

### DIFF
--- a/src/Attachment/Engines/Generator.php
+++ b/src/Attachment/Engines/Generator.php
@@ -32,6 +32,11 @@ class Generator implements Engine
     protected $uniqueId;
 
     /**
+     * @var string
+     */
+    protected $path;
+
+    /**
      * Generator constructor.
      *
      * @param UploadedFile $file
@@ -72,7 +77,18 @@ class Generator implements Engine
      */
     public function path(): string
     {
-        return date('Y/m/d', $this->time());
+        return $this->path ?? date('Y/m/d', $this->time());
+    }
+    
+    /**
+     * Set a custom path
+     *
+     * @return Generator
+     */
+    public function setPath(string $path)
+    {
+        $this->path = $path;
+        return $this;
     }
 
     /**

--- a/src/Attachment/Engines/Generator.php
+++ b/src/Attachment/Engines/Generator.php
@@ -32,7 +32,7 @@ class Generator implements Engine
     protected $uniqueId;
 
     /**
-     * @var string
+     * @var ?string
      */
     protected $path;
 
@@ -44,6 +44,7 @@ class Generator implements Engine
     public function __construct(UploadedFile $file)
     {
         $this->file = $file;
+        $this->path = null;
         $this->time = time();
         $this->mimes = new MimeTypes();
         $this->uniqueId = uniqid('', true);
@@ -85,7 +86,7 @@ class Generator implements Engine
      *
      * @return Generator
      */
-    public function setPath(string $path)
+    public function setPath(?string $path = null)
     {
         $this->path = $path;
         return $this;

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -135,4 +135,16 @@ class File
 
         return $attachment;
     }
+
+    /**
+     * set a custom Path
+     * @return File
+     */
+
+    public function path(String $path) {
+        $this->engine->setPath($path);
+        return $this;
+    }
+
+    
 }

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -141,7 +141,7 @@ class File
      * @return File
      */
 
-    public function path(String $path) {
+    public function path(?string $path = null) {
         $this->engine->setPath($path);
         return $this;
     }

--- a/tests/Unit/AttachmentTest.php
+++ b/tests/Unit/AttachmentTest.php
@@ -24,10 +24,17 @@ class AttachmentTest extends TestUnitCase
      */
     protected $disk;
 
+    /**
+     * @var string
+     */
+    protected $path;
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->disk = 'public';
+        $this->path = '/test';
+
     }
 
     public function testAttachmentFile(): void
@@ -74,6 +81,32 @@ class AttachmentTest extends TestUnitCase
         $this->assertStringContainsString($path, $upload->physicalPath());
         $this->assertStringContainsString('/storage/'.$path, $upload->url());
     }
+
+    public function testAttachmentCustomPath(): void
+    {
+
+        $file = UploadedFile::fake()->create('document.xml', 200);
+        $attachment = new File($file, $this->disk);
+
+        /** @var Attachment $upload */
+        $upload = $attachment->path($this->path)->load();
+
+        $this->assertEquals([
+            'size' => $file->getSize(),
+            'name' => $file->name,
+        ], [
+            'size' => $upload->size,
+            'name' => $upload->original_name,
+        ]);
+
+        $this->assertTrue(Storage::disk($this->disk)->exists($upload->physicalPath()));
+
+        $path = $this->path . "/" . $upload->name.'.xml';
+
+        $this->assertStringContainsString($path, $upload->physicalPath());
+        $this->assertStringContainsString($path, $upload->url());
+    }
+
 
     public function testAttachmentImage(): void
     {


### PR DESCRIPTION
Fixes #2166

this is a clean version of this [pull request](https://github.com/orchidsoftware/platform/pull/2167)


## Feature
add the ability to the user to choose a different path without extending the generator, benefits : 

- the path can be dynamic 
- you don't have to set only one generator
- backward compatible ( no existing method changes )

## Changes

add `$path` param to and `Generator`  null as default value , null will keep it the default way Y/m/d
add `path(?string $path)` method to `File`
adding `public function testAttachmentCustomPath(): void` test

#### in Generator
```PHP
 return $this->path ?? date('Y/m/d', $this->time());
```

#### in File
```PHP
public function path(?string $path = null) {
        $this->engine->setPath($path);
        return $this;
    }
```
#### usage 

```PHP
$upload = $attachment->path($this->path)->load();
```




  

