### PR TITLE
Fix dots in button and link names

### DIFF
--- a/src/Screen/Builder.php
+++ b/src/Screen/Builder.php
@@ -122,8 +122,10 @@ class Builder
         $field->set('lang', $this->language);
         $field->set('prefix', $this->buildPrefix($field));
 
-        foreach ($this->fill($field->getAttributes()) as $key => $value) {
-            $field->set($key, $value);
+        if(!($field instanceof Action)) {
+            foreach ($this->fill($field->getAttributes()) as $key => $value) {
+                $field->set($key, $value);
+            }
         }
 
         return $field->render();


### PR DESCRIPTION
Fixes #
If you use dots in Links or Menu or Buttons it is converted into array
For example domain.com becomes domain[com].

Fixed conversion to Array for Action instances
