### PR TITLE
Redundant Argument

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -16,7 +16,7 @@ return [
      |
      */
 
-    'domain' => env('DASHBOARD_DOMAIN', null),
+    'domain' => env('DASHBOARD_DOMAIN'),
 
     /*
      |--------------------------------------------------------------------------


### PR DESCRIPTION
Hello 👋 

This PR contains a minor correction.

## Proposed Changes

  - The default value of the `domain` variable in the **platform.php** file is already `null`, so there is no need to write it.

![image](https://github.com/orchidsoftware/platform/assets/45540321/eb9b40f5-445c-408e-b9a0-679b8f5add5c)

