### PR TITLE
Allow events AutoDiscovery in Laravel 11

### DIFF
--- a/src/Platform/Providers/EventServiceProvider.php
+++ b/src/Platform/Providers/EventServiceProvider.php
@@ -20,4 +20,18 @@ class EventServiceProvider extends ServiceProvider
             LockUserForLogin::class,
         ],
     ];
+
+    /**
+     * Determine if events and listeners should be automatically discovered.
+     *
+     * @return bool
+     */
+    public function shouldDiscoverEvents()
+    {
+        if(isset(static::$shouldDiscoverEvents)) {
+            return get_class($this) === __CLASS__ && static::$shouldDiscoverEvents === true;
+        }
+
+        return parent::shouldDiscoverEvents();
+    }
 }


### PR DESCRIPTION
Fixes #2828

## Proposed Changes
Laravel 11 automatically disable events auto discovery if a different instance of EventServiceProvider is loaded. This is handle by `shouldDiscoverEvents` method at line [137 in Illuminate/Foundation/Support/Providers/EventServiceProvider.php](https://github.com/laravel/framework/blob/v11.6.0/src/Illuminate/Foundation/Support/Providers/EventServiceProvider.php#L137).
Since Orchid extend and register it's own version of `EventServiceProvider` the class check at `get_class($this) === __CLASS__` starts to fail since it's executed with an instance of Orchid `EventsServiceProvider`.

I propose to override the `shouldDiscoverEvents` in order to match `get_class` and `__CLASS__` values and re-enable the auto discovery. 