### PR TITLE
feat: add option to customize display name for select based on enums

### DIFF
--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -91,18 +91,19 @@ class Select extends Field implements ComplexFieldConcern
 
     /**
      * @param string $enum
+     * @param string|null $displayName
      *
      * @throws \ReflectionException
      *
      * @return self
      */
-    public function fromEnum(string $enum): self
+    public function fromEnum(string $enum, ?string $displayName = null): self
     {
         $reflection = new \ReflectionEnum($enum);
         $options = [];
         foreach ($enum::cases() as $item) {
             $key = $reflection->isBacked() ? $item->value : $item->name;
-            $options[$key] = __($item->name);
+            $options[$key] = is_null($displayName) ? __($item->name) : $item->$displayName();
         }
         $this->set('options', $options);
 
@@ -110,6 +111,7 @@ class Select extends Field implements ComplexFieldConcern
             $value = [];
             collect($this->get('value'))->each(static function ($item) use (&$value, $reflection, $enum) {
                 if ($item instanceof $enum) {
+                    /** @var \UnitEnum $item */
                     $value[] = $reflection->isBacked() ? $item->value : $item->name;
                 } else {
                     $value[] = $item;

--- a/tests/App/Enums/RoleNames.php
+++ b/tests/App/Enums/RoleNames.php
@@ -6,4 +6,12 @@ enum RoleNames: string
 {
     case Admin = 'admin';
     case User = 'user';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Admin => 'Administrator',
+            self::User => 'Regular user',
+        };
+    }
 }

--- a/tests/Unit/Screen/Fields/SelectTest.php
+++ b/tests/Unit/Screen/Fields/SelectTest.php
@@ -8,6 +8,7 @@ use Orchid\Platform\Models\Role;
 use Orchid\Screen\Fields\Select;
 use Orchid\Support\Color;
 use Orchid\Tests\App\EmptyUserModel;
+use Orchid\Tests\App\Enums\RoleNames;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
 
 /**
@@ -231,6 +232,18 @@ class SelectTest extends TestFieldsUnitCase
         $this->assertStringContainsString('value="first" selected', $view);
         $this->assertStringContainsString('value="second" selected', $view);
         $this->assertStringNotContainsString('value="third" selected', $view);
+    }
+
+    public function testFromEnumWithDisplayName(): void
+    {
+        $select = Select::make('choice')
+            ->value(RoleNames::User)
+            ->fromEnum(RoleNames::class, 'label');
+
+        $view = self::minifyRenderField($select);
+
+        // <option value="user" selected>Regular user</option>
+        $this->assertStringContainsString('value="'.RoleNames::User->value.'" selected>'.RoleNames::User->label(), $view);
     }
 
     public function testMultipleFromEnum(): void


### PR DESCRIPTION
## Proposed Changes

This PR gives option to change displayed values for Select Field based on Enum

```php
// Enum
enum RoleNames: string
{
    case Admin = 'admin';
    case User = 'user';

    public function label(): string
    {
        return match ($this) {
            self::Admin => 'Administrator',
            self::User => 'Regular user',
        };
    }
}

// Layout
Select::make('fromEnum')
   ->fromEnum(RoleNames::class, 'label'), // pass second option as method name
```

This will generate values based on label method

![Снимок экрана от 2023-12-20 12-10-04](https://github.com/orchidsoftware/platform/assets/86893348/517a9a18-cf08-4b71-a838-1dce508dda48)
