### PR TITLE
Configurable UserPresenter classname

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | UserPresenter classname
+    |--------------------------------------------------------------------------
+    |
+    | This value is the classname of UserPresenter inside your app root namespace.
+    | You should change this value to your own classname if you have changed app
+    | root namespace via `php artisan app:name` command.
+    |
+    */
+
+    'user_presenter_class' => 'App\Orchid\Presenters\UserPresenter',
+
+    /*
+    |--------------------------------------------------------------------------
     | Sub-Domain Routing
     |--------------------------------------------------------------------------
     |

--- a/src/Platform/Models/User.php
+++ b/src/Platform/Models/User.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Models;
 
-use App\Orchid\Presenters\UserPresenter;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -111,6 +110,11 @@ class User extends Authenticatable implements UserInterface
      */
     public function presenter()
     {
-        return new UserPresenter($this);
+        $userPresenterClass = config('platform.user_presenter_class', 'App\Orchid\Presenters\UserPresenter');
+        if (!class_exists($userPresenterClass)) {
+            throw new \Exception('UserPresenter class does not exist. Check config platform.user_presenter_class.');
+        }
+
+        return new $userPresenterClass($this);
     }
 }


### PR DESCRIPTION
Fixes #2274

## Proposed Changes

This PR implements [**Option 3**](https://github.com/orchidsoftware/platform/issues/2274#:~:text=%233%3A-,Add%20a%20new%20config,-entry%20to%20point) from suggested changes in the linked issue.
1. Adds a new config entry `user_presenter_class` (defaults to `App\Orchid\Presenters\UserPresenter`)
2. Inside `Orchid\Platform\Models\User::presenter()`, check if above classname exists.
   - If not found, throw an exception `UserPresenter class does not exist. Check config platform.user_presenter_class.`.
   - If found, creates a new instance.
   
My PR might not meet your coding standards and principles. I even't didn't write testcases for this. Please comment on the PR thread your opinions.

Thanks. :hugs: 