### PR TITLE
Add AJAX options to Select field

### DIFF
--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -48,8 +48,7 @@ export default class extends ApplicationController {
                 axios
                 .get(ajaxOptionsUrl, { query })
                 .then((response) => {
-                    console.log(1);
-                    callback(response.data.items);
+                    callback(response.data.options);
                 });
             };
         

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -37,16 +37,18 @@ export default class extends ApplicationController {
             }
         };
 
-        const fromUrl = select.getAttribute('fromUrl');
+        const fromUrl = select.getAttribute('fromurl');
 
         if (fromUrl) {
-            options['valueField']  = select.getAttribute('ajaxvaluefield') ?? 'value';
-            options['labelField']  = select.getAttribute('ajaxlabelfield') ?? 'label';
+            const fromUrlOptions = JSON.parse(select.getAttribute('fromurl'));
+
+            options['valueField']  = fromUrlOptions['value'];
+            options['labelField']  = fromUrlOptions['label'];
             options['searchField'] = [options['valueField'], options['labelField']];
 
             options['load'] = async (query, callback) => {
                 axios
-                .get(fromUrl, {params: {query}})
+                .get(fromUrlOptions['url'], {params: {query}})
                 .then((response) => {
                     callback(response.data.options);
                 });

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -37,16 +37,16 @@ export default class extends ApplicationController {
             }
         };
 
-        const ajaxOptionsUrl = select.getAttribute('ajaxoptionsurl');
+        const fromUrl = select.getAttribute('fromUrl');
 
-        if (ajaxOptionsUrl) {
+        if (fromUrl) {
             options['valueField']  = select.getAttribute('ajaxvaluefield') ?? 'value';
             options['labelField']  = select.getAttribute('ajaxlabelfield') ?? 'label';
             options['searchField'] = [options['valueField'], options['labelField']];
 
             options['load'] = async (query, callback) => {
                 axios
-                .get(ajaxOptionsUrl, {params: {query}})
+                .get(fromUrl, {params: {query}})
                 .then((response) => {
                     callback(response.data.options);
                 });

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -46,7 +46,7 @@ export default class extends ApplicationController {
 
             options['load'] = async (query, callback) => {
                 axios
-                .get(ajaxOptionsUrl, { query })
+                .get(ajaxOptionsUrl, {params: {query}})
                 .then((response) => {
                     callback(response.data.options);
                 });

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -18,14 +18,14 @@ export default class extends ApplicationController {
             plugins.push('clear_button');
         }
 
-        this.choices = new TomSelect(select, {
+        const options = {
             create: this.data.get('allow-add') === 'true',
             allowEmptyOption: true,
             maxOptions: 'null',
             placeholder: select.getAttribute('placeholder') === 'false' ? '' : select.getAttribute('placeholder'),
             preload: true,
             plugins,
-            maxItems: select.getAttribute('maximumSelectionLength') || (select.hasAttribute('multiple') ? null : 1),
+            maxItems: select.getAttribute('maximumSelectionLength') || select.hasAttribute('multiple') ? null : 1,
             render: {
                 option_create: (data, escape) => `<div class="create">${this.data.get('message-add')} <strong>${escape(data.input)}</strong>&hellip;</div>`,
                 no_results: () => `<div class="no-results">${this.data.get('message-notfound')}</div>`,
@@ -35,7 +35,51 @@ export default class extends ApplicationController {
                 this.setTextboxValue('');
                 this.refreshOptions(false);
             }
-        });
+        };
+
+        const ajaxOptionsUrl = select.getAttribute('ajaxoptionsurl');
+
+        if (ajaxOptionsUrl) {
+            options['valueField']  = select.getAttribute('ajaxvaluefield') ?? 'value';
+            options['labelField']  = select.getAttribute('ajaxlabelfield') ?? 'label';
+            options['searchField'] = [options['valueField'], options['labelField']];
+
+            options['load'] = async (query, callback) => {
+                axios
+                .get(ajaxOptionsUrl, { query })
+                .then((response) => {
+                    console.log(1);
+                    callback(response.data.items);
+                });
+            };
+        
+            options['render'] = {
+                option: function(item, escape) {
+                    return `<div class="py-2 d-flex">
+                                <div>
+                                    <div class="mb-1">
+                                        <span class="h4">
+                                            ${ escape(item[options['labelField']]) }
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>`;
+                },
+                item: function(item, escape) {
+                    return `<div class="py-2 d-flex">
+                                <div>
+                                    <div class="mb-1">
+                                        <span class="h4">
+                                            ${ escape(item[options['labelField']]) }
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>`;
+                }
+            }
+        }
+
+        this.choices = new TomSelect(select, options);
     }
 
     /**

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -68,8 +68,8 @@ class Select extends Field implements ComplexFieldConcern
         'tags',
         'maximumSelectionLength',
         'ajaxOptionsUrl',
-		'ajaxValueField',
-		'ajaxLabelField',
+        'ajaxValueField',
+        'ajaxLabelField',
     ];
 
     public function __construct()

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -67,7 +67,7 @@ class Select extends Field implements ComplexFieldConcern
         'tabindex',
         'tags',
         'maximumSelectionLength',
-        'ajaxOptionsUrl',
+        'fromUrl',
         'ajaxValueField',
         'ajaxLabelField',
     ];

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -67,6 +67,9 @@ class Select extends Field implements ComplexFieldConcern
         'tabindex',
         'tags',
         'maximumSelectionLength',
+        'ajaxOptionsUrl',
+		'ajaxValueField',
+		'ajaxLabelField',
     ];
 
     public function __construct()

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -68,8 +68,6 @@ class Select extends Field implements ComplexFieldConcern
         'tags',
         'maximumSelectionLength',
         'fromUrl',
-        'ajaxValueField',
-        'ajaxLabelField',
     ];
 
     public function __construct()
@@ -153,6 +151,18 @@ class Select extends Field implements ComplexFieldConcern
         $key = $key ?? $builder->getModel()->getKeyName();
 
         return $this->setFromEloquent($builder->get(), $name, $key);
+    }
+
+    public function fromUrl(string $url, string $value, ?string $label = null): self
+    {
+        $key = $label ?? $value;
+
+        return $this->set('fromUrl', json_encode(
+			array(
+			'url'   => $url,
+			'value' => $value,
+			'label' => $key
+		)));
     }
 
     public function empty(string $name = '', string $key = ''): self


### PR DESCRIPTION
This PR adds the option to load Select values via AJAX using Tom's own [remote feature](https://tom-select.js.org/examples/remote/).

Example:

```
Select::make( 'cities' )
    ->title( __( 'Cities' ) )
    ->ajaxOptionsUrl( 'https://example.com/api/cities' )
    ->horizontal(),
```

The API must return an array like:

```
{
    "options": [
        {
            "value": 1,
            "label": "Example"
        }
    ]
}
```

I also added the option to change the "value" and "label" key names.

---

I think it's valid to discuss the new attributes' names first and then decide whether to add them as inline attributes or normal ones.