### PR TITLE
Add role Fixed : UserEditScreen fixes #2235

### DIFF
--- a/stubs/app/Orchid/Screens/User/UserEditScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserEditScreen.php
@@ -184,6 +184,9 @@ class UserEditScreen extends Screen
             $userData['password'] = Hash::make($userData['password']);
         }
 
+        // remove roles array from userData to avoid the fill
+        unset($userData["roles"]);
+
         $user
             ->fill($userData)
             ->fill([


### PR DESCRIPTION
Fixes #2235

## Issues

when adding roles to a user, the roles array and all other fields are added to the `$userData`  array at the `save()`  method under `UserEditScreen.php` ,
```
$userData = $request->get('user');
```
then the fill method fills the user as if roles is a field in the `users` table and that's what causes these issues, 

instead of that roles should be attached after the fill because they unlike permissions a relationship
```
$user->replaceRoles($request->input('user.roles'));
```

## Proposed Changes

  - removing "roles" key from userData array before filling the user model .

```PHP
       // remove roles array from userData to avoid the fill
       
        unset($userData["roles"]);

        $user
            ->fill($userData)
            ->fill([
                'permissions' => $permissions,
            ])
            ->save(); 
```
