### PR TITLE
Check if the $url in the action button class has ended with /

### DIFF
--- a/src/Screen/Actions/Button.php
+++ b/src/Screen/Actions/Button.php
@@ -78,7 +78,7 @@ class Button extends Action
 
             $query = http_build_query($this->get('parameters'));
 
-            $action = rtrim("{$url}/{$this->get('method')}?{$query}", '/?');
+            $action = rtrim((str_ends_with($url, '/') ? $url : "{$url}/") . "{$this->get('method')}?{$query}", '/?');
             $this->set('action', $action);
         })->addBeforeRender(function () {
             $action = $this->get('action');


### PR DESCRIPTION
# Improvement
I don't know if anyone ever needs this, but in my case, I set my Laravel application to always have a trailing slash at the end, and I came up with an issue that the URL in the button has a double slash before the method name:
![image](https://github.com/orchidsoftware/platform/assets/30499443/0b79cbf8-7a3f-438d-b9a4-7ed73c315027)
 

## Changes
If the `$url` in the action button class has ended with `/` no need to hard-coded additional `/` 

