### PR TITLE
Update select_controller.js & datetime_controller.js

### DIFF
--- a/resources/js/controllers/datetime_controller.js
+++ b/resources/js/controllers/datetime_controller.js
@@ -37,6 +37,8 @@ export default class extends ApplicationController {
             minDate: 'min-date',
             mode: "mode",
             defaultDate: "default-date",
+            altInput: "alt-input",
+            altFormat: "alt-format",
         };
 
         const config = {

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -25,7 +25,7 @@ export default class extends ApplicationController {
             placeholder: select.getAttribute('placeholder') === 'false' ? '' : select.getAttribute('placeholder'),
             preload: true,
             plugins,
-            maxItems: select.getAttribute('maximumSelectionLength') || select.hasAttribute('multiple') ? null : 1,
+            maxItems: select.getAttribute('maximumSelectionLength') || (select.hasAttribute('multiple') ? null : 1),
             render: {
                 option_create: (data, escape) => `<div class="create">${this.data.get('message-add')} <strong>${escape(data.input)}</strong>&hellip;</div>`,
                 no_results: () => `<div class="no-results">${this.data.get('message-notfound')}</div>`,

--- a/src/Screen/Fields/DateTimer.php
+++ b/src/Screen/Fields/DateTimer.php
@@ -56,6 +56,7 @@ class DateTimer extends Field
         'data-datetime-inline'                  => 'false',
         'data-datetime-position'                => 'auto auto',
         'data-datetime-shorthand-current-month' => 'false',
+        'data-datetime-alt-input'               => 'false',
         'data-datetime-show-months'             => 1,
         'allowEmpty'                            => false,
         'placeholder'                           => 'Select Date...',
@@ -100,6 +101,8 @@ class DateTimer extends Field
         'data-datetime-position',
         'data-datetime-shorthand-current-month',
         'data-datetime-show-months',
+        'data-datetime-alt-input',
+        'data-datetime-alt-format',
     ];
 
     /**
@@ -415,6 +418,21 @@ class DateTimer extends Field
             ->all();
 
         $this->attributes['quickDates'] = $formattedPresets;
+
+        return $this;
+    }
+
+    /**
+     * Set the date format for the alt input field.
+     * 
+     * @param string $format
+     * 
+     * @return $this
+     */
+    public function altFormat(string $format): static
+    {
+        $this->set('data-datetime-alt-format', $format);
+        $this->set('data-datetime-alt-input', var_export(true, true));
 
         return $this;
     }


### PR DESCRIPTION
### select_controller.js

The "maximumSelectionLength" option in select_controller.js was not working. The problem was solved by adding parentheses.

Before the relevant change is made;

<img width="538" alt="image" src="https://github.com/user-attachments/assets/4c30d891-81c0-43a3-8998-6bf52bf65ec7">

![image](https://github.com/user-attachments/assets/4b3bb67d-e367-4aa4-b9d7-26a880ffd568)

### datetime_controller.js

In order to use the formatting feature correctly, the "altInput" and "altFormat" attributes recommended by the "flatpickr" package have been added.
