### PR TITLE
Update ScreenDependencyResolver.php

### DIFF
--- a/src/Screen/Resolvers/ScreenDependencyResolver.php
+++ b/src/Screen/Resolvers/ScreenDependencyResolver.php
@@ -68,7 +68,7 @@ class ScreenDependencyResolver
             return $instance;
         }
 
-        $model = $instance->resolveRouteBinding($value);
+        $model = is_a($value, $class) ? $value : $instance->resolveRouteBinding($value);
 
         throw_if(
             $model === null && ! $parameter->isDefaultValueAvailable(),


### PR DESCRIPTION
Resolved 404 error issue that happens when you use laravel `explicit binding`: https://laravel.com/docs/9.x/routing#explicit-binding and use `Implicit Binding` on the `query` function of an orchid screen at the same time