### PR TITLE
Fix: change default value for metrics layout to be compatible with modals

### DIFF
--- a/src/Screen/Layouts/Metric.php
+++ b/src/Screen/Layouts/Metric.php
@@ -44,7 +44,7 @@ class Metric extends Layout
             return;
         }
 
-        $metrics = collect($this->labels)->map(fn (string $value) => $repository->getContent($value, []));
+        $metrics = collect($this->labels)->map(fn (string $value) => $repository->getContent($value, ''));
 
         return view($this->template, [
             'title'   => $this->title,


### PR DESCRIPTION
This PR fixes error when using metrics and modals are presents at the same time (not within modal)

I will not open issue, basically steps to reproduce

1. Install Orchid, go to users list, click on "edit email" modal - everything is OK
2. Add dummy metric layout

```php
public function query(): iterable
{
  return [
     // ...
     'metrics' => 1,
  ];
}

public function layout(): iterable
{
 // ...
 Layout::metrics(['Metrics' => 'metrics']),
}
``` 

3. Click same button again - modal data was not loaded (we can see skeleton and 500 error in a console)

## Proposed Changes

Default data for metrics currently is empty array so it is passes `is_array()` check within `layouts/metric.blade.php` (currently [line 13](https://github.com/orchidsoftware/platform/blob/master/resources/views/layouts/metric.blade.php#L13)) and expects `value` key to be present. This PR should fix it
