### PR TITLE
replace diffAssoc with diff so the method is removed when there are parameters in front of it

### DIFF
--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -216,7 +216,7 @@ abstract class Screen extends Controller
 
         $prepare = collect($parameters)
             ->merge($request->query())
-            ->diffAssoc($method)
+            ->diff($method)
             ->all();
 
         return $this->callMethod($method, $prepare) ?? back();


### PR DESCRIPTION
Fixes #2216 