### PR TITLE
Fixed hiding modal placeholder on screen size < 768px

### DIFF
--- a/resources/sass/core/modals.scss
+++ b/resources/sass/core/modals.scss
@@ -155,6 +155,21 @@
       }
     }
   }
+
+  .modal-placeholder {
+    display: none;
+  }
+
+  &.modal-loading {
+    .modal-placeholder{
+      display: block;
+      opacity: 1;
+    }
+
+    .modal-header, .modal-body, .modal-footer {
+      display: none;
+    }
+  }
 }
 
 .fill-in-modal {
@@ -215,19 +230,4 @@
 		width: auto;
 		margin: 30px auto;
 	}
-
-    .modal-placeholder {
-        display: none;
-    }
-
-    &.modal-loading {
-         .modal-placeholder{
-           display: block;
-           opacity: 1;
-         }
-
-        .modal-header, .modal-body, .modal-footer {
-            display: none;
-        }
-    }
 }


### PR DESCRIPTION
## Proposed Changes

  - fix: modal placeholder not hiding on small screen

Most likely just by accident these rules were added not for all screen sizes, but only for more than 768px.