### PR TITLE
Updates translation registration

### DIFF
--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -30,7 +30,6 @@ class FoundationServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this
-            ->registerTranslations()
             ->registerViews()
             ->registerOctaneEventsListen();
     }
@@ -111,7 +110,9 @@ class FoundationServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->registerProviders();
+        $this
+            ->registerTranslations()
+            ->registerProviders();
 
         $this->app->singleton(Dashboard::class, static fn () => new Dashboard());
 


### PR DESCRIPTION
Moves calling `registerTranslations` method from `boot` method to `register` method

Set locale

```php
// config/app.php
'locale' => 'ru'
```

Before changes:

```
Illuminate\Translation\Translator {#275 ▼ // public/index.php:55
  #parsed: array:13 [▶]
  #loader: Illuminate\Translation\FileLoader {#274 ▶}
  #locale: "ru"
  #fallback: "ru"
  #loaded: array:1 [▼
    "*" => array:14 [▼
      "*" => array:1 [▶]
      "System" => array:1 [▶]
      "Roles" => array:1 [▶]
      "Users" => array:1 [▶]
      "Main" => array:1 [▶]
      "Attachment" => array:1 [▶]
      "Sign in to your account" => array:1 [▶]
      "Email address" => array:1 [▶]
      "Enter your email" => array:1 [▶]
      "Password" => array:1 [▶]
      "Enter your password" => array:1 [▶]
      "Remember Me" => array:1 [▶]
      "Login" => array:1 [▶]
      "The application code is published under the MIT license" => array:1 [▶]
    ]
  ]
  #selector: null
  #determineLocalesUsing: null
  #stringableHandlers: []
}
```

After changes:

```
Illuminate\Translation\Translator {#276 ▼ // public/index.php:55
  #parsed: array:2 [▶]
  #loader: Illuminate\Translation\FileLoader {#275 ▶}
  #locale: "ru"
  #fallback: "ru"
  #loaded: array:1 [▼
    "*" => array:3 [▼
      "*" => array:1 [▼
        "ru" => array:165 [▶]
      ]
      "Введите ваш адрес электронной почты" => array:1 [▶]
      "Введите ваш пароль" => array:1 [▶]
    ]
  ]
  #selector: null
  #determineLocalesUsing: null
  #stringableHandlers: []
}
```
