### PR TITLE
Prevent CSRF token from being leaked to cross-origin requests

### DIFF
--- a/resources/js/controllers/html_load_controller.js
+++ b/resources/js/controllers/html_load_controller.js
@@ -41,8 +41,21 @@ export default class extends ApplicationController {
         window.axios.defaults.headers.common['X-CSRF-TOKEN'] = token.content;
         window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
+        axios.interceptors.request.use(function (config) {
+            const url = new URL(config.url);
+
+            if (url.origin !== window.location.origin) {
+                delete config.headers['X-CSRF-TOKEN'];
+            }
+            return config;
+        });
+
         document.addEventListener("turbo:before-fetch-request", (event) => {
-            event.detail.fetchOptions.headers["X-CSRF-TOKEN"] = token.content;
+            const url = new URL(config.url);
+
+            if (url.origin !== window.location.origin) {
+                event.detail.fetchOptions.headers["X-CSRF-TOKEN"] = token.content;
+            }
         });
 
     }


### PR DESCRIPTION
Currently, the code inside the html_load_controller.js makes the CSRF token being sent to every Axios and Turbo request:

https://github.com/orchidsoftware/platform/blob/7e63b9c68af945c09f1dbb50896ad9f135a0e324/resources/js/controllers/html_load_controller.js#L41-L46

This, however, leaks the token to cross-origin requests as well, defeating the whole purpose of CSRF protection.

This fix prevents the token from being leaked to cross-origin requests.

For Axios, it is certain that it needs to be implemented. For Turbo, I'm not sure the "turbo:before-fetch-request" is triggered during cross-origin requests, but I added the fix there as well, just in case.