### PR TITLE
Reduce Data Transfer for State Restore

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -512,7 +512,7 @@ class Field implements Fieldable, Htmlable
      */
     private function getErrorsMessage()
     {
-       return session()->get('errors', new MessageBag());
+        return session()->get('errors', new MessageBag());
     }
 
     /**


### PR DESCRIPTION
This PR introduces a significant change to how screen state is handled. To better understand this, let’s first review the current behavior:

All recorded public properties of the screen are wrapped in a signalizer, which typically increases the length of the data since its contents are serialized:

```php
// Serialized:
O:7:"Example":2:{s:9:"property1";s:6:"value1";s:9:"property2";s:6:"value2";}
```

The data is then encrypted, further increasing the text length:

```php
// Encripted:
Tzo3OiJFeGFtcGxlIjoxOntzOjk6InByb3BlcnR5MSI7czo2OiJ2YWx1MSI7czo5OiJwcm9wZXJ0eTIiO3M6Njoi dmFsdWUiO30=
```

As a result, if a user writes too much data into a public property, such as a model with many relationships, this impacts the length of the response/request. In extreme cases, this can lead to a 413 – Request Entity Too Large error.

To address this issue while retaining functionality, this PR proposes the following change:

Instead of serializing the entire model and its properties, we will serialize the SQL query, similar to how Laravel Queues handle this with the `SerializeModel` trait. This approach will significantly reduce the amount of data transferred, as it avoids storing the complete information. During deserialization, the data will be retrieved again from the database.

This change aims to preserve functionality while mitigating the risk of data overload issues.