### PR TITLE
Added unaccessed method to Screen

### DIFF
--- a/src/Platform/Http/Middleware/Access.php
+++ b/src/Platform/Http/Middleware/Access.php
@@ -13,6 +13,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
+use Orchid\Screen\Screen;
 
 /**
  * Class Access.
@@ -56,7 +57,7 @@ class Access
 
         // The current user is already signed in.
         // It means that he does not have the privileges to view.
-        abort(403);
+        abort(Screen::unaccessed());
     }
 
     /**

--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -6,8 +6,10 @@ namespace Orchid\Screen;
 
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Route;
@@ -195,6 +197,16 @@ abstract class Screen extends Controller
     }
 
     /**
+     *  Response or HTTP code that will be returned if user does not have access to screen.
+     *
+     * @return int | Response
+     */
+    public static function unaccessed(){
+        return 403;
+    }
+
+
+    /**
      * @param \Illuminate\Http\Request $request
      * @param mixed                    ...$parameters
      *
@@ -206,7 +218,7 @@ abstract class Screen extends Controller
     {
         Dashboard::setCurrentScreen($this);
 
-        abort_unless($this->checkAccess($request), 403);
+        abort_unless($this->checkAccess($request), static::unaccessed());
 
         if ($request->isMethod('GET')) {
             return $this->redirectOnGetMethodCallOrShowView($parameters);


### PR DESCRIPTION
Developer can change default 403 error response by overriding `Screen::unaccessed` method.
Some project may need to hide screens from admins with lower access lever or hide the very existance of admin panel. That can be achieved by making `unaccessed` return 404 code.

`unaccessed` may also return \Illuminate\Http\Response instance so that user can be redirected to route, any view can be shown etc.
