### PR TITLE
Proposal: allow to retrieve impersonator user after impersonation switch

### DIFF
--- a/src/Access/Impersonation.php
+++ b/src/Access/Impersonation.php
@@ -6,6 +6,7 @@ namespace Orchid\Access;
 
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Auth\Authenticatable;
 
 class Impersonation
 {
@@ -48,5 +49,17 @@ class Impersonation
     protected static function getAuth()
     {
         return Auth::guard(config('platform.guard'));
+    }
+
+    /**
+     * @return \Illuminate\Contracts\Auth\Authenticatable|null
+     */
+    public static function impersonator(): Authenticatable|null {
+        if(self::isSwitch()) {
+            $id = session()->get(self::SESSION_NAME);
+            return self::getAuth()->getProvider()->retrieveById($id);
+        }
+
+        return null;
     }
 }

--- a/src/Access/Impersonation.php
+++ b/src/Access/Impersonation.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Orchid\Access;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\User;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Contracts\Auth\Authenticatable;
 
 class Impersonation
 {
@@ -54,9 +54,11 @@ class Impersonation
     /**
      * @return \Illuminate\Contracts\Auth\Authenticatable|null
      */
-    public static function impersonator(): Authenticatable|null {
-        if(self::isSwitch()) {
+    public static function impersonator(): Authenticatable|null
+    {
+        if (self::isSwitch()) {
             $id = session()->get(self::SESSION_NAME);
+
             return self::getAuth()->getProvider()->retrieveById($id);
         }
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -64,6 +64,25 @@ class UserTest extends TestUnitCase
         $this->assertEquals($user->id, Auth::id());
     }
 
+    public function testImpersonator(): void
+    {
+        $user = $this->createUser();
+        $userSwitch = $this->createUser();
+
+        $this->actingAs($user);
+        $this->assertEquals($user->id, Auth::id());
+
+        $this->assertEquals(null, Impersonation::impersonator());
+
+        Impersonation::loginAs($userSwitch);
+
+        $this->assertEquals($user->id, Impersonation::impersonator()->id);
+
+        Impersonation::logout();
+
+        $this->assertEquals(null, Impersonation::impersonator());
+    }
+
     public function testLoginAsLimit(): void
     {
         $user = $this->createUser([


### PR DESCRIPTION
Hi folks,
I made a small addition to Impersonation class to expose the impersonator user after the switch.

## Proposed Changes
  - Add an API to allow Impersonation class to retrieve the impersonator user.
