### PR TITLE
Load all console-based registrations in console only

### DIFF
--- a/src/Platform/Providers/ConsoleServiceProvider.php
+++ b/src/Platform/Providers/ConsoleServiceProvider.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+namespace Orchid\Platform\Providers;
+
+use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Support\ServiceProvider;
+use Orchid\Platform\Commands\AdminCommand;
+use Orchid\Platform\Commands\ChartCommand;
+use Orchid\Platform\Commands\FilterCommand;
+use Orchid\Platform\Commands\InstallCommand;
+use Orchid\Platform\Commands\ListenerCommand;
+use Orchid\Platform\Commands\PresenterCommand;
+use Orchid\Platform\Commands\PublishCommand;
+use Orchid\Platform\Commands\RowsCommand;
+use Orchid\Platform\Commands\ScreenCommand;
+use Orchid\Platform\Commands\SelectionCommand;
+use Orchid\Platform\Commands\TableCommand;
+use Orchid\Platform\Commands\TabMenuCommand;
+use Orchid\Platform\Dashboard;
+
+class ConsoleServiceProvider extends ServiceProvider
+{
+    /**
+     * The available command shortname.
+     *
+     * @var array
+     */
+    protected $commands = [
+        InstallCommand::class,
+        PublishCommand::class,
+        AdminCommand::class,
+        FilterCommand::class,
+        RowsCommand::class,
+        ScreenCommand::class,
+        TableCommand::class,
+        ChartCommand::class,
+        SelectionCommand::class,
+        ListenerCommand::class,
+        PresenterCommand::class,
+        TabMenuCommand::class,
+    ];
+
+    public function boot(): void
+    {
+        AboutCommand::add('Orchid Platform', fn() => [
+            'Version' => Dashboard::version(),
+            'Domain' => config('platform.domain'),
+            'Prefix' => config('platform.prefix'),
+            'Assets Status' => Dashboard::assetsAreCurrent() ? '<fg=green;options=bold>CURRENT</>' : '<fg=yellow;options=bold>OUTDATED</>',
+        ]);
+
+        $this->commands($this->commands);
+
+        $this
+            ->registerMigrationsPublisher()
+            ->registerTranslationsPublisher()
+            ->registerConfigPublisher()
+            ->registerOrchidPublisher()
+            ->registerViewsPublisher()
+            ->registerAssetsPublisher();
+    }
+
+    /**
+     * Register migrate.
+     *
+     * @return $this
+     */
+    protected function registerMigrationsPublisher(): self
+    {
+        $this->publishes([
+            Dashboard::path('database/migrations') => database_path('migrations'),
+        ], 'orchid-migrations');
+
+        return $this;
+    }
+
+    /**
+     * Register translations.
+     *
+     * @return $this
+     */
+    public function registerTranslationsPublisher(): self
+    {
+        $this->publishes([
+            Dashboard::path('resources/lang') => lang_path('vendor/platform'),
+        ], 'orchid-lang');
+
+        return $this;
+    }
+
+    /**
+     * Register views & Publish views.
+     *
+     * @return $this
+     */
+    public function registerViewsPublisher(): self
+    {
+        $this->publishes([
+            Dashboard::path('resources/views') => resource_path('views/vendor/platform'),
+        ], 'orchid-views');
+
+        return $this;
+    }
+
+    /**
+     * Register config.
+     *
+     * @return $this
+     */
+    protected function registerConfigPublisher(): self
+    {
+        $this->publishes([
+            Dashboard::path('config/platform.php') => config_path('platform.php'),
+        ], 'orchid-config');
+
+        return $this;
+    }
+
+    /**
+     * Register orchid.
+     *
+     * @return $this
+     */
+    protected function registerOrchidPublisher(): self
+    {
+        $this->publishes([
+            Dashboard::path('stubs/app/routes/') => base_path('routes'),
+            Dashboard::path('stubs/app/Orchid/') => app_path('Orchid'),
+        ], 'orchid-app-stubs');
+
+        return $this;
+    }
+
+
+    /**
+     * Register the asset publishing configuration.
+     *
+     * @return $this
+     */
+    protected function registerAssetsPublisher(): self
+    {
+        $this->publishes([
+            Dashboard::path('public') => public_path('vendor/orchid'),
+        ], ['orchid-assets', 'laravel-assets']);
+
+        return $this;
+    }
+}

--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Providers;
 
-use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
@@ -12,18 +11,6 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Scout\ScoutServiceProvider;
 use Orchid\Icons\IconServiceProvider;
-use Orchid\Platform\Commands\AdminCommand;
-use Orchid\Platform\Commands\ChartCommand;
-use Orchid\Platform\Commands\FilterCommand;
-use Orchid\Platform\Commands\InstallCommand;
-use Orchid\Platform\Commands\ListenerCommand;
-use Orchid\Platform\Commands\PresenterCommand;
-use Orchid\Platform\Commands\PublishCommand;
-use Orchid\Platform\Commands\RowsCommand;
-use Orchid\Platform\Commands\ScreenCommand;
-use Orchid\Platform\Commands\SelectionCommand;
-use Orchid\Platform\Commands\TableCommand;
-use Orchid\Platform\Commands\TabMenuCommand;
 use Orchid\Platform\Components\Notification;
 use Orchid\Platform\Components\Stream;
 use Orchid\Platform\Dashboard;


### PR DESCRIPTION
Solves https://github.com/orchidsoftware/platform/issues/2586

Registers all console-based commands, migrations, publishers and other things in ConsoleServiceProvider, loaded only when running in console, to avoid doing these for HTTP requests.

Allows HTTP requests to execute a little faster, especially under load/concurrency.