### PR TITLE
Add addClass() method to Field class for easier class manipulation

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -31,6 +31,7 @@ use Throwable;
  * @method self style($value = true)
  * @method self tabindex($value = true)
  * @method self autocomplete($value = true)
+ * @method self addClass($value = true)
  */
 class Field implements Fieldable, Htmlable
 {
@@ -541,5 +542,23 @@ class Field implements Fieldable, Htmlable
     public function toHtml()
     {
         return $this->render()->toHtml();
+    }
+
+    /**
+     * Add a class to the field including the existing classes.
+     *
+     * @param string|array $classes
+     *
+     * @return static
+     */
+    public function addClass(string|array $classes): self
+    {
+        $currentClasses = array_filter(explode(' ', $this->get('class', '')));
+        $newClasses = is_array($classes) ? $classes : explode(' ', $classes);
+
+        $mergedClasses = array_unique(array_merge($currentClasses, $newClasses));
+        $this->set('class', implode(' ', array_filter($mergedClasses)));
+
+        return $this;
     }
 }

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -217,4 +217,44 @@ class FieldTest extends TestUnitCase
 
         $this->assertSame('3.141', Input::make('numeric')->getOldValue());
     }
+
+    public function testAddsSingleClassToEmptyClassAttribute(): void
+    {
+        $field = Field::make('test');
+        $field->addClass('new-class');
+
+        $this->assertEquals('new-class', $field->get('class'));
+    }
+
+    public function testAddsMultipleClassesToEmptyClassAttribute(): void
+    {
+        $field = Field::make('test');
+        $field->addClass('class1 class2');
+
+        $this->assertEquals('class1 class2', $field->get('class'));
+    }
+
+    public function testAddsArrayOfClassesToEmptyClassAttribute(): void
+    {
+        $field = Field::make('test');
+        $field->addClass(['class1', 'class2']);
+
+        $this->assertEquals('class1 class2', $field->get('class'));
+    }
+
+    public function testAddsNewClassToExistingClasses(): void
+    {
+        $field = Field::make('test')->set('class', 'existing-class');
+        $field->addClass('new-class');
+
+        $this->assertEquals('existing-class new-class', $field->get('class'));
+    }
+
+    public function testDoesNotDuplicateClasses(): void
+    {
+        $field = Field::make('test')->set('class', 'existing-class');
+        $field->addClass('existing-class new-class');
+
+        $this->assertEquals('existing-class new-class', $field->get('class'));
+    }
 }


### PR DESCRIPTION
# Add addClass() method to Field class

This PR introduces a new `addClass()` method to the `Field` class. This method allows adding new classes to the existing ones without overwriting them.

## Changes

- Added `addClass()` method to `Field` class
- Updated class documentation
- Added unit tests for the new method
- Updated CHANGELOG.md

## Usage

```php
$field->addClass('new-class');
$field->addClass(['class1', 'class2']);