### PR TITLE
don't needed crash if value is empty

### DIFF
--- a/src/Screen/Components/Cells/Currency.php
+++ b/src/Screen/Components/Cells/Currency.php
@@ -16,6 +16,7 @@ class Currency extends Component
      * @param string|null $thousands_separator
      * @param string|null $before
      * @param string|null $after
+     * @param string|null $empty string value if empty
      */
     public function __construct(
         protected float $value,
@@ -24,6 +25,7 @@ class Currency extends Component
         protected ?string $thousands_separator = ',',
         protected ?string $before = '',
         protected ?string $after = '',
+        protected ?string $empty = '',
     ) {
     }
 
@@ -34,7 +36,12 @@ class Currency extends Component
      */
     public function render()
     {
-        $value = number_format($this->value, $this->decimals, $this->decimal_separator, $this->thousands_separator);
+        if(empty($this->value)) {
+            $value = $this->empty;
+        }
+        else {
+            $value = number_format($this->value, $this->decimals, $this->decimal_separator, $this->thousands_separator);
+        }
 
         return Str::of($value)
             ->prepend($this->before.' ')


### PR DESCRIPTION
Fixes #
Fix crash if an empty attribute is passed to a component. 
![image](https://github.com/orchidsoftware/platform/assets/8983338/5653eb60-2d50-4f98-9d7a-cf8c7f0ec5d5)

## Proposed Changes
Added a optional param that represent the empty value. 
If empty value is passed, this parameter is used. Default as empty string.

