### PR TITLE
Fix for Nested sub menus in the Sidebar.

### DIFF
--- a/resources/views/actions/menu.blade.php
+++ b/resources/views/actions/menu.blade.php
@@ -25,7 +25,11 @@
 @if(!empty($list))
     <div class="nav collapse sub-menu ps-2 {{active($active, 'show')}}"
          id="menu-{{$slug}}"
-         data-bs-parent="#headerMenuCollapse">
+         @isset($parent)
+            data-bs-parent="#menu-{{$parent}}">
+         @else
+            data-bs-parent="#headerMenuCollapse">
+         @endisset
         @foreach($list as $item)
             {!!  $item->build($source) !!}
         @endforeach

--- a/src/Screen/Actions/Menu.php
+++ b/src/Screen/Actions/Menu.php
@@ -51,6 +51,7 @@ class Menu extends Link
         'divider'        => false,
         'active'         => null,
         'data-bs-toggle' => null,
+        'parent'         => null,
         'sort'           => 0,
         'slug'           => null,
     ];
@@ -231,5 +232,15 @@ class Menu extends Link
     public function slug(string $slug): self
     {
         return $this->set('slug', $slug);
+    }
+
+    /**
+     * @param string $parent
+     *
+     * @return $this
+     */
+    public function parent(string $parent): self
+    {
+        return $this->set('parent', $parent);
     }
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Added a parent attribute & a setter for the same attribute in the Menu class to store the parent of the sub menu.
  - Added a isset check for $parent in the menu.blade file and instead of setting "data-bs-target" to "headerMenuCollapse" as default, set it to $parent if it is not null.
