### PR TITLE
Enforce non null @section values to prevent dangling output buffers

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -1,7 +1,7 @@
 @extends('platform::dashboard')
 
-@section('title', __($name))
-@section('description', __($description))
+@section('title', (string) __($name))
+@section('description', (string) __($description))
 @section('controller', 'base')
 
 @section('navbar')


### PR DESCRIPTION
Fixes #2763

Calling `@section` with a null value trigger a bug that does not close an output buffer, causing PHPUnit to mark tests that use this view without name or description defined to be marked as risky.

## Proposed Changes
Changes introduced by d9700e9753ba09c20e3e4e0b22305960f8801d04 removed the `e` function call that fallback to empty string when called with null.
Using a `string` cast force `null` values to be empty string.

More references: https://laracasts.com/discuss/channels/testing/test-code-or-tested-code-did-not-only-close-its-own-output-buffers-actingas
