### PR TITLE
Add support for modal with XL size and fix $type position

### DIFF
--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -1,5 +1,5 @@
 @push('modals-container')
-    <div class="modal fade center-scale"
+    <div class="modal fade center-scale {{$type}}"
          id="screen-modal-{{$key}}"
          role="dialog"
          aria-labelledby="screen-modal-{{$key}}"
@@ -10,7 +10,7 @@
          data-modal-open="{{$open}}"
         {{$staticBackdrop ? "data-bs-backdrop=static" : ''}}
     >
-        <div class="modal-dialog modal-fullscreen-md-down {{$size}} {{$type}}"
+        <div class="modal-dialog modal-fullscreen-md-down {{$size}}"
              role="document"
              id="screen-modal-type-{{$key}}"
         >

--- a/src/Screen/Layouts/Modal.php
+++ b/src/Screen/Layouts/Modal.php
@@ -18,6 +18,7 @@ class Modal extends Layout
 {
     use Commander;
 
+    public const SIZE_XL = 'modal-xl';
     public const SIZE_LG = 'modal-lg';
     public const SIZE_SM = 'modal-sm';
 


### PR DESCRIPTION
**Feature:** Added support for modal with XL (Extra large) size.
- Updated modal component to handle XL size configurations.
- Ensured consistent styling and behavior for the new size option.

**Bug Fix:** Corrected the misplaced `$type` variable.
- Moved `$type` to the appropriate location in the layout template.
- Verified that the fix does not impact other functionalities or cause regressions.
