### PR TITLE
add localization for the notice displayed before impersonating a user

### DIFF
--- a/stubs/app/Orchid/Screens/User/UserEditScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserEditScreen.php
@@ -85,7 +85,7 @@ class UserEditScreen extends Screen
         return [
             Button::make(__('Impersonate user'))
                 ->icon('login')
-                ->confirm('You can revert to your original state by logging out.')
+                ->confirm(__('You can revert to your original state by logging out.'))
                 ->method('loginAs')
                 ->canSee($this->user->exists && \request()->user()->id !== $this->user->id),
 


### PR DESCRIPTION
The string 'You can revert to your original state by logging out.' in the UserEditScreen stub isn't localized yet. This pull request modifies the hard coded string to a localized one.