### PR TITLE
Make accordion items stay open when another item is opened.

### DIFF
--- a/resources/views/layouts/accordion.blade.php
+++ b/resources/views/layouts/accordion.blade.php
@@ -14,7 +14,7 @@
         <div id="collapse-{{\Illuminate\Support\Str::slug($name)}}"
              class="mt-2 collapse @if (!$loop->index) show @endif"
              aria-labelledby="heading-{{\Illuminate\Support\Str::slug($name)}}"
-             data-bs-parent="#accordion-{{$templateSlug}}">
+             @if (!$stayOpen) data-bs-parent="#accordion-{{$templateSlug}} @endif">
                 @foreach($forms as $form)
                     {!! $form !!}
                 @endforeach

--- a/src/Screen/Layouts/Accordion.php
+++ b/src/Screen/Layouts/Accordion.php
@@ -24,6 +24,9 @@ abstract class Accordion extends Layout
      */
     public function __construct(array $layouts = [])
     {
+        $this->variables = [
+            'stayOpen' => false,
+        ];
         $this->layouts = $layouts;
     }
 
@@ -33,5 +36,16 @@ abstract class Accordion extends Layout
     public function build(Repository $repository)
     {
         return $this->buildAsDeep($repository);
+    }
+
+    /**
+     * Make accordion items stay open when another item is opened.
+     * @param bool $stayOpen
+     * @return $this
+     */
+    public function stayOpen(bool $stayOpen = true): self
+    {
+        $this->variables['stayOpen'] = $stayOpen;
+        return $this;
     }
 }


### PR DESCRIPTION
#### Proposed Changes

  - Add option to make accordion items stay open when another item is opened.

#### Usage

```
Layout::accordion([
    'Personal Information' => [
        Layout::rows([
            Input::make('user.name')
                ->type('text')
                ->required()
                ->title('Name')
                ->placeholder('Name'),

            Input::make('user.email')
                ->type('email')
                ->required()
                ->title('Email')
                ->placeholder('Email'),
        ]),
    ],
    'Billing Address'      => [
        Layout::rows([
            Input::make('address')
                ->type('text')
                ->required(),
        ]),
    ],
])->stayOpen()
```