### PR TITLE
Fix row in container-fluid to center on login

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -50,7 +50,7 @@
 
 <div class="container-fluid" data-controller="@yield('controller')" @yield('controller-data')>
 
-    <div class="row d-md-flex h-100">
+    <div class="row justify-content-center d-md-flex h-100">
         @yield('aside')
 
         <div class="col-xxl col-xl-9 col-12">


### PR DESCRIPTION
## Proposed Changes

  - Fix form login align center on /admin/login page with screen width from 1200px to 1399px
