### PR TITLE
Allow values in deeper values

### DIFF
--- a/resources/views/partials/fields/matrixRow.blade.php
+++ b/resources/views/partials/fields/matrixRow.blade.php
@@ -2,9 +2,17 @@
     @foreach($columns as $column)
 
         <th class="p-0 align-middle">
+            @php
+                $columnsArray = explode('.', $column);
+                $value= $row;
+                foreach($columnsArray as $curr) {
+                $value = $value[$curr] ?? "";
+                    if ($value == "") break;
+                }
+            @endphp
             {!!
                $fields[$column]
-                    ->value($row[$column] ?? '')
+                    ->value($value)
                     ->prefix($name)
                     ->id("$idPrefix-$key-$column")
                     ->name($keyValue ? $column : "[$key][$column]")


### PR DESCRIPTION
Fixes #
When values comes with "pivot" from pivot tables. It can't be used in form values. 
## Proposed Changes

  - Now with this fix, you can put in fields "pivot.url" and read values from 
`"pivot" : [
"url" => "someurl"
]`
  -
  -
