### PR TITLE
Fixed screen constructor property initialization during deserialization

### DIFF
--- a/src/Screen/Concerns/ModelStateRetrievable.php
+++ b/src/Screen/Concerns/ModelStateRetrievable.php
@@ -51,7 +51,7 @@ trait ModelStateRetrievable
             $name = $property->getName();
 
             if ($property->isPrivate() || $property->isProtected()) {
-              continue;
+                continue;
             }
 
             $values[$name] = $this->getSerializedPropertyValue(
@@ -69,9 +69,10 @@ trait ModelStateRetrievable
      *
      * @param array $values
      *
-     * @return void
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \ReflectionException
+     *
+     * @return void
      */
     public function __unserialize(array $values)
     {
@@ -101,7 +102,8 @@ trait ModelStateRetrievable
     /**
      * Get the property value for the given property.
      *
-     * @param  \ReflectionProperty  $property
+     * @param \ReflectionProperty $property
+     *
      * @return mixed
      */
     protected function getPropertyValue(\ReflectionProperty $property)
@@ -110,9 +112,10 @@ trait ModelStateRetrievable
     }
 
     /**
-     * @return array
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      * @throws \ReflectionException
+     *
+     * @return array
      */
     protected function getDefaultPropertyWithConstructor(): array
     {
@@ -121,7 +124,7 @@ trait ModelStateRetrievable
         $defaultReflection = (new \ReflectionClass($default))->getProperties();
 
         return collect($defaultReflection)
-            ->mapWithKeys(fn(\ReflectionProperty $property) => [$property->getName() => $property->getValue($default)])
+            ->mapWithKeys(fn (\ReflectionProperty $property) => [$property->getName() => $property->getValue($default)])
             ->all();
     }
 }

--- a/src/Screen/Concerns/ModelStateRetrievable.php
+++ b/src/Screen/Concerns/ModelStateRetrievable.php
@@ -2,7 +2,8 @@
 
 namespace Orchid\Screen\Concerns;
 
-use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\Attributes\WithoutRelations;
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 
 /**
  * This trait is designed for managing the state of Eloquent models. It uses
@@ -14,5 +15,113 @@ use Illuminate\Queue\SerializesModels;
  */
 trait ModelStateRetrievable
 {
-    use SerializesModels;
+    use SerializesAndRestoresModelIdentifiers;
+
+    /**
+     * Prepare the instance values for serialization.
+     *
+     * @return array
+     */
+    public function __serialize()
+    {
+        $values = [];
+
+        $reflectionClass = new \ReflectionClass($this);
+
+        [$properties, $classLevelWithoutRelations] = [
+            $reflectionClass->getProperties(),
+            ! empty($reflectionClass->getAttributes(WithoutRelations::class)),
+        ];
+
+        foreach ($properties as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            if (! $property->isInitialized($this)) {
+                continue;
+            }
+
+            $value = $this->getPropertyValue($property);
+
+            if ($property->hasDefaultValue() && $value === $property->getDefaultValue()) {
+                continue;
+            }
+
+            $name = $property->getName();
+
+            if ($property->isPrivate() || $property->isProtected()) {
+              continue;
+            }
+
+            $values[$name] = $this->getSerializedPropertyValue(
+                $value,
+                ! $classLevelWithoutRelations &&
+                empty($property->getAttributes(WithoutRelations::class))
+            );
+        }
+
+        return $values;
+    }
+
+    /**
+     * Restore the model after serialization.
+     *
+     * @param array $values
+     *
+     * @return void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \ReflectionException
+     */
+    public function __unserialize(array $values)
+    {
+        $default = $this->getDefaultPropertyWithConstructor();
+
+        $values = array_merge($default, $values);
+
+        $properties = (new \ReflectionClass($this))->getProperties();
+
+        foreach ($properties as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $name = $property->getName();
+
+            if (! array_key_exists($name, $values)) {
+                continue;
+            }
+
+            $property->setValue(
+                $this, $this->getRestoredPropertyValue($values[$name])
+            );
+        }
+    }
+
+    /**
+     * Get the property value for the given property.
+     *
+     * @param  \ReflectionProperty  $property
+     * @return mixed
+     */
+    protected function getPropertyValue(\ReflectionProperty $property)
+    {
+        return $property->getValue($this);
+    }
+
+    /**
+     * @return array
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \ReflectionException
+     */
+    protected function getDefaultPropertyWithConstructor(): array
+    {
+        $default = app()->make(static::class);
+
+        $defaultReflection = (new \ReflectionClass($default))->getProperties();
+
+        return collect($defaultReflection)
+            ->mapWithKeys(fn(\ReflectionProperty $property) => [$property->getName() => $property->getValue($default)])
+            ->all();
+    }
 }

--- a/src/Screen/Screen.php
+++ b/src/Screen/Screen.php
@@ -496,7 +496,7 @@ abstract class Screen extends Controller
             $propertyName = $property->getName();
 
             // Skip if there's no default value for the property
-            if (!$defaultProperties->has($propertyName)) {
+            if (! $defaultProperties->has($propertyName)) {
                 continue;
             }
 
@@ -509,8 +509,10 @@ abstract class Screen extends Controller
      * Returns an associative array of property names and their values for the given object.
      *
      * @param object $object
-     * @return Collection
+     *
      * @throws \ReflectionException
+     *
+     * @return Collection
      */
     private function getPropertiesWithValues(object $object): Collection
     {
@@ -519,6 +521,7 @@ abstract class Screen extends Controller
         return collect($reflection->getProperties())
             ->mapWithKeys(function (\ReflectionProperty $property) use ($object) {
                 $property->setAccessible(true); // Ensure we can access private/protected properties
+
                 return [$property->getName() => $property->getValue($object)];
             });
     }

--- a/tests/App/Screens/SerializeRetrievableScreen.php
+++ b/tests/App/Screens/SerializeRetrievableScreen.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\App\Screens;
+
+use Illuminate\Foundation\Application;
+use Orchid\Screen\Concerns\ModelStateRetrievable;
+use Orchid\Screen\Screen;
+
+class SerializeRetrievableScreen extends Screen
+{
+    use ModelStateRetrievable;
+
+    public $public = "Public";
+
+    public function __construct(
+        protected Application   $application,
+        private readonly string $private = "Private",
+        public $user = null
+    )
+    {
+        $this->middleware(function ($request, $next) {
+            return $next($request);
+        });
+    }
+
+
+    /**
+     * Query data.
+     */
+    public function query(): array
+    {
+        return [];
+    }
+
+    /**
+     * Display header name.
+     */
+    public function name(): ?string
+    {
+        return 'Route Resolve Screen';
+    }
+
+    /**
+     * Display header description.
+     */
+    public function description(): ?string
+    {
+        return 'Test screen';
+    }
+
+    /**
+     * Button commands.
+     *
+     * @return \Orchid\Screen\Action[]
+     */
+    public function commandBar(): array
+    {
+        return [];
+    }
+
+    /**
+     * Views.
+     *
+     * @return \Orchid\Screen\Layout[]
+     */
+    public function layout(): array
+    {
+        return [];
+    }
+}

--- a/tests/App/Screens/SerializeRetrievableScreen.php
+++ b/tests/App/Screens/SerializeRetrievableScreen.php
@@ -12,19 +12,17 @@ class SerializeRetrievableScreen extends Screen
 {
     use ModelStateRetrievable;
 
-    public $public = "Public";
+    public $public = 'Public';
 
     public function __construct(
-        protected Application   $application,
-        private readonly string $private = "Private",
+        protected Application $application,
+        private readonly string $private = 'Private',
         public $user = null
-    )
-    {
+    ) {
         $this->middleware(function ($request, $next) {
             return $next($request);
         });
     }
-
 
     /**
      * Query data.

--- a/tests/App/Screens/SerializeScreen.php
+++ b/tests/App/Screens/SerializeScreen.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\App\Screens;
+
+use Illuminate\Foundation\Application;
+use Orchid\Screen\Screen;
+
+class SerializeScreen extends Screen
+{
+    public $public = "Public";
+
+    public function __construct(
+        protected Application   $application,
+        private readonly string $private = "Private",
+        public $user = null
+    )
+    {
+        $this->middleware(function ($request, $next) {
+            return $next($request);
+        });
+    }
+
+
+    /**
+     * Query data.
+     */
+    public function query(): array
+    {
+        return [];
+    }
+
+    /**
+     * Display header name.
+     */
+    public function name(): ?string
+    {
+        return 'Route Resolve Screen';
+    }
+
+    /**
+     * Display header description.
+     */
+    public function description(): ?string
+    {
+        return 'Test screen';
+    }
+
+    /**
+     * Button commands.
+     *
+     * @return \Orchid\Screen\Action[]
+     */
+    public function commandBar(): array
+    {
+        return [];
+    }
+
+    /**
+     * Views.
+     *
+     * @return \Orchid\Screen\Layout[]
+     */
+    public function layout(): array
+    {
+        return [];
+    }
+}

--- a/tests/App/Screens/SerializeScreen.php
+++ b/tests/App/Screens/SerializeScreen.php
@@ -9,19 +9,17 @@ use Orchid\Screen\Screen;
 
 class SerializeScreen extends Screen
 {
-    public $public = "Public";
+    public $public = 'Public';
 
     public function __construct(
-        protected Application   $application,
-        private readonly string $private = "Private",
+        protected Application $application,
+        private readonly string $private = 'Private',
         public $user = null
-    )
-    {
+    ) {
         $this->middleware(function ($request, $next) {
             return $next($request);
         });
     }
-
 
     /**
      * Query data.

--- a/tests/Unit/Screen/ScreenSerializeTest.php
+++ b/tests/Unit/Screen/ScreenSerializeTest.php
@@ -6,8 +6,8 @@ namespace Orchid\Tests\Unit\Screen;
 
 use Illuminate\Support\Facades\DB;
 use Orchid\Platform\Models\User;
-use Orchid\Tests\App\Screens\SerializeScreen;
 use Orchid\Tests\App\Screens\SerializeRetrievableScreen;
+use Orchid\Tests\App\Screens\SerializeScreen;
 use Orchid\Tests\TestUnitCase;
 use ReflectionClass;
 use ReflectionException;

--- a/tests/Unit/Screen/ScreenSerializeTest.php
+++ b/tests/Unit/Screen/ScreenSerializeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Unit\Screen;
+
+use Illuminate\Support\Facades\DB;
+use Orchid\Platform\Models\User;
+use Orchid\Tests\App\Screens\SerializeScreen;
+use Orchid\Tests\App\Screens\SerializeRetrievableScreen;
+use Orchid\Tests\TestUnitCase;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionProperty;
+
+class ScreenSerializeTest extends TestUnitCase
+{
+    /**
+     * Ensures that an empty screen property is correctly serialized and deserialized.
+     *
+     * @throws ReflectionException
+     */
+    public function testEmptyProperty(): void
+    {
+        $screen = app()->make(SerializeScreen::class);
+        $serializedScreen = serialize($screen);
+
+        $this->assertSame(
+            'O:40:"Orchid\Tests\App\Screens\SerializeScreen":2:{s:6:"public";s:6:"Public";s:4:"user";N;}',
+            $serializedScreen,
+            'The serialized string does not match the expected output.'
+        );
+
+        $unserializedScreen = unserialize($serializedScreen);
+        $reflectionClass = new ReflectionClass($unserializedScreen);
+
+        collect($reflectionClass->getProperties())
+            ->each(function (ReflectionProperty $property) use ($unserializedScreen) {
+                $this->assertTrue(
+                    $property->isInitialized($unserializedScreen),
+                    "The property {$property->getName()} is not initialized."
+                );
+            });
+    }
+
+    /**
+     * Tests the serialization and deserialization of a screen with a populated property.
+     *
+     * The user's name is intentionally changed without saving to test how this affects serialization.
+     *
+     * @throws ReflectionException
+     */
+    public function testWithProperty(): void
+    {
+        $user = User::factory()->create();
+
+        // Intentionally change the user's name without saving it
+        $user->name = 'Changed Name';
+
+        $screen = app()->make(SerializeScreen::class, ['user' => $user]);
+        $serializedScreen = serialize($screen);
+
+        // Ensure the user's email is present in the serialized object
+        $this->assertStringContainsString($user->email, $serializedScreen);
+
+        DB::enableQueryLog();
+
+        // Deserialize the screen
+        $unserializedScreen = unserialize($serializedScreen);
+        $queries = DB::getQueryLog();
+
+        // Ensure no SQL queries were executed during deserialization
+        $this->assertEmpty($queries);
+
+        $this->assertSame($unserializedScreen->user->getKey(), $user->getKey());
+        $this->assertSame($unserializedScreen->user->name, 'Changed Name');
+    }
+
+    /**
+     * Ensures that an empty screen property is correctly serialized and deserialized
+     * when using the ModelStateRetrievable trait.
+     *
+     * @throws ReflectionException
+     */
+    public function testEmptyPropertyRetrievable(): void
+    {
+        $screen = app()->make(SerializeRetrievableScreen::class);
+        $serializedScreen = serialize($screen);
+
+        $this->assertSame(
+            'O:51:"Orchid\Tests\App\Screens\SerializeRetrievableScreen":0:{}',
+            $serializedScreen,
+            'The serialized string does not match the expected output.'
+        );
+
+        $unserializedScreen = unserialize($serializedScreen);
+        $reflectionClass = new ReflectionClass($unserializedScreen);
+
+        collect($reflectionClass->getProperties())
+            ->each(function (ReflectionProperty $property) use ($unserializedScreen) {
+                $this->assertTrue(
+                    $property->isInitialized($unserializedScreen),
+                    "The property {$property->getName()} is not initialized."
+                );
+            });
+    }
+
+    /**
+     * Tests serialization and deserialization with the ModelStateRetrievable trait.
+     *
+     * Ensures that only the necessary information is serialized, and the model is
+     * retrieved via an SQL query upon deserialization.
+     *
+     * @throws ReflectionException
+     */
+    public function testWithPropertyRetrievable(): void
+    {
+        $user = User::factory()->create();
+
+        // Intentionally change the user's name without saving it
+        $user->name = 'Changed Name';
+
+        $screen = app()->make(SerializeRetrievableScreen::class, ['user' => $user]);
+        $serializedScreen = serialize($screen);
+
+        // Ensure the user's email is not present in the serialized object
+        $this->assertStringNotContainsString($user->email, $serializedScreen);
+
+        DB::enableQueryLog();
+
+        // Deserialize the screen
+        $unserializedScreen = unserialize($serializedScreen);
+        $query = collect(DB::getQueryLog())->first();
+
+        // Verify the correct SQL query was executed to retrieve the user model
+        $this->assertSame('select * from "users" where "users"."id" = ? limit 1', $query['query']);
+        $this->assertSame([$user->id], $query['bindings']);
+
+        $this->assertSame($user->getKey(), $unserializedScreen->user->getKey());
+
+        // Ensure the user's name after deserialization does not match the unsaved change
+        $this->assertNotSame('Changed Name', $unserializedScreen->user->name);
+    }
+}


### PR DESCRIPTION
When we pass arguments to the constructor for dependency injection, we expect these arguments to be properly initialized and available for use with the object's methods after deserialization.

```php
public function __construct(
    private readonly NewsService $newsService,
    private readonly CatalogService $catalogService,
    private readonly ConstructorService $constructorService
) {
    // ...
}
```

However, in the current implementation, this can lead to errors such as:

```php
Serialization of 'Closure' is not allowed
```

This change aims to ensure the reinitialization of the class with all its arguments after deserialization, similar to how it is handled for GET requests. This will help avoid serialization issues and correctly restore the object's state.