### PR TITLE
Fixing 12-hour format to 24-hour format of an hour with leading zeros

### DIFF
--- a/src/Screen/Components/Cells/DateTimeSplit.php
+++ b/src/Screen/Components/Cells/DateTimeSplit.php
@@ -19,7 +19,7 @@ class DateTimeSplit extends Component
     public function __construct(
         protected mixed $value,
         protected string $upperFormat = 'M j, Y',
-        protected string $lowerFormat = 'D, h:i',
+        protected string $lowerFormat = 'D, H:i',
         protected DateTimeZone|null|string $tz = null,
     ) {}
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Fixing 12-hour format to 24-hour format of an hour with leading zeros on `DateTimeSplit` component
