### PR TITLE
Prevent CSRF token from being leaked to cross origin requests

### DIFF
--- a/resources/js/controllers/html_load_controller.js
+++ b/resources/js/controllers/html_load_controller.js
@@ -41,8 +41,21 @@ export default class extends ApplicationController {
         window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
         window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
+        axios.interceptors.request.use(function (config) {
+            const url = new URL(config.url);
+
+            if (url.origin !== window.location.origin) {
+                delete config.headers['X-CSRF-TOKEN'];
+            }
+            return config;
+        });
+
         document.addEventListener("turbo:before-fetch-request", (event) => {
-            event.detail.fetchOptions.headers["X-CSRF-TOKEN"] = token.content;
+            const url = new URL(config.url);
+
+            if (url.origin !== window.location.origin) {
+                event.detail.fetchOptions.headers["X-CSRF-TOKEN"] = token.content;
+            }
         });
 
     }

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -48,8 +48,7 @@ export default class extends ApplicationController {
                 axios
                 .get(ajaxOptionsUrl, { query })
                 .then((response) => {
-                    console.log(1);
-                    callback(response.data.items);
+                    callback(response.data.options);
                 });
             };
         

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -37,16 +37,18 @@ export default class extends ApplicationController {
             }
         };
 
-        const fromUrl = select.getAttribute('fromUrl');
+        const fromUrl = select.getAttribute('fromurl');
 
         if (fromUrl) {
-            options['valueField']  = select.getAttribute('ajaxvaluefield') ?? 'value';
-            options['labelField']  = select.getAttribute('ajaxlabelfield') ?? 'label';
+            const fromUrlOptions = JSON.parse(select.getAttribute('fromurl'));
+
+            options['valueField']  = fromUrlOptions['value'];
+            options['labelField']  = fromUrlOptions['label'];
             options['searchField'] = [options['valueField'], options['labelField']];
 
             options['load'] = async (query, callback) => {
                 axios
-                .get(fromUrl, {params: {query}})
+                .get(fromUrlOptions['url'], {params: {query}})
                 .then((response) => {
                     callback(response.data.options);
                 });

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -37,16 +37,16 @@ export default class extends ApplicationController {
             }
         };
 
-        const ajaxOptionsUrl = select.getAttribute('ajaxoptionsurl');
+        const fromUrl = select.getAttribute('fromUrl');
 
-        if (ajaxOptionsUrl) {
+        if (fromUrl) {
             options['valueField']  = select.getAttribute('ajaxvaluefield') ?? 'value';
             options['labelField']  = select.getAttribute('ajaxlabelfield') ?? 'label';
             options['searchField'] = [options['valueField'], options['labelField']];
 
             options['load'] = async (query, callback) => {
                 axios
-                .get(ajaxOptionsUrl, {params: {query}})
+                .get(fromUrl, {params: {query}})
                 .then((response) => {
                     callback(response.data.options);
                 });

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -46,7 +46,7 @@ export default class extends ApplicationController {
 
             options['load'] = async (query, callback) => {
                 axios
-                .get(ajaxOptionsUrl, { query })
+                .get(ajaxOptionsUrl, {params: {query}})
                 .then((response) => {
                     callback(response.data.options);
                 });

--- a/resources/js/controllers/select_controller.js
+++ b/resources/js/controllers/select_controller.js
@@ -18,14 +18,14 @@ export default class extends ApplicationController {
             plugins.push('clear_button');
         }
 
-        this.choices = new TomSelect(select, {
+        const options = {
             create: this.data.get('allow-add') === 'true',
             allowEmptyOption: true,
             maxOptions: 'null',
             placeholder: select.getAttribute('placeholder') === 'false' ? '' : select.getAttribute('placeholder'),
             preload: true,
             plugins,
-            maxItems: select.getAttribute('maximumSelectionLength') || (select.hasAttribute('multiple') ? null : 1),
+            maxItems: select.getAttribute('maximumSelectionLength') || select.hasAttribute('multiple') ? null : 1,
             render: {
                 option_create: (data, escape) => `<div class="create">${this.data.get('message-add')} <strong>${escape(data.input)}</strong>&hellip;</div>`,
                 no_results: () => `<div class="no-results">${this.data.get('message-notfound')}</div>`,
@@ -35,7 +35,51 @@ export default class extends ApplicationController {
                 this.setTextboxValue('');
                 this.refreshOptions(false);
             }
-        });
+        };
+
+        const ajaxOptionsUrl = select.getAttribute('ajaxoptionsurl');
+
+        if (ajaxOptionsUrl) {
+            options['valueField']  = select.getAttribute('ajaxvaluefield') ?? 'value';
+            options['labelField']  = select.getAttribute('ajaxlabelfield') ?? 'label';
+            options['searchField'] = [options['valueField'], options['labelField']];
+
+            options['load'] = async (query, callback) => {
+                axios
+                .get(ajaxOptionsUrl, { query })
+                .then((response) => {
+                    console.log(1);
+                    callback(response.data.items);
+                });
+            };
+        
+            options['render'] = {
+                option: function(item, escape) {
+                    return `<div class="py-2 d-flex">
+                                <div>
+                                    <div class="mb-1">
+                                        <span class="h4">
+                                            ${ escape(item[options['labelField']]) }
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>`;
+                },
+                item: function(item, escape) {
+                    return `<div class="py-2 d-flex">
+                                <div>
+                                    <div class="mb-1">
+                                        <span class="h4">
+                                            ${ escape(item[options['labelField']]) }
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>`;
+                }
+            }
+        }
+
+        this.choices = new TomSelect(select, options);
     }
 
     /**

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -68,8 +68,8 @@ class Select extends Field implements ComplexFieldConcern
         'tags',
         'maximumSelectionLength',
         'ajaxOptionsUrl',
-		'ajaxValueField',
-		'ajaxLabelField',
+        'ajaxValueField',
+        'ajaxLabelField',
     ];
 
     public function __construct()

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -67,7 +67,7 @@ class Select extends Field implements ComplexFieldConcern
         'tabindex',
         'tags',
         'maximumSelectionLength',
-        'ajaxOptionsUrl',
+        'fromUrl',
         'ajaxValueField',
         'ajaxLabelField',
     ];

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -67,6 +67,9 @@ class Select extends Field implements ComplexFieldConcern
         'tabindex',
         'tags',
         'maximumSelectionLength',
+        'ajaxOptionsUrl',
+		'ajaxValueField',
+		'ajaxLabelField',
     ];
 
     public function __construct()

--- a/src/Screen/Fields/Select.php
+++ b/src/Screen/Fields/Select.php
@@ -68,8 +68,6 @@ class Select extends Field implements ComplexFieldConcern
         'tags',
         'maximumSelectionLength',
         'fromUrl',
-        'ajaxValueField',
-        'ajaxLabelField',
     ];
 
     public function __construct()
@@ -153,6 +151,18 @@ class Select extends Field implements ComplexFieldConcern
         $key = $key ?? $builder->getModel()->getKeyName();
 
         return $this->setFromEloquent($builder->get(), $name, $key);
+    }
+
+    public function fromUrl(string $url, string $value, ?string $label = null): self
+    {
+        $key = $label ?? $value;
+
+        return $this->set('fromUrl', json_encode(
+			array(
+			'url'   => $url,
+			'value' => $value,
+			'label' => $key
+		)));
     }
 
     public function empty(string $name = '', string $key = ''): self


### PR DESCRIPTION
Currently, the code inside the html_load_controller.js makes the CSRF token being sent to every Axios and Turbo request:

https://github.com/orchidsoftware/platform/blob/7e63b9c68af945c09f1dbb50896ad9f135a0e324/resources/js/controllers/html_load_controller.js#L41-L46

This, however, leaks the token to cross-origin requests as well, defeating the whole purpose of CSRF protection.

This fix prevents the token from being leaked to cross-origin requests.

For Axios, it is certain that it needs to be implemented. For Turbo, I'm not sure the "turbo:before-fetch-request" is triggered during cross-origin requests, but I added the fix there as well, just in case.