### PR TITLE
Change default `platform.php` file to prevent log warnings with PHP 8.1

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -128,8 +128,8 @@ return [
     */
 
     'template' => [
-        'header' => null,
-        'footer' => null,
+        'header' => '',
+        'footer' => '',
     ],
 
     /*


### PR DESCRIPTION
When using Laravel Sail with PHP 8.1 I've noticed my `laravel.log` has a lot of warnings. Even on fresh Laravel-Orchid installation. Happens only with PHP 8.1

It repeated this lines again and again
```
laravel.EMERGENCY: Unable to create configured logger. Using emergency logger. {"exception":"[object] (InvalidArgumentException(code: 0): Log [deprecations] is not defined. at /var/www/html/vendor/laravel/framework/src/Illuminate/Log/LogManager.php:207)
laravel.WARNING: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/vendor/laravel/framework/src/Illuminate/View/FileViewFinder.php on line 75  
 ```
 
 So when I start digging, I found it comes from config `platform.php` file
 ```php
 'template' => [
        'header' => null,
        'footer' => null,

 ],
 ```
 
 and within `dashboard.blade.php` resource file 
 
 ```
 @includeFirst([config('platform.template.header'), 'platform::header'])
 ```
 
 it passes null value as first argument. If you change `null` into `''` (empty string), errors gone and default dashboard header is being included.

## Proposed Changes

  - Change default `platform.php` configuration file `template` keys from null to '' to prevent such behaviour with PHP 8.1
