### PR TITLE
Allow to set NULL value for `Select` and `Relation` fields when cleared

### DIFF
--- a/resources/views/fields/relation.blade.php
+++ b/resources/views/fields/relation.blade.php
@@ -11,9 +11,12 @@
          data-relation-append="{{ $relationAppend }}"
          data-relation-chunk="{{ $chunk }}"
          data-relation-route="{{ route('platform.systems.relation') }}"
-         data-relation-message-notfound="{{ __('No results found') }}"
-         data-relation-message-add="{{ __('Add') }}"
     >
+
+		@if ($nullable)
+			<input type="hidden" name="{{ isset($attributes['multiple']) ? Str::substr($attributes['name'], 0, -2) : $attributes['name'] }}" value="">
+		@endif
+
         <select id="{{$id}}" data-relation-target="select" {{ $attributes }}>
         </select>
     </div>

--- a/resources/views/fields/relation.blade.php
+++ b/resources/views/fields/relation.blade.php
@@ -11,6 +11,8 @@
          data-relation-append="{{ $relationAppend }}"
          data-relation-chunk="{{ $chunk }}"
          data-relation-route="{{ route('platform.systems.relation') }}"
+         data-relation-message-notfound="{{ __('No results found') }}"
+         data-relation-message-add="{{ __('Add') }}"
     >
 
 		@if ($nullable)

--- a/resources/views/fields/select.blade.php
+++ b/resources/views/fields/select.blade.php
@@ -1,5 +1,8 @@
 @component($typeForm, get_defined_vars())
-    <div data-controller="select">
+    <div data-controller="select"
+        data-select-message-notfound="{{ __('No results found') }}"
+        data-select-message-add="{{ __('Add') }}"
+    >
 
 		@if ($nullable)
 			<input type="hidden" name="{{ isset($attributes['multiple']) ? Str::substr($attributes['name'], 0, -2) : $attributes['name'] }}" value="">

--- a/resources/views/fields/select.blade.php
+++ b/resources/views/fields/select.blade.php
@@ -1,8 +1,10 @@
 @component($typeForm, get_defined_vars())
-    <div data-controller="select"
-         data-select-message-notfound="{{ __('No results found') }}"
-         data-select-message-add="{{ __('Add') }}"
-    >
+    <div data-controller="select">
+
+		@if ($nullable)
+			<input type="hidden" name="{{ isset($attributes['multiple']) ? Str::substr($attributes['name'], 0, -2) : $attributes['name'] }}" value="">
+		@endif
+
         <select {{ $attributes }}>
             @foreach($options as $key => $option)
                 <option value="{{$key}}"

--- a/src/Screen/Fields/Relation.php
+++ b/src/Screen/Fields/Relation.php
@@ -48,6 +48,7 @@ class Relation extends Field
         'relationAppend'        => null,
         'relationSearchColumns' => null,
         'chunk'                 => 10,
+		'nullable'              => 0,
     ];
 
     /**
@@ -254,4 +255,15 @@ class Relation extends Field
     {
         return $this->set('chunk', $value);
     }
+
+    /**
+     * Allow nullable value to be returned
+     *
+     * @param boolean $value
+     * @return $this
+     */
+	public function nullable(bool $value = true)
+	{
+		return $this->set('nullable', $value);
+	}
 }

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -42,8 +42,9 @@ class Select extends Field implements ComplexFieldConcern
      * @var array
      */
     protected $attributes = [
-        'class'   => 'form-control',
-        'options' => [],
+        'class'    => 'form-control',
+        'options'  => [],
+		'nullable' => 0,
     ];
 
     /**
@@ -147,4 +148,15 @@ class Select extends Field implements ComplexFieldConcern
     {
         return $this->set('tags', true);
     }
+
+    /**
+     * Allow nullable value to be returned
+     *
+     * @param boolean $value
+     * @return $this
+     */
+	public function nullable(bool $value = true)
+	{
+		return $this->set('nullable', $value);
+	}
 }

--- a/src/Screen/Fields/TimeZone.php
+++ b/src/Screen/Fields/TimeZone.php
@@ -36,8 +36,9 @@ class TimeZone extends Field
      * @var array
      */
     protected $attributes = [
-        'class'   => 'form-control',
-        'options' => [],
+        'class'    => 'form-control',
+        'options'  => [],
+        'nullable' => 0,
     ];
 
     /**

--- a/tests/Unit/Screen/Fields/RelationTest.php
+++ b/tests/Unit/Screen/Fields/RelationTest.php
@@ -197,4 +197,68 @@ class RelationTest extends TestFieldsUnitCase
 
         $this->assertEquals(['email', 'id'], Crypt::decrypt($crypt));
     }
+
+    public function testNullable(): void
+    {
+        $select = Relation::make('users')
+            ->nullable()
+            ->fromModel(EmptyUserModel::class, 'name');
+
+        $view = self::renderField($select);
+
+        $this->assertStringContainsString('type="hidden" name="users"', $view);
+    }
+
+    public function testNullableSelected(): void
+    {
+        /** @var User $current */
+        $current = $this->users->random();
+
+        // With parameters
+        $select = Relation::make('users')
+            ->nullable()
+            ->value($current->id)
+            ->fromModel(EmptyUserModel::class, 'name');
+
+        $view = self::renderField($select);
+
+        $this->assertStringContainsString($current->name, $view);
+    }
+
+    public function testNotNullable(): void
+    {
+        $select = Relation::make('users')
+            ->nullable(false)
+            ->fromModel(EmptyUserModel::class, 'name');
+
+        $view = self::renderField($select);
+
+        $this->assertStringNotContainsString('type="hidden" name="users"', $view);
+    }
+
+    public function testNullableMultiple(): void
+    {
+        $select = Relation::make('users')
+            ->nullable()
+            ->multiple()
+            ->fromModel(EmptyUserModel::class, 'name');
+
+        $view = self::renderField($select);
+
+        $this->assertStringContainsString('type="hidden" name="users"', $view);
+        $this->assertStringNotContainsString('type="hidden" name="users[]"', $view);
+    }
+
+    public function testNotNullableMultiple(): void
+    {
+        // nullable() was not set, default to 0
+        $select = Relation::make('users')
+            ->multiple()
+            ->fromModel(EmptyUserModel::class, 'name');
+
+        $view = self::renderField($select);
+
+        $this->assertStringNotContainsString('type="hidden" name="users"', $view);
+        $this->assertStringNotContainsString('type="hidden" name="users[]"', $view);
+    }
 }

--- a/tests/Unit/Screen/Fields/SelectTest.php
+++ b/tests/Unit/Screen/Fields/SelectTest.php
@@ -220,4 +220,79 @@ class SelectTest extends TestFieldsUnitCase
         $this->assertStringContainsString('value="second" selected', $view);
         $this->assertStringNotContainsString('value="third" selected', $view);
     }
+
+    public function testNullable(): void
+    {
+        $select = Select::make('choice')
+            ->nullable()
+            ->options([
+                '1' => '1',
+                '2' => '2',
+            ]);
+
+        $view = self::minifyRenderField($select);
+
+        $this->assertStringContainsString('type="hidden" name="choice"', $view);
+    }
+
+    public function testNullableSelected(): void
+    {
+        $select = Select::make('choice')
+            ->nullable()
+            ->value(1)
+            ->options([
+                '1' => '1',
+                '2' => '2',
+            ]);
+
+        $view = self::minifyRenderField($select);
+
+        $this->assertStringContainsString('value="1" selected', $view);
+    }
+
+    public function testNotNullable(): void
+    {
+        $select = Select::make('choice')
+            ->nullable(false)
+            ->options([
+                '1' => '1',
+                '2' => '2',
+            ]);
+
+        $view = self::minifyRenderField($select);
+
+        $this->assertStringNotContainsString('type="hidden" name="choice"', $view);
+    }
+
+    public function testNullableMultiple(): void
+    {
+        $select = Select::make('choice')
+            ->nullable()
+            ->multiple()
+            ->options([
+                '1' => '1',
+                '2' => '2',
+            ]);
+
+        $view = self::minifyRenderField($select);
+
+        $this->assertStringContainsString('type="hidden" name="choice"', $view);
+        $this->assertStringNotContainsString('type="hidden" name="choice[]"', $view);
+    }
+
+    public function testNotNullableMultiple(): void
+    {
+        // nullable() was not set, default to 0
+        $select = Select::make('choice')
+            ->multiple()
+            ->options([
+                '1' => '1',
+                '2' => '2',
+            ]);
+
+        $view = self::minifyRenderField($select);
+
+        $this->assertStringNotContainsString('type="hidden" name="choice"', $view);
+        $this->assertStringNotContainsString('type="hidden" name="choice[]"', $view);
+    }
 }


### PR DESCRIPTION
Fixes [#2217](https://github.com/orchidsoftware/platform/issues/2217)

## Proposed Changes

- Added `nullable()` method for `Select` and `Relation` fields allowed to save nullable value if no value selected

## Example

I have `Project` model. Every Project may have `Branch`. But it is nullable column

```php
// migration
$table->foreignId('branch_id')
    ->nullable()
    ->constrained()
    ->onDelete('set null');

// relation
public function branch()
{
    return $this->belongsTo(Branch::class)->withDefault([
        'name' => 'Иное',
    ]);
}

// screen
Relation::make('project.branch_id')
    ->fromModel(Branch::class, 'name')
    ->chunk(50)
    ->title('Отрасль'),
```

Currently I cannot set null to a `branch_id` if value was set before (if I clear select, hit "Update" button, it is will not affect database value as request does not contain `branch_id` key)

Currently if no value was selected

```php
dd($request->input('project')); // [];
```

If I select some

```php
dd($request->input('project')); // ['branch_id' => 2];
```

In order to set `null` I had to check request if key present or not. 

## What Does This PR Does

With this PR user may select desirable behaviour

```php
Select::make('choices')
    ->nullable() // tell select to store null value in request
    ->options([
        'one' => 'One',
        'two' => 'Two',
    ]);
```

If no value was selected

```php
dd($request->input()); // ['choices' => null];
```

By default nullable option is set to `false`, so if no `nullable()` method was set, `$request` will not contain key, if nothing was select (as it is now)

```php
Select::make('choices')
    ->options([
        'one' => 'One',
        'two' => 'Two',
    ]);

dd($request->input()); // []; when nothing was selected
```

It is also correct for multiple options

```php
Select::make('choices')
    ->nullable(true) // may pass boolean value
    ->multiple()
    ->options([
        'one' => 'One',
        'two' => 'Two',
        'three' => 'Three',
    ]);
```

No key was selected

```php
dd($request->input()); // ['choices' => null];
```

Selected some

```php
dd($request->input()); // ['choices' => ['one', 'two']];
```

All above is valid for `Relation` field as well

```php
Relation::make('foreign_id')
    ->nullable()
    ->fromModel(User::class, 'name');

dd($request->input()); // ['foreign_id' => null]; or ['foreign_id' => 1] if selected
```

## Extra Information

- `TimeZone` field was not changed although `nullable` attribute was added to prevent errors
- Maybe store `null` value with `multiple()` value is not a good idea at all (as we'll get non-iterable value. Of course it may be checked during validation, but it is also may be checked now, so no major difference). Also some refactoring may be needed as I [strip](https://github.com/czernika/platform/blob/feat.select/resources/views/fields/select.blade.php#L5) `[]` from hidden input name, which was previously added and required for select attributes
- May require more tests
