### PR TITLE
Added attribute `inputmode` for input tag

### DIFF
--- a/resources/views/auth/lockme.blade.php
+++ b/resources/views/auth/lockme.blade.php
@@ -20,6 +20,7 @@
 
     {!!  \Orchid\Screen\Fields\Password::make('password')
             ->required()
+            ->autocomplete('current-password')
             ->tabindex(1)
             ->autofocus()
             ->placeholder(__('Enter your password'))

--- a/resources/views/auth/signin.blade.php
+++ b/resources/views/auth/signin.blade.php
@@ -9,6 +9,8 @@
         ->required()
         ->tabindex(1)
         ->autofocus()
+        ->autocomplete('email')
+        ->inputmode('email')
         ->placeholder(__('Enter your email'))
     !!}
 </div>
@@ -20,6 +22,7 @@
 
     {!!  \Orchid\Screen\Fields\Password::make('password')
         ->required()
+        ->autocomplete('current-password')
         ->tabindex(2)
         ->placeholder(__('Enter your password'))
     !!}

--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -41,6 +41,7 @@ use Orchid\Screen\Field;
  * @method Input popover(string $value = null)
  * @method Input mask($value = true)
  * @method Input title(string $value = null)
+ * @method Input inputmode(string $value = null)
  */
 class Input extends Field
 {
@@ -96,6 +97,7 @@ class Input extends Field
         'type',
         'value',
         'mask',
+        'inputmode',
     ];
 
     /**


### PR DESCRIPTION
## Proposed Changes

This PR aims to allow the use of the inline `inputmode` attribute which enables the keyboard to type to be changed on mobile devices.

More details can be found here:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode
- https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/
- https://www.twilio.com/blog/html-attributes-two-factor-authentication-autocomplete

## Usage

Example usage:

```php
use Orchid\Screen\Fields\Input;

Input::make('token')
    ->type('text')
    ->inputmode('numeric')
    ->pattern("[0-9]*")
```

![image](https://user-images.githubusercontent.com/5102591/193464165-b2d86b18-9d52-4e70-813a-1297c0e2c600.png)

