### PR TITLE
PHPStan issue when the return type of Field::value is self

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -148,7 +148,7 @@ class Field implements Fieldable, Htmlable
      *
      * @param mixed $value The value to be set for the 'value' attribute.
      */
-    public function value(mixed $value): self
+    public function value(mixed $value): static
     {
         return $this->set('value', $value);
     }


### PR DESCRIPTION
Issue
When the return type of the value method is self, PHPStan gives this error:

![Screenshot 2024-09-24 165425](https://github.com/user-attachments/assets/3fd0a2a8-a446-4de2-9db8-165e1654ccc4)

for this code snippet that inherit your **value** method.
```
public function value($value): static
    {
        if (empty($value)) {
            $value = [];
        }

        return parent::value($value);
    }

```
   
PHPStan works correctly only when you change the return type from **self** to **static**, as I suggested in my PR. So, you need to change to **static** if you want the method to be compatible with subclasses.


