### PR TITLE
Fixed `ModalTest` expected validation error message

### DIFF
--- a/tests/Browser/ModalTest.php
+++ b/tests/Browser/ModalTest.php
@@ -23,8 +23,8 @@ class ModalTest extends TestBrowserCase
                 ->waitForText('Validation modal message')
                 ->type('message', 'Hello')
                 ->press('Apply')
-                ->waitForText('The message must be at least 10 characters.', 30)
-                ->assertSee('The message must be at least 10 characters.')
+                ->waitForText('The message field must be at least 10 characters.', 30)
+                ->assertSee('The message field must be at least 10 characters.')
                 ->assertInputValue('message', 'Hello')
                 ->waitForText('Validation modal message', 2500)
                 ->type('message', 'Hello World!')
@@ -49,13 +49,13 @@ class ModalTest extends TestBrowserCase
                 ->waitForText('Validation modal message')
                 ->type('message', 'Hello')
                 ->press('Apply')
-                ->waitForText('The message must be at least 10 characters.', 30)
-                ->assertSee('The message must be at least 10 characters.')
+                ->waitForText('The message field must be at least 10 characters.', 30)
+                ->assertSee('The message field must be at least 10 characters.')
                 ->assertInputValue('message', 'Hello')
                 ->waitForText('Validation modal message', 2500)
                 ->type('message', 'Hello!')
                 ->press('Apply')
-                ->waitForText('The message must be at least 10 characters.');
+                ->waitForText('The message field must be at least 10 characters.');
         });
     }
 


### PR DESCRIPTION
## Proposed Changes

  - Fixes the field validation error message expected in methods `testReopenModalForValidationFailed` and `testDoubleReopenModalForValidationFailed`.

Now message "The message must be at least 10 characters." is expected, but in reality the [template ](https://github.com/illuminate/translation/blob/d6f7bf61b3d223abf0c279ea0d8d127e8f51c095/lang/en/validation.php#L103)is "The :attribute **field** must be at least :min characters.", that is "field" is missing.



 Therefore, we are waiting for text that will never appear.
