### PR TITLE
Fix upload description target

### DIFF
--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -80,7 +80,7 @@
                             <div class="form-group">
                                 <label>{{ __('Description') }}</label>
                                 <textarea class="form-control no-resize"
-                                          data-upload-target="upload.description"
+                                          data-upload-target="description"
                                           placeholder="{{ __('Description') }}"
                                           maxlength="255"
                                           rows="3"></textarea>


### PR DESCRIPTION
Fixes #

Change data-upload-target="upload.description" into data-upload-target="description" to follow with commit #2228 
