### PR TITLE
Add margin to items in command bar

### DIFF
--- a/resources/views/layouts/block.blade.php
+++ b/resources/views/layouts/block.blade.php
@@ -21,7 +21,9 @@
         @empty(!$commandBar)
             <div class="bg-light px-4 py-3 d-flex justify-content-end rounded-bottom">
                 @foreach($commandBar as $command)
-                    {!! $command !!}
+                    <div class="ms-2">
+                        {!! $command !!}
+                    </div>
                 @endforeach
             </div>
         @endempty


### PR DESCRIPTION
## Proposed Changes

  - Add start margin to items in command bar

Before:

 
![Screenshot from 2022-06-09 00-36-57](https://user-images.githubusercontent.com/22416775/172766420-ffc06daf-40ca-40c6-a266-a93528529e29.png)


After:

![Screenshot from 2022-06-09 00-36-27](https://user-images.githubusercontent.com/22416775/172766374-fed28920-afb5-400e-a2c9-eea5792b2746.png)

