### PR TITLE
Fixed filling in a password when creating a user

### DIFF
--- a/stubs/app/Orchid/Screens/User/UserEditScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserEditScreen.php
@@ -180,7 +180,7 @@ class UserEditScreen extends Screen
 
         $userData = $request->get('user');
 
-        $user->when($user->exists && ! empty($userData['password']), function (Builder $builder) use ($userData) {
+        $user->when(! empty($userData['password']), function (Builder $builder) use ($userData) {
             $builder->getModel()->password = Hash::make($userData['password']);
         });
 


### PR DESCRIPTION
## Proposed Changes

  - Fixed filling in a password when creating a user

At the moment, when we try to create a user, we get error - "Field 'password' doesn't have a default value (SQL: insert into `users`..."

so the password is not filled in here

https://github.com/orchidsoftware/platform/blob/16ea2e13ffab14157fdbd0ab1c679146901073bf/stubs/app/Orchid/Screens/User/UserEditScreen.php#L188

or here 

https://github.com/orchidsoftware/platform/blob/16ea2e13ffab14157fdbd0ab1c679146901073bf/stubs/app/Orchid/Screens/User/UserEditScreen.php#L183-L185
