### PR TITLE
Fixed missing `bs` in popover data attributes

### DIFF
--- a/resources/views/components/popover.blade.php
+++ b/resources/views/components/popover.blade.php
@@ -2,13 +2,13 @@
      role="button"
      data-controller="popover"
      data-action="click->popover#trigger"
-     data-container="body"
-     data-toggle="popover"
+     data-bs-container="body"
+     data-bs-toggle="popover"
      tabindex="0"
-     data-trigger="focus"
-     data-placement="{{ $placement }}"
-     data-delay-show="300"
-     data-delay-hide="200"
+     data-bs-trigger="click"
+     data-bs-placement="{{ $placement }}"
+     data-bs-delay-show="300"
+     data-bs-delay-hide="200"
      data-bs-content="{{ $content }}">
     <x-orchid-icon path="bs.question-lg" width="1em" height="1em"/>
 </sup>

--- a/tests/Unit/Support/BladeComponentTest.php
+++ b/tests/Unit/Support/BladeComponentTest.php
@@ -65,7 +65,7 @@ class BladeComponentTest extends TestUnitCase
         $this->assertStringContainsString('data-bs-placement="auto"', $view);
 
         $view = Blade::renderComponent('orchid-popover', [
-            'content' => 'Hello world',
+            'content'   => 'Hello world',
             'placement' => 'right',
         ]);
 

--- a/tests/Unit/Support/BladeComponentTest.php
+++ b/tests/Unit/Support/BladeComponentTest.php
@@ -54,4 +54,22 @@ class BladeComponentTest extends TestUnitCase
 
         $this->assertStringContainsString('Hello world', $view);
     }
+
+    public function testPopoverComponent(): void
+    {
+        $view = Blade::renderComponent('orchid-popover', [
+            'content' => 'Hello world',
+        ]);
+
+        $this->assertStringContainsString('data-bs-content="Hello world"', $view);
+        $this->assertStringContainsString('data-bs-placement="auto"', $view);
+
+        $view = Blade::renderComponent('orchid-popover', [
+            'content' => 'Hello world',
+            'placement' => 'right',
+        ]);
+
+        $this->assertStringContainsString('data-bs-content="Hello world"', $view);
+        $this->assertStringContainsString('data-bs-placement="right"', $view);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

  - Fixed missing `bs` in popover data attributes.
  - Added test.

In addition, I will explain why `trigger` was changed to `click`.

In the current state, the value from the data attribute is not used and the behavior is exactly like `click`, that is, it opens on the first click, and closes on the second click.

If use `focus`, then something strange turns out in general - it opens on the first click, and you can close it only if you click the second time and additionally again in another place, although in theory it should close on the second click in another place.

@tabuna Do you have a problem with trigger `focus` and how should I proceed?