### PR TITLE
Filter static properties in Screen

### DIFF
--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -269,6 +269,7 @@ abstract class Screen extends Controller
         $reflections = (new \ReflectionClass($this))->getProperties(\ReflectionProperty::IS_PUBLIC);
 
         collect($reflections)
+            ->filter(fn (\ReflectionProperty $property) => !$property->isStatic())
             ->map(fn (\ReflectionProperty $property) => $property->getName())
             ->each(fn (string $key) => $this->$key = $repository->get($key, $this->$key));
     }


### PR DESCRIPTION
If a public static property is used in Screen class, the system tries to assign a value to it, which causes exception "Accessing static property $xxx as non static"