### PR TITLE
Use `whereLike` for case-insensitive search

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -47,6 +47,9 @@
         },
         "trim_array_spaces": true,
         "single_trait_insert_per_statement": false,
-        "new_with_parentheses": false
+        "new_with_parentheses": false,
+        "php_unit_method_casing": {
+            "case": "camel_case"
+        }
     }
 }

--- a/src/Platform/Http/Controllers/RelationController.php
+++ b/src/Platform/Http/Controllers/RelationController.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Http\Controllers;
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Crypt;
 use Orchid\Platform\Http\Requests\RelationRequest;
-use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
 
 class RelationController extends Controller
 {
@@ -84,7 +84,7 @@ class RelationController extends Controller
 
         if (InstalledVersions::satisfies(new VersionParser, 'laravel/framework', '>11.17.0')) {
             $model = $model->where(function ($query) use ($name, $search, $searchColumns) {
-                $value = '%' . $search . '%';
+                $value = '%'.$search.'%';
 
                 $query->whereLike($name, $value);
 
@@ -99,7 +99,7 @@ class RelationController extends Controller
              * @deprecated logic for older Laravel versions
              */
             $model = $model->where(function ($query) use ($name, $search, $searchColumns) {
-                $value = '%' . $search . '%';
+                $value = '%'.$search.'%';
 
                 $query->where($name, 'like', $value);
 

--- a/src/Platform/Http/Controllers/RelationController.php
+++ b/src/Platform/Http/Controllers/RelationController.php
@@ -10,6 +10,8 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection as BaseCollection;
 use Illuminate\Support\Facades\Crypt;
 use Orchid\Platform\Http\Requests\RelationRequest;
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 
 class RelationController extends Controller
 {
@@ -80,14 +82,34 @@ class RelationController extends Controller
             });
         }
 
-        $model = $model->where(function ($query) use ($name, $search, $searchColumns) {
-            $query->where($name, 'like', '%'.$search.'%');
-            if ($searchColumns !== null) {
-                foreach ($searchColumns as $column) {
-                    $query->orWhere($column, 'like', '%'.$search.'%');
-                }
-            }
-        });
+        if (InstalledVersions::satisfies(new VersionParser, 'laravel/framework', '>11.17.0')) {
+            $model = $model->where(function ($query) use ($name, $search, $searchColumns) {
+                $value = '%' . $search . '%';
+
+                $query->whereLike($name, $value);
+
+                $query->when($searchColumns !== null, function ($query) use ($searchColumns, $value) {
+                    foreach ($searchColumns as $column) {
+                        $query->orWhereLike($column, $value);
+                    }
+                });
+            });
+        } else {
+            /**
+             * @deprecated logic for older Laravel versions
+             */
+            $model = $model->where(function ($query) use ($name, $search, $searchColumns) {
+                $value = '%' . $search . '%';
+
+                $query->where($name, 'like', $value);
+
+                $query->when($searchColumns !== null, function ($query) use ($searchColumns, $value) {
+                    foreach ($searchColumns as $column) {
+                        $query->orWhere($column, 'like', $value);
+                    }
+                });
+            });
+        }
 
         return $model
             ->limit($chunk)


### PR DESCRIPTION
This updates search functionality to use the `whereLike` method, introduced in Laravel v11.17.0, for performing case-insensitive searches. For Laravel versions below 11.17.0, the existing implementation using `like` is retained.  

The `whereLike` method adapts to the specifics of different databases:  
- **PostgreSQL**: Uses `ilike` for case-insensitive search.  
- **MySQL**: Uses `like`.  
- **SQLite**: Uses `like`.  
- **SQL Server**: Behavior depends on the column/database collation.  