### PR TITLE
Array to string conversion

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -224,7 +224,8 @@ class Field implements Fieldable, Htmlable
         collect($this->attributes)
             ->intersectByKeys(array_flip($this->translations))
             ->each(function ($value, $key) use ($lang) {
-                $this->set($key, __($value, [], $lang));
+                $translation = __($value, [], $lang);
+                $this->set($key, is_string($translation) ? $translation : $value);
             });
 
         return $this;


### PR DESCRIPTION
При формировании ссылки:
```
TD::make('title', 'Заголовок')
                ->filter(TD::FILTER_TEXT)
                ->render(static function(Article $article) {
                    return Link::make($article->title)
                        ->route('article.platform.edit', $article);
                }),
```
получилось так, что название статьи было задано (на скорую руку случайно), как catalog, и так случилось, что лежал файл локализации catalog.php в итоге при срабатывании кода на приведённой строке кода вернулся массив. предлагаю добавить доп. проверку, что функция перевода вернула строку и только тогда подменять name у поля Link

```
collect($this->attributes)
            ->intersectByKeys(array_flip($this->translations))
            ->each(function ($value, $key) use ($lang) {
                $translation = __($value, [], $lang);
                $this->set($key, is_string($translation) ? $translation : $value);
            });
```