### PR TITLE
правило валидации для Attachment, загруженных ранее полями Upload, Cr…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
             "Orchid\\Filters\\": "src/Filters/",
             "Orchid\\Metrics\\": "src/Metrics/",
             "Orchid\\Platform\\": "src/Platform/",
+            "Orchid\\Rule\\": "src/Rule/",
             "Orchid\\Screen\\": "src/Screen/",
             "Orchid\\Support\\": "src/Support/"
         },

--- a/src/Rule/AttachmentRule.php
+++ b/src/Rule/AttachmentRule.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Orchid\Rule;
+
+use Closure;
+use Illuminate\Contracts\Filesystem\Cloud;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Database\Eloquent\Collection;
+use Orchid\Attachment\Models\Attachment;
+use Storage;
+use Symfony\Component\HttpFoundation\File\File as FileSymfony;
+
+class AttachmentRule implements ValidationRule
+{
+    /** @var Collection<Attachment>} */
+    protected Collection $attachment;
+
+    /**
+     * @param mixed $rules правила валидации файлов Attachment см. документацию по валидации файлов.
+     *                     Например: File::image()->dimensions(Rule::dimensions()->maxWidth(960)->maxHeight(639)) или
+     *                     то-же самое 'image|dimensions:min_width=960,min_height=639'
+     * @param bool $removeFailed удалять или нет файлы, не прошедшие валидацию
+     */
+    public function __construct(protected mixed $rules, protected bool $removeFailed = true)
+    {
+    }
+
+    /**
+     * Получение Attachment для валидации
+     * @param mixed $ids
+     * @return void
+     */
+    protected function setAttachment(mixed $ids): void
+    {
+        $this->attachment = is_array($ids)
+            ? Attachment::whereIn('id', $ids)->get()
+            : Attachment::where('id', $ids)->get();
+
+        $this->attachment = $this->attachment->mapWithKeys(fn(Attachment $attachment) => ["_{$attachment->id}" => $attachment]);
+    }
+
+    /**
+     * Получение объекта типа \Symfony\Component\HttpFoundation\File\File из AttachmentModel
+     *
+     * @param Attachment $attachment
+     * @return FileSymfony|null
+     */
+    protected function getFileObjectFromAttachment(Attachment $attachment): ?FileSymfony
+    {
+        if ($attachment->exists) {
+            /** @var Filesystem|Cloud $disk */
+            $disk = Storage::disk($attachment->disk);
+            return new FileSymfony($disk->path($attachment->physicalPath()));
+        }
+
+        return null;
+    }
+
+    /**
+     * Генерация валидатора
+     *
+     * @return Validator
+     */
+    protected function getValidator(): Validator
+    {
+        $data = $this->attachment->mapWithKeys(fn(Attachment $attachment, $key) => [$key => $this->getFileObjectFromAttachment($attachment)])->filter(fn($item) => !empty($item))->toArray();
+        $rules = $this->attachment->mapWithKeys(fn(Attachment $attachment, $key) => [$key => $this->rules])->toArray();
+        $attributes = $this->attachment->mapWithKeys(fn(Attachment $attachment, $key) => [$key => $attachment->original_name])->toArray();
+
+        return validator(data: $data, rules: $rules, attributes: $attributes);
+    }
+
+    /**
+     * @param \Illuminate\Support\Collection $errors
+     * @return void
+     */
+    protected function removeFiles(\Illuminate\Support\Collection $errors): void
+    {
+        $errors->each(function ($message, $key) {
+            if ($this->attachment->has($key)) {
+                $this->attachment[$key]->delete();
+            }
+        });
+    }
+
+    /**
+     * Run the validation rule.
+     *
+     * @param \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $this->setAttachment($value);
+        $validator = $this->getValidator();
+
+        if ($validator->fails()) {
+            $errors = collect($validator->errors()->toArray());
+
+            if ($this->removeFailed) {
+                $this->removeFiles($errors);
+            }
+
+            $fail($errors->flatten()->implode(' '));
+        }
+    }
+}


### PR DESCRIPTION
Часто необходимо выполнять валидацию файлов, загруженных через Upload. Можно через Observer, но лучше, лгично и читаемо - через контроллер или Form Request в стандартном валидаторе Laravel. Предлагаю такое правило для валидатора.

Как использовать:

```
use Orchid\Rule\AttachmentRule;

class SomeClassScreen  extends Screen {

    public function save(Request $request) {
        $request->validate([
            'file' => ['required', new AttachmentRule('bail|image|dimensions:max_width=100,max_height=100', true)]
        ]);
    }
}
```

или

```
namespace App\Http\Requests;

use Orchid\Rule\AttachmentRule;

class SomeRequest extends FormRequest
{
    public function rules(): array
    {
        return [
            'file' => ['required', new AttachmentRule('bail|image|dimensions:max_width=100,max_height=100')],
        ];
    }
}
```

Класс принимает 2 параметра в конструктор - правила валидации и надо ли удалять файлы, не прошедшие валидацию (по умолчанию - true).

Есть один нюанс: required должно быть вынесено, как в примере выше, т.к. если поле не пришло или пустое - валидатор просто пропускает это поле, даже если указать required в параметрах AttachmentRule.

Вот, что получаем в итоге:
![image](https://github.com/orchidsoftware/platform/assets/5114650/030baf68-95d3-494d-94f3-9c5cd74c8129)

После валидации:
![image](https://github.com/orchidsoftware/platform/assets/5114650/6fa41f72-3ae6-434a-8585-881e1bfde2bd)

Ну и исправить описание ошибок, чтобы было не "Поле ... должно быть картинкой", а - "Файл ... должен быть картинкой" ну или как-то так, если это критично, конечно.