### PR TITLE
getOldValue return float as string

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -316,7 +316,7 @@ class Field implements Fieldable, Htmlable
     {
         $value = old($this->getOldName());
 
-        return is_numeric($value)
+        return is_numeric($value) && is_int($value + 0)
             ? $value + 0
             : $value;
     }

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -219,6 +219,6 @@ class FieldTest extends TestUnitCase
 
         request()->setLaravelSession(session());
 
-        $this->assertSame(1.1, Input::make('numeric')->getOldValue());
+        $this->assertSame("1.1", Input::make('numeric')->getOldValue());
     }
 }


### PR DESCRIPTION
A long number line doesn’t convert to scientific notation