### PR TITLE
Test for SearchScreen with query and empty result

### DIFF
--- a/tests/Feature/Platform/SearchTest.php
+++ b/tests/Feature/Platform/SearchTest.php
@@ -49,4 +49,12 @@ class SearchTest extends TestFeatureCase
             ->assertOk()
             ->assertSee($user->name);
     }
+    
+    public function testSearchPageNotFound(): void
+    {
+        $this
+            ->actingAs($this->createAdminUser())
+            ->get(route('platform.search', 'search@localhost.com',))
+            ->assertNotFound();
+    }
 }


### PR DESCRIPTION
With non-empty search query I get an error: Class name must be a valid object or a string