### PR TITLE
Add frontend controller in screen.

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -57,7 +57,7 @@
     <div class="row justify-content-center d-md-flex h-100">
         @yield('aside')
 
-        <div class="col-xxl col-xl-9 col-12" @if(!empty($controller))data-controller="{{$controller}}"@endif>
+        <div class="col-xxl col-xl-9 col-12">
             @yield('body')
         </div>
     </div>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -57,7 +57,7 @@
     <div class="row justify-content-center d-md-flex h-100">
         @yield('aside')
 
-        <div class="col-xxl col-xl-9 col-12">
+        <div class="col-xxl col-xl-9 col-12" @if(!empty($controller))data-controller="{{$controller}}"@endif>
             @yield('body')
         </div>
     </div>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -2,7 +2,7 @@
 
 @section('title', (string) __($name))
 @section('description', (string) __($description))
-@section('controller', 'base')
+@section('controller', $controller)
 
 @section('navbar')
     @foreach($commandBar as $command)

--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -218,6 +218,7 @@ abstract class Screen extends Controller
             'formValidateMessage'     => $this->formValidateMessage(),
             'needPreventsAbandonment' => $this->needPreventsAbandonment(),
             'state'                   => $this->serializeStateWithPublicProperties($repository),
+            'controller'              => $this->frontendController(),
         ]);
     }
 
@@ -497,5 +498,13 @@ abstract class Screen extends Controller
         $repository = new Repository($data);
 
         return back()->with('_state', $this->serializableState($repository));
+    }
+
+    /**
+     * Name frontend controller in screen.
+     */
+    public function frontendController(): string
+    {
+        return '';
     }
 }

--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -505,6 +505,6 @@ abstract class Screen extends Controller
      */
     public function frontendController(): string
     {
-        return '';
+        return 'base';
     }
 }


### PR DESCRIPTION
Added the ability to assign a stimulus controller to the screen.
Usage:
```
class PlatformScreen extends Screen
{
    ...

    public function frontendController(): string
    {
        return 'hello';
    }

    ...
}
```