### PR TITLE
Fixed `ChartTest` export button

### DIFF
--- a/tests/Unit/Screen/Layouts/ChartTest.php
+++ b/tests/Unit/Screen/Layouts/ChartTest.php
@@ -18,16 +18,10 @@ class ChartTest extends TestUnitCase
              * @var string
              */
             protected $target = 'charts';
-
-            /**
-             * Determines whether to display the export button.
-             *
-             * @var bool
-             */
-            protected $export = false;
         };
 
         $html = $layout
+            ->export(false)
             ->build($this->getRepository())
             ->withErrors([])
             ->render();
@@ -46,6 +40,7 @@ class ChartTest extends TestUnitCase
         };
 
         $html = $layout
+            ->export()
             ->build($this->getRepository())
             ->withErrors([])
             ->render();


### PR DESCRIPTION
## Proposed Changes

  - Fixes check whether the export button is enabled.

The last commit https://github.com/orchidsoftware/platform/commit/936632a63bec04c4c70df34c63311f3914a39d57#diff-d541a53fe6317d98b6936370f6b096f9a28b6859b8af68f9304019a073f06947L93-R93 changed the default state, so the test `testEnabledExportButton` failed.