### PR TITLE
Retrieve Screen inherited public properties from parent classes

### DIFF
--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -266,11 +266,14 @@ abstract class Screen extends Controller
      */
     protected function getPublicPropertyNames(): Collection
     {
-        $reflections = (new \ReflectionClass($this))->getProperties(\ReflectionProperty::IS_PUBLIC);
+        $properties = (new \ReflectionClass(static::class))->getProperties(\ReflectionProperty::IS_PUBLIC);
+        $baseProperties = (new \ReflectionClass(Screen::class))->getProperties(\ReflectionProperty::IS_PUBLIC);
 
-        return collect($reflections)
+        return collect($properties)
+            ->mapWithKeys(fn (\ReflectionProperty $property) => [$property->getName() => $property])
             ->filter(fn (\ReflectionProperty $property) => ! $property->isStatic())
-            ->map(fn (\ReflectionProperty $property) => $property->getName());
+            ->except(array_map(fn (\ReflectionProperty $property) => $property->getName(), $baseProperties))
+            ->keys();
     }
 
     /**


### PR DESCRIPTION
Fixes #2879

## Proposed Changes

  - Iterate over parent classes public properties while creating public properties list;
  - Stop at base Screen class to avoid changes to Orchid native properties;
