### PR TITLE
Fast Attribute Access

### DIFF
--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -22,10 +22,16 @@ trait AsSource
      *
      * @return mixed|null The value of the field, or null if the field is not found.
      */
-    public function getContent(string $field)
+    public function getContent(string $field): mixed
     {
-        return Arr::get($this->toArray(), $field) // Try to get the field value from the object's array representation.
+        // When field does not contain a dot, it is a simple field name.
+        // And we not need to use cast model to array for this case.
+        if (!str_contains($field, '.')) {
+            return $this->getAttribute($field);
+        }
+
+        return $this->getAttribute($field) // Try to get the field value from the object's attributes.
             ?? Arr::get($this->getRelations(), $field) // Try to get the field value from the object's relations.
-            ?? $this->getAttribute($field);  // Try to get the field value from the object's attributes.
+            ?? Arr::get($this, $field); // Try to get the field value from the object's array representation.
     }
 }

--- a/src/Screen/AsSource.php
+++ b/src/Screen/AsSource.php
@@ -26,7 +26,7 @@ trait AsSource
     {
         // When field does not contain a dot, it is a simple field name.
         // And we not need to use cast model to array for this case.
-        if (!str_contains($field, '.')) {
+        if (! str_contains($field, '.')) {
             return $this->getAttribute($field);
         }
 


### PR DESCRIPTION
When calling the `getContent()` method, the model is transformed into a flat structure, allowing for dot notation searches.

However, converting the model to an array triggers all its type casts.

In my experience, direct access to specific attributes is far more common than dot notation usage. Therefore, in this Pull Request, I adjusted the value retrieval order so that type casting only occurs when dot notation is needed.

In my experiments, this change resulted in a noticeable performance improvement.