### PR TITLE
Added html encoding on alert.blade.php partial

### DIFF
--- a/resources/views/partials/alert.blade.php
+++ b/resources/views/partials/alert.blade.php
@@ -13,7 +13,7 @@
         {{ __('Change a few things up and try submitting again.') }}
         <ul>
             @foreach ($errors->all() as $error)
-                <li>{{ $error }}</li>
+                <li>{!! $error !!}</li>
             @endforeach
         </ul>
     </div>


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Adding HTML Encoding on alert.blade.php, to encode correctly html text markdowns (like <strong>, <b>, etc...) and enrich errors texts.
