### PR TITLE
Add access denied error code customization

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -239,7 +239,7 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Access Denied HTTP Verb
+    | Access Denied HTTP error code
     |--------------------------------------------------------------------------
     |
     | Orchid will return error page if user does not have access to given screen.

--- a/config/platform.php
+++ b/config/platform.php
@@ -237,4 +237,16 @@ return [
 
     'provider' => \App\Orchid\PlatformProvider::class,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Access Denied HTTP Verb
+    |--------------------------------------------------------------------------
+    |
+    | Orchid will return error page if user does not have access to given screen.
+    | You can change the error code (e.g. to 404) if you don't want to expose platform routes to outsiders.
+    |
+     */
+
+    'status' => 403,
+
 ];

--- a/src/Platform/Http/Controllers/Controller.php
+++ b/src/Platform/Http/Controllers/Controller.php
@@ -26,9 +26,9 @@ class Controller extends BaseController
             if (Auth::user()->hasAccess($permission)) {
                 return $next($request);
             }
-            abort(403);
+            abort(config('platform.status', 403));
         });
 
-        abort_if(Auth::user() !== null && ! Auth::user()->hasAccess($permission), 403);
+        abort_if(Auth::user() !== null && ! Auth::user()->hasAccess($permission), config('platform.status', 403));
     }
 }

--- a/src/Platform/Http/Middleware/Access.php
+++ b/src/Platform/Http/Middleware/Access.php
@@ -56,7 +56,7 @@ class Access
 
         // The current user is already signed in.
         // It means that he does not have the privileges to view.
-        abort(403);
+        abort(config('platform.status', 403));
     }
 
     /**

--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -206,7 +206,7 @@ abstract class Screen extends Controller
     {
         Dashboard::setCurrentScreen($this);
 
-        abort_unless($this->checkAccess($request), 403);
+        abort_unless($this->checkAccess($request), config('platform.status', 403));
 
         if ($request->isMethod('GET')) {
             return $this->redirectOnGetMethodCallOrShowView($parameters);

--- a/tests/Feature/Platform/AccessTest.php
+++ b/tests/Feature/Platform/AccessTest.php
@@ -26,7 +26,7 @@ class AccessTest extends TestFeatureCase
             ->assertStatus(200);
 
         $this->get('/_test/accessMiddlewarePrivateData')
-            ->assertStatus(403);
+            ->assertStatus(config('platform.status', 403));
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Some applications require not to expose its routes with `403` error code.
If access denied code is e.g. `404` it becomes harder to extract links from application.


