### PR TITLE
Add "aria-*" to $universalAttributes in Field.php

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -112,6 +112,7 @@ class Field implements Fieldable, Htmlable
         'xml:lang',
         'autocomplete',
         'data-*',
+        'aria-*',
     ];
 
     /**


### PR DESCRIPTION
Hello!

I noticed the Field class does not have a way to use [accessibility attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA). The proposal adds "aria-*" to the universal attributes array.

## Proposed Changes

  - Added the possibility to set accessibility attributes for fields