### PR TITLE
Improve overall accessibility

### DIFF
--- a/resources/js/controllers/accordion_controller.js
+++ b/resources/js/controllers/accordion_controller.js
@@ -1,0 +1,51 @@
+import ApplicationController from "./application_controller";
+
+export default class extends ApplicationController {
+
+    /**
+     * Automatically called when the controller is connected to the DOM.
+     */
+    connect() {
+        // Ensures elements are focusable using Tab
+        this.accordionHeadings = this.element.querySelectorAll('.accordion-heading');
+
+        this.accordionHeadings.forEach(heading => {
+            heading.setAttribute('tabindex', '0');
+
+            // Adds the listener for keyboard behavior
+            heading.addEventListener('keydown', this.handleKeydown);
+        });
+    }
+
+    /**
+     * Disconnects events/handlers when the controller is removed from the DOM.
+     */
+    disconnect() {
+        this.accordionHeadings.forEach(heading => {
+            // Removes the listener to avoid memory leaks
+            heading.removeEventListener('keydown', this.handleKeydown);
+        });
+    }
+
+    /**
+     * Handles keyboard behavior for opening/closing the accordion.
+     */
+    handleKeydown = (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+
+            const heading = event.currentTarget;
+            const isExpanded = heading.getAttribute('aria-expanded') === 'true';
+            heading.setAttribute('aria-expanded', !isExpanded);
+
+            // Show/hide the associated content
+            const targetId = heading.getAttribute('data-bs-target') || heading.getAttribute('aria-controls');
+            if (targetId) {
+                const targetElement = document.querySelector(targetId);
+                if (targetElement) {
+                    targetElement.classList.toggle('show', !isExpanded);
+                }
+            }
+        }
+    };
+}

--- a/resources/sass/core/reset.scss
+++ b/resources/sass/core/reset.scss
@@ -10,6 +10,10 @@ body {
   line-height: $line-height-base;
 }
 
+body[data-theme="dark"] :focus-visible {
+  outline: 2px solid $blue !important;  /* Lighter blue for dark theme */
+}
+
 *:focus {
   outline: 0 !important;
 }
@@ -31,6 +35,11 @@ a:hover,
 a:focus {
   color: $link-hover-color;
   text-decoration: none;
+}
+
+a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible, [tabindex]:focus-visible {
+  outline: 2px auto $primary !important;  /* Blue outline */
+  outline-offset: 3px !important;         /* Space between the outline and element */
 }
 
 label {
@@ -135,6 +144,14 @@ blockquote {
 .accordion-inner {
   border-color: $border-color;
   border-radius: $border-radius-base;
+}
+
+.accordion-heading:focus-visible {
+  outline: 2px solid $light;
+  background-color: $grey;
+  h6{
+    color: $light;
+  }
 }
 
 .alert {
@@ -317,15 +334,21 @@ blockquote {
         border-radius: 0;
         border-color: transparent !important;
         background: transparent !important;
-		&.active {
+		&.active,.focus-visible {
 			border-bottom-color: $primary !important;
             cursor: default;
+            outline: 2px solid $light;
+            background-color: $grey !important;
+            color: $light !important;
 		}
       }
       &.active {
         .nav-link {
           border-bottom-color: $primary !important;
         }
+      }
+      &.focus-visible{
+        box-shadow: 0 0 5px 2px $grey;
       }
     }
   }
@@ -723,4 +746,19 @@ legend {
             @extend .shadow-sm;
         }
     }
+}
+
+.skip {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip:focus-visible {
+  position: static;
+  width: auto;
+  height: auto;
 }

--- a/resources/views/actions/button.blade.php
+++ b/resources/views/actions/button.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-label to provide a descriptive name for the button.
+     - Added aria-hidden to the icon to hide it from screen readers, as it is decorative and does not convey meaningful content.
+ --}}
 @component($typeForm, get_defined_vars())
     <button
             data-controller="button"
@@ -6,10 +11,11 @@
                 data-action="button#confirm"
                 data-button-confirm="{{ $confirm }}"
             @endempty
-        {{ $attributes }}>
+            aria-label="{{ $name ? __('Button: ' . $name) : __('Button') }}"
+            {{ $attributes }}>
 
         @isset($icon)
-            <x-orchid-icon :path="$icon" class="overflow-visible"/>
+            <x-orchid-icon :path="$icon" class="overflow-visible" aria-hidden="true"/>
         @endisset
 
         {{ $name ?? '' }}

--- a/resources/views/actions/dropdown.blade.php
+++ b/resources/views/actions/dropdown.blade.php
@@ -1,19 +1,33 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-expanded to indicate the dropdown state (open or closed).
+     - Added aria-haspopup to specify that the button opens a menu.
+     - Added aria-controls to associate the button with the controlled menu via id.
+     - Added aria-hidden to the icon to hide it from screen readers, as it is decorative and does not convey meaningful content.
+     - Added aria-hidden to the dropdown-menu to ensure it is hidden from screen readers when not visible.
+ --}}
 @component($typeForm, get_defined_vars())
     <button
         {{ $attributes }}
         type="button"
+        aria-label="{{ $name ? __('Button: ' . $name) : __('Button') }}"
         data-bs-toggle="dropdown"
         aria-expanded="false"
+        aria-haspopup="true"
+        aria-controls="dropdown-menu"
     >
         @isset($icon)
-            <x-orchid-icon :path="$icon" class="overflow-visible"/>
+            <x-orchid-icon :path="$icon" class="overflow-visible" aria-hidden="true"/>
         @endisset
 
         {{ $name ?? '' }}
     </button>
 
     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow bg-white"
+         role="menu"
          x-placement="bottom-end"
+         id="dropdown-menu"
+         aria-hidden="true"
     >
         @foreach($list as $item)
             {!!  $item->build($source) !!}

--- a/resources/views/actions/link.blade.php
+++ b/resources/views/actions/link.blade.php
@@ -1,10 +1,16 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-label to provide a descriptive name for the link.
+     - Added aria-hidden to the icon to hide it from screen readers, as it is decorative and does not convey meaningful content.
+ --}}
 @component($typeForm, get_defined_vars())
     <a
         data-turbo="{{ var_export($turbo) }}"
+        aria-label="{{ $name ? __('Navigate to: ' . $name) : __('Navigate') }}"
         {{ $attributes }}
     >
         @isset($icon)
-            <x-orchid-icon :path="$icon" class="overflow-visible"/>
+            <x-orchid-icon :path="$icon" class="overflow-visible" aria-hidden="true"/>
         @endisset
 
         {{ $name ?? '' }}

--- a/resources/views/actions/menu.blade.php
+++ b/resources/views/actions/menu.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-label to provide descriptive names for links and badges, ensuring better screen reader compatibility.
+     - Added aria-hidden to icons to hide decorative elements from screen readers since they do not convey meaningful content.
+--}}
 @isset($title)
     <li class="nav-item mt-3 mb-1">
         <small class="text-muted ms-4 w-100 user-select-none">{{ __($title) }}</small>
@@ -8,15 +13,16 @@
 <li class="nav-item {{ active($active) }}">
     <a data-turbo="{{ var_export($turbo) }}"
         {{ $attributes }}
+        aria-label="{{ $name ? __('Link: ' . $name) : __('Link') }}"
     >
         @isset($icon)
-            <x-orchid-icon :path="$icon" class="overflow-visible"/>
+            <x-orchid-icon :path="$icon" class="overflow-visible" aria-hidden="true"/>
         @endisset
 
         <span class="mx-2">{{ $name ?? '' }}</span>
 
         @isset($badge)
-            <b class="badge rounded-pill bg-{{$badge['class']}} col-auto ms-auto">{{$badge['data']()}}</b>
+            <b class="badge rounded-pill bg-{{$badge['class']}} col-auto ms-auto" aria-label="{{ $badge['data']() ? __('Badge: ' . $badge['data']()) : __('Badge') }}">{{$badge['data']()}}</b>
         @endisset
     </a>
 </li>

--- a/resources/views/actions/modal.blade.php
+++ b/resources/views/actions/modal.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-label to provide descriptive names for interactive elements, ensuring better screen reader compatibility.
+     - Added aria-hidden to icons to hide decorative elements from screen readers since they do not convey meaningful content.
+--}}
 @component($typeForm, get_defined_vars())
     <button type="button"
             {{ $attributes }}
@@ -11,10 +16,11 @@
             @if(!empty($parameters))
                 data-modal-toggle-parameters-value='@json($parameters)'
             @endif
+            aria-label="{{ $name ?? $modalTitle ?? $title ?? __('Open modal') }}"
     >
 
         @isset($icon)
-            <x-orchid-icon :path="$icon" class="overflow-visible"/>
+            <x-orchid-icon :path="$icon" class="overflow-visible" aria-hidden="true"/>
         @endisset
 
         {{ $name ?? '' }}

--- a/resources/views/auth.blade.php
+++ b/resources/views/auth.blade.php
@@ -1,25 +1,32 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="main"` to the outer container `<div>` to designate the primary content area of the page, enabling assistive technologies to skip directly to it.
+    - Added `aria-label` to interactive elements, such as input fields and links, to provide clear and meaningful descriptions for assistive technologies.
+--}}
 @extends('platform::app')
 
 @section('body')
 
-    <div class="container-md">
-        <div class="form-signin h-full min-vh-100 d-flex flex-column justify-content-center">
+    <div class="container-md" role="main">
+        <div class="form-signin h-full min-vh-100 d-flex flex-column justify-content-center" aria-label="Sign-in form">
 
-            <a class="d-flex justify-content-center mb-4 p-0 px-sm-5" href="{{Dashboard::prefix()}}">
+            <a class="d-flex justify-content-center mb-4 p-0 px-sm-5" href="{{Dashboard::prefix()}}" aria-label="Dashboard Home">
                 @includeFirst([config('platform.template.header'), 'platform::header'])
             </a>
 
             <div class="row justify-content-center">
                 <div class="col-md-10 col-lg-6 col-xxl-5 px-md-5">
 
-                    <div class="bg-white p-4 p-sm-5 rounded shadow-sm">
+                    <div class="bg-white p-4 p-sm-5 rounded shadow-sm" role="region" aria-label="Content Area">
                         @yield('content')
                     </div>
                 </div>
             </div>
 
 
-            @includeFirst([config('platform.template.footer'), 'platform::footer'])
+            <footer>
+                @includeFirst([config('platform.template.footer'), 'platform::footer'])
+            </footer>
         </div>
     </div>
 

--- a/resources/views/auth/impersonation.blade.php
+++ b/resources/views/auth/impersonation.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-label to provide descriptive names for interactive elements, ensuring better screen reader compatibility.
+     - Added aria-hidden to icons to hide decorative elements from screen readers since they do not convey meaningful content.
+--}}
 @extends('platform::auth')
 @section('title',__('Access Denied: Viewing as Another User'))
 
@@ -16,8 +21,8 @@
             {{ __("You are currently viewing this page on behalf of a user who does not have access to it. To return to viewing as yourself, please click the 'Switch to My Account' button. It's possible that the page may be displayed correctly when viewed from your own account.") }}
         </p>
 
-        <button id="button-login" type="submit" class="btn btn-default btn-block" tabindex="2">
-            <x-orchid-icon path="bs.box-arrow-in-right" class="small me-2"/> {{__('Switch to My Account')}}
+        <button id="button-login" type="submit" class="btn btn-default btn-block" tabindex="2" aria-label="{{ __('Switch to My Account') }}">
+            <x-orchid-icon path="bs.box-arrow-in-right" class="small me-2" aria-hidden="true"/> {{__('Switch to My Account')}}
         </button>
 
     </form>

--- a/resources/views/auth/lockme.blade.php
+++ b/resources/views/auth/lockme.blade.php
@@ -1,10 +1,19 @@
-<div class="mb-3 d-flex align-items-center">
+{{--
+   Improved Accessibility:
+    - Added aria-labels to provide descriptive labels for the various user interface elements.
+    - Added aria-hidden to appropriate elements to enhance screen reader usability.
+    - Added aria-describedby for improved contextual awareness for screen readers.
+    - Applied visually-hidden class for descriptive help content accessible by screen readers.
+    - Added aria-controls to associate the button with the controlled menu via id.
+--}}
+
+<div class="mb-3 d-flex align-items-center" role="group" aria-label="{{ __('User Information') }}">
     <div class="thumb-sm avatar me-3">
-        <img src="{{ $lockUser->presenter()->image() }}" class="b bg-light" alt="{{ $lockUser->presenter()->title() }}">
+        <img src="{{ $lockUser->presenter()->image() }}" class="b bg-light" alt="{{ $lockUser->presenter()->title() }}" aria-hidden="false">
     </div>
     <div class="d-flex flex-column overflow-hidden small">
-        <span class="text-ellipsis">{{ $lockUser->presenter()->title() }}</span>
-        <span class="text-muted d-block text-ellipsis">{{ $lockUser->presenter()->subTitle() }}</span>
+        <span class="text-ellipsis" aria-label="{{ __('User Name') }}">{{ $lockUser->presenter()->title() }}</span>
+        <span class="text-muted d-block text-ellipsis" aria-label="{{ __('User Role or Subtitle') }}">{{ $lockUser->presenter()->subTitle() }}</span>
     </div>
     <input type="hidden" name="email" required value="{{ $lockUser->email }}">
 </div>
@@ -34,8 +43,9 @@
         </a>
     </div>
     <div class="col-md-6 col-xs-12">
-        <button id="button-login" type="submit" class="btn btn-default btn-block" tabindex="2">
-            <x-orchid-icon path="bs.box-arrow-in-right" class="small me-2"/>
+        <button id="button-login" type="submit" class="btn btn-default btn-block" tabindex="2" aria-label="{{ __('Submit Login Form') }}" aria-describedby="login-button-description">
+            <span id="login-button-description" class="visually-hidden">{{ __('This button submits the login form.') }}</span>
+            <x-orchid-icon path="bs.box-arrow-in-right" class="small me-2" aria-hidden="true"/>
             {{__('Login')}}
         </button>
     </div>

--- a/resources/views/auth/signin.blade.php
+++ b/resources/views/auth/signin.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-label to the Remember Me checkbox for describing its function to screen readers.
+     - Added aria-describedby to associate ARIA help text with interactive elements.
+     - Used aria-hidden on icons that are decorative for screen readers.
+ --}}
 <div class="mb-3">
 
     <label class="form-label">
@@ -33,15 +39,15 @@
     <div class="col-md-6 col-xs-12">
         <label class="form-check">
             <input type="hidden" name="remember">
-            <input type="checkbox" name="remember" value="true"
+            <input type="checkbox" name="remember" value="true" aria-label="{{ __('Remember Me') }}" aria-describedby="remember-help"
                    class="form-check-input" {{ !old('remember') || old('remember') === 'true'  ? 'checked' : '' }}>
-            <span class="form-check-label"> {{__('Remember Me')}}</span>
+            <span id="remember-help" class="form-check-label"> {{__('Remember Me')}}</span>
         </label>
     </div>
     <div class="col-md-6 col-xs-12">
-        <button id="button-login" type="submit" class="btn btn-default btn-block" tabindex="3">
-            <x-orchid-icon path="bs.box-arrow-in-right" class="small me-2"/>
-            {{__('Login')}}
+        <button id="button-login" type="submit" class="btn btn-default btn-block" tabindex="3"  aria-label="{{ __('Login') }}" aria-describedby="button-login-help">
+            <x-orchid-icon path="bs.box-arrow-in-right" class="small me-2" aria-hidden="true"/>
+            {{__('Login')}}<span id="button-login-help" class="visually-hidden"> {{ __('Press to log in to your account') }}</span>
         </button>
     </div>
 </div>

--- a/resources/views/components/notification.blade.php
+++ b/resources/views/components/notification.blade.php
@@ -1,3 +1,10 @@
+{{--
+    Accessibility Improvements:
+     - Added the "button" role to ensure screen readers support links with interactive behavior.
+     - Added aria-label for better screen reader descriptions.
+     - Added aria-describedBy to connect hidden descriptive text to the button.
+     - Added aria-hidden attribute to empty <span> elements used for badges to improve accessibility.
+--}}
 <a href="{{ route('platform.notifications') }}"
    class="m-auto d-flex align-items-center btn btn-link position-relative px-1 py-0 h-100"
    data-controller="notification"
@@ -5,14 +12,20 @@
    data-notification-url="{{ route('platform.api.notifications') }}"
    data-notification-method="post"
    data-notification-interval="{{ config('platform.notifications.interval') }}"
+   aria-label="{{ __('View Notifications') }}"
+   aria-describedBy="notification-desc"
+   role="button"
 >
-    <x-orchid-icon path="bs.bell" width="1.1em" height="1.1em" />
+    <x-orchid-icon path="bs.bell" width="1.1em" height="1.1em" aria-hidden="true"/>
 
     <template id="notification-circle">
-        <x-orchid-icon path="bs.circle-fill" width="0.4em" height="0.4em" />
+        <x-orchid-icon path="bs.circle-fill" width="0.4em" height="0.4em" aria-hidden="true"/>
     </template>
 
-    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" data-notification-target="badge">
+    <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+            data-notification-target="badge"
+            aria-hidden="true">
     </span>
 </a>
+<span id="notification-desc" class="visually-hidden">{{ __('This button opens your notifications panel.') }}</span>
 

--- a/resources/views/components/popover.blade.php
+++ b/resources/views/components/popover.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+     - Added aria-describedby to reference the description of the popover.
+     - Added aria-hidden on the orchid icon to hide it from screen readers since it is decorative.
+--}}
 <sup class="text-body-emphasis"
      role="button"
      data-controller="popover"
@@ -8,6 +13,11 @@
      data-bs-placement="{{ $placement }}"
      data-bs-delay-show="300"
      data-bs-delay-hide="200"
-     data-bs-content="{{ $content }}">
-    <x-orchid-icon path="bs.question-lg" width="1em" height="1em"/>
+     data-bs-content="{{ $content }}"
+     aria-label="{{ __('More information') }}"
+     aria-describedby="popover-description">
+    <x-orchid-icon path="bs.question-lg" width="1em" height="1em" aria-hidden="true"/>
 </sup>
+<span id="popover-description" class="visually-hidden">
+    {{ __('This button provides additional information in a popover.') }}
+</span>

--- a/resources/views/components/stream.blade.php
+++ b/resources/views/components/stream.blade.php
@@ -1,9 +1,15 @@
+{{--
+    Accessibility Improvements:
+    - Used aria-live="polite" to notify assistive technologies about content updates without interrupting the user.
+    - Added role="region" to define a landmark region for better navigation by assistive technologies.
+--}}
+
 @props(['target', 'action', 'push', 'rule' => \Orchid\Support\Facades\Dashboard::isPartialRequest()])
 
 
 @if(filter_var($rule, FILTER_VALIDATE_BOOLEAN))
     @fragment($target)
-        <turbo-stream target="{{ $target }}" action="{{ $action ?? 'replace' }}">
+        <turbo-stream target="{{ $target }}" action="{{ $action ?? 'replace' }}" aria-live="polite" role="region">
             <template>
                 {!! $slot !!}
             </template>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,11 +1,18 @@
+{{--
+    Accessibility Enhancements:
+    - Added role `search` to the container wrapping the search bar to identify the search region and make it easily discoverable by users with assistive tools.
+    - Added role `button` to the "to-top" element (scroll-to-top button) to ensure it is semantically recognized as a button for proper usability and keyboard navigation.
+    - Added role `alert` to the alert/notification section to ensure important messages are immediately recognized and announced by assistive technologies.
+--}}
 @extends(config('platform.workspace', 'platform::workspace.compact'))
 
 @section('aside')
-    <div class="aside col-xs-12 col-xxl-2 bg-dark d-flex flex-column" data-controller="menu">
+    <div class="aside col-xs-12 col-xxl-2 bg-dark d-flex flex-column" data-controller="menu"
+         aria-label="Sidebar menu">
         <header class="d-xl-block p-3 mt-xl-4 w-100 d-flex align-items-center">
             <a href="#" class="header-toggler d-xl-none me-auto order-first d-flex align-items-center lh-1"
                data-action="click->menu#toggle">
-                <x-orchid-icon path="bs.three-dots-vertical" class="icon-menu"/>
+                <x-orchid-icon path="bs.three-dots-vertical" class="icon-menu" aria-hidden="true"/>
 
                 <span class="ms-2">@yield('title')</span>
             </a>
@@ -17,26 +24,28 @@
 
         <nav class="aside-collapse w-100 d-xl-flex flex-column collapse-horizontal" id="headerMenuCollapse">
 
-            @include('platform::partials.search')
+            <div role="search">
+                @include('platform::partials.search')
+            </div>
 
             <ul class="nav flex-column mb-md-1 mb-auto ps-0">
                 {!! Dashboard::renderMenu() !!}
             </ul>
 
-            <div class="h-100 w-100 position-relative to-top cursor d-none d-md-flex mt-md-5"
+            <div class="h-100 w-100 position-relative to-top cursor d-none d-md-flex mt-md-5" role="button" tabindex="0"
                  data-action="click->html-load#goToTop"
                  title="{{ __('Scroll to top') }}">
                 <div class="bottom-left w-100 mb-2 ps-3 overflow-hidden">
                     <small data-controller="viewport-entrance-toggle"
                            class="scroll-to-top"
                            data-viewport-entrance-toggle-class="show">
-                        <x-orchid-icon path="bs.chevron-up" class="me-2"/>
+                        <x-orchid-icon path="bs.chevron-up" class="me-2" aria-hidden="true"/>
                         {{ __('Scroll to top') }}
                     </small>
                 </div>
             </div>
 
-            <footer class="position-sticky bottom-0">
+            <footer class="position-sticky bottom-0" aria-label="Sidebar footer">
                 <div class="bg-dark position-relative overflow-hidden" style="padding-bottom: 10px;">
                     @includeWhen(Auth::check(), 'platform::partials.profile')
                 </div>
@@ -57,20 +66,24 @@
         </nav>
     @endif
 
-    <div class="order-last order-md-0 command-bar-wrapper">
-        <div class="@hasSection('navbar') @else d-none d-md-block @endif layout d-md-flex align-items-center">
-            <header class="d-none d-md-block col-xs-12 col-md p-0 me-3">
-                <h1 class="m-0 fw-light h3 text-body-emphasis">@yield('title')</h1>
-                <small class="text-muted" title="@yield('description')">@yield('description')</small>
-            </header>
-            <nav class="col-xs-12 col-md-auto ms-md-auto p-0">
-                <ul class="nav command-bar justify-content-sm-end justify-content-start d-flex align-items-center gap-2 flex-wrap-reverse flex-sm-nowrap">
-                    @yield('navbar')
-                </ul>
-            </nav>
-        </div>
-    </div>
+            <div class="order-last order-md-0 command-bar-wrapper">
+                <div class="@hasSection('navbar') @else d-none d-md-block @endif layout d-md-flex align-items-center">
+                    <header class="d-none d-md-block col-xs-12 col-md p-0 me-3">
 
-    @include('platform::partials.alert')
-    @yield('content')
-@endsection
+                        <h1 class="m-0 fw-light h3 text-body-emphasis" tabindex="0">@yield('title')</h1>
+                        <small class="text-muted" title="@yield('description')">@yield('description')</small>
+                    </header>
+                    <nav class="col-xs-12 col-md-auto ms-md-auto p-0">
+                        <ul class="nav command-bar justify-content-sm-end justify-content-start d-flex align-items-center gap-2 flex-wrap-reverse flex-sm-nowrap"
+                            aria-label="Command bar options">
+                            @yield('navbar')
+                        </ul>
+                    </nav>
+                </div>
+            </div>
+
+            <div role="alert">
+                @include('platform::partials.alert')
+            </div>
+        @yield('content')
+        @endsection

--- a/resources/views/dummy/block.blade.php
+++ b/resources/views/dummy/block.blade.php
@@ -1,5 +1,11 @@
+{{--
+    Accessibility improvements:
+     - Added role="region" to define a landmark region for assistive technology.
+     - Added aria-label="Dummy Section" to provide a meaningful label for the region.
+     - Added tabindex="0" to make the heading focusable via keyboard navigation, enhancing usability.
+--}}
 <div class="rounded bg-white mb-3 p-3">
-    <div class="border-dashed d-flex align-items-center w-100 rounded overflow-hidden" style="min-height: 250px;">
-        <h2 class="text-muted center fw-light">Dummy <small class="d-block text-center">{{ Str::random(8) }}</small></h2>
+    <div class="border-dashed d-flex align-items-center w-100 rounded overflow-hidden" style="min-height: 250px;" role="region" aria-label="Dummy Section">
+        <h2 class="text-muted center fw-light" tabindex="0">Dummy <small class="d-block text-center">{{ Str::random(8) }}</small></h2>
     </div>
 </div>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,3 +1,12 @@
+{{--
+    Accessibility improvements:
+     - Added role="main" to the container to define the primary content area of the page for assistive technologies.
+     - Added tabindex="-1" to the container to allow programmatic focus, useful for skip-to-content links.
+     - Added aria-live="polite" to the heading for assistive technologies to announce it dynamically.
+     - Associated the paragraph element with id="description" as a label for the list using aria-labelledby, providing better context to screen reader users.
+     - Defined role="listitem" for each list item to explicitly convey the list structure to assistive technologies.
+     - Added aria-live="assertive" to the final paragraph to dynamically inform assistive technologies of important updates in its content.
+--}}
 @extends('platform::dashboard')
 
 @section('title', '404')
@@ -5,20 +14,21 @@
 
 @section('content')
 
-    <div class="container py-md-4">
-            <h1 class="h2 mb-3">
+    <div class="container py-md-4" role="main" tabindex="-1">
+
+            <h1 class="h2 mb-3" aria-live="polite">
                 {{ __("Sorry, we don't have anything to show you on this page") }}
             </h1>
 
 
-            <p>{{ __("This could be because:") }}</p>
-            <ul>
-                <li>{{ __("The item you're looking for has been deleted") }}</li>
-                <li>{{ __("You don't have access to it") }}</li>
-                <li>{{ __("You clicked a broken link") }}</li>
+            <p id="description">{{ __("This could be because:") }}</p>
+            <ul aria-labelledby="description">
+                <li role="listitem">{{ __("The item you're looking for has been deleted") }}</li>
+                <li role="listitem">{{ __("You don't have access to it") }}</li>
+                <li role="listitem">{{ __("You clicked a broken link") }}</li>
             </ul>
 
-            <p class="mb-0">{{ __("If you think you should have access to this page, ask the person who manages the project (or the account) to add you to it.") }}</p>
+            <p class="mb-0" aria-live="assertive">{{ __("If you think you should have access to this page, ask the person who manages the project (or the account) to add you to it.") }}</p>
     </div>
 
 @endsection

--- a/resources/views/fields/attach.blade.php
+++ b/resources/views/fields/attach.blade.php
@@ -1,3 +1,11 @@
+{{--
+    Accessibility improvements:
+     - Added aria-label to the file input container to provide a descriptive label for screen readers.
+     - Added aria-describedby linking to a description (id="{{$id}}-description") for additional context about the placeholder text.
+     - Included aria-hidden="true" on the icon to prevent it from being announced by assistive technologies as it is decorative.
+     - Enhanced the alt attribute for the image to provide a meaningful description, like "Preview of {original_name}".
+     - Added a unique id="{{$id}}-loading" for the visually-hidden spinner description to indicate loading status to assistive technologies.
+--}}
 @component($typeForm, get_defined_vars())
     <div data-controller="attach"
          class="attach"
@@ -26,7 +34,7 @@
     >
         <div data-target="attach.preview" class="row row-cols-4 row-cols-lg-6 gy-3 sortable-dropzone">
             <div class="col order-last attach-file-uploader" data-attach-target="container">
-                <label for="{{$id}}" class="border rounded bg-light attach-image-placeholder pointer-event h-100">
+                <label for="{{$id}}" class="border rounded bg-light attach-image-placeholder pointer-event h-100" aria-label="{{ __($placeholder) }}" aria-describedby="{{$id}}-description">
                     <input class="form-control d-none"
                            type="file"
                            data-attach-target="files"
@@ -37,12 +45,12 @@
 
                     <span class="d-block text-center fw-normal small text-muted p-3 mx-auto">
                     <span class="choose d-flex flex-column gap-2 align-items-center text-balance text-wrap">
-                            <x-orchid-icon path="bs.cloud-arrow-up" class="h3"/>
-                            <small class="text-muted d-block">{{ __($placeholder) }}</small>
+                            <x-orchid-icon path="bs.cloud-arrow-up" class="h3" aria-hidden="true"/>
+                            <small id="{{$id}}-description" class="text-muted d-block">{{ __($placeholder) }}</small>
                     </span>
 
                     <span class="spinner-border" role="status">
-                        <span class="visually-hidden">{{ __('Loading...') }}</span>
+                        <span id="{{$id}}-loading" class="visually-hidden">{{ __('Loading...') }}</span>
                     </span>
                 </span>
                 </label>
@@ -56,7 +64,7 @@
                 <input type="hidden" name="{name}" value="{id}">
 
 
-                <img class="attach-image rounded border user-select-none overflow-hidden" src="{url}" title="{original_name}"/>
+                <img class="attach-image rounded border user-select-none overflow-hidden" src="{url}" title="{original_name}" alt="{{ __('Preview of {original_name}') }}"/>
 
                 {{--
                     <object class="attach-image rounded border user-select-none" border="0" data="{url}" type="{mime}" title="test"  load="lazy" controls allowfullscreen autoplay="false">

--- a/resources/views/fields/checkbox.blade.php
+++ b/resources/views/fields/checkbox.blade.php
@@ -1,18 +1,25 @@
+{{--
+    Accessibility improvements:
+     - Added `role="group"` to the container div to ensure assistive technologies correctly identify the group of related checkboxes.
+     - Utilized `aria-labelledby` to associate the input fields with their respective labels, improving clarity for screen readers.
+--}}
 @component($typeForm, get_defined_vars())
-    <div data-controller="checkbox"
+    <div data-controller="checkbox" role="group"
          data-checkbox-indeterminate="{{$indeterminate}}">
         @isset($sendTrueOrFalse)
             <input hidden name="{{$attributes['name']}}" value="{{$attributes['novalue']}}">
             <div class="form-check">
                 <input value="{{$attributes['yesvalue']}}"
                        {{ $attributes }}
+                       aria-labelledby="label-{{$id}}"
                        @if(isset($attributes['value']) && $attributes['value']) checked @endif
                 >
-                <label class="form-check-label" for="{{$id}}">{{$placeholder ?? ''}}</label>
+                <label class="form-check-label" for="{{$id}}" id="label-{{$id}}">{{$placeholder ?? ''}}</label>
             </div>
         @else
             <div class="form-check">
                 <input {{ $attributes }}
+                       aria-labelledby="label-{{$id}}"
                        @if(isset($attributes['value']) && $attributes['value'] && (!isset($attributes['checked']) || $attributes['checked'] !== false)) checked @endif
                 >
                 <label class="form-check-label" for="{{$id}}">{{$placeholder ?? ''}}</label>

--- a/resources/views/fields/code.blade.php
+++ b/resources/views/fields/code.blade.php
@@ -1,11 +1,21 @@
+{{--
+    Accessibility improvements:
+     - Added `role="application"` to the outer container to describe it as a functional widget for assistive technologies.
+     - Included `aria-labelledby` to associate the `role="region"` div with a hidden label for better navigation.
+     - Updated `aria-label` with more descriptive instructions for screen reader users.
+     - Added a `visually-hidden` label for enhanced clarity for assistive technologies.
+--}}
 @component($typeForm, get_defined_vars())
     <div
-        data-controller="code"
+        id="code-editor" data-controller="code"
         data-code-language="{{$language}}"
         data-code-line-numbers="{{$lineNumbers}}"
         data-code-default-Theme="{{$defaultTheme}}"
-    >
-        <div class="code border position-relative w-100" style="min-height: {{ $attributes['height'] }}"></div>
+        aria-label="{{ __('Code editor. Use arrow keys for navigation. Esc to exit.') }}"
+        tabindex="0" role="application" >
+
+        <div class="code border position-relative w-100" style="min-height: {{ $attributes['height'] }}" role="region" aria-labelledby="code-editor-label"></div>
         <input type="hidden" {{ $attributes }}>
     </div>
+    <span id="code-editor-label" class="visually-hidden">{{ __('Code editor container') }}</span>
 @endcomponent

--- a/resources/views/fields/cropper.blade.php
+++ b/resources/views/fields/cropper.blade.php
@@ -1,5 +1,13 @@
+{{--
+    Accessibility Improvements:
+     - Added `role="application"` and `aria-label` to describe the cropper as an interactive widget and provide usage instructions.
+     - Used `aria-labelledby` with hidden labels (`visually-hidden`) for better screen reader navigation and clarity.
+     - Added meaningful `alt` attributes to images and set `aria-hidden="true"` on decorative icons to avoid confusion.
+     - Ensured keyboard accessibility with `tabindex="0"` on focusable elements and modal components, and proper use of roles like `dialog` and `region`.
+--}}
 @component($typeForm, get_defined_vars())
     <div data-controller="cropper"
+         role="application"
          data-cropper-value="{{ $attributes['value'] }}"
          data-cropper-storage="{{ $storage ?? config('platform.attachment.disk', 'public') }}"
          data-cropper-width="{{ $width }}"
@@ -16,29 +24,34 @@
          data-cropper-path="{{ $attributes['path'] ?? '' }}"
          data-cropper-keep-original-type-value="{{ $keepOriginalType }}"
          data-cropper-max-size-message-value="{{ __($maxSizeValidateMessage) }}"
+         aria-label="{{ __('Image cropper. Use tab to navigate, upload, and crop the image. Spacebar to interact and buttons to finalize actions.') }}"
     >
-        <div class="border-dashed text-end p-3 cropper-actions">
+        <div class="border-dashed text-end p-3 cropper-actions" role="region" aria-labelledby="cropper-hidden-label">
+            <span id="cropper-hidden-label" class="visually-hidden">{{ __('Image cropping functionality') }}</span>
 
             <div class="fields-cropper-container">
-                <img src="#" class="cropper-preview img-fluid img-full mb-2 border" alt="" style="--cropper-width: {{ $width }}; --cropper-height: {{ $height }};">
+                <img src="#" class="cropper-preview img-fluid img-full mb-2 border" alt="{{ __('Image preview showing the dimensions of cropped image') }}" style="--cropper-width: {{ $width }}; --cropper-height: {{ $height }};">
             </div>
 
             <span class="mt-1 float-start">{{ __('Upload image from your computer:') }}</span>
 
             <div class="btn-group">
                 <label class="btn btn-default m-0">
-                    <x-orchid-icon path="bs.cloud-arrow-up" class="me-2"/>
+                    <x-orchid-icon path="bs.cloud-arrow-up" class="me-2" aria-hidden="true"/>
 
                     {{ __('Browse') }}
                     <input type="file"
                            accept="image/*"
+                           aria-labelledby="img-upload-description"
                            data-cropper-target="upload"
                            data-action="change->cropper#upload click->cropper#openModal"
-                           class="d-none">
+                           tabindex="0"
+                           class="d-none"
+                           aria-label="{{ __('Browse for an image to upload and crop') }}">
                 </label>
 
                 <button type="button" class="btn btn-outline-danger cropper-remove"
-                        data-action="cropper#clear">{{ __('Remove') }}</button>
+                        data-action="cropper#clear" aria-label="{{ __('Remove the selected image') }}" tabindex="0">{{ __('Remove') }}</button>
             </div>
 
             <input type="file"
@@ -52,19 +65,21 @@
             {{ $attributes }}
         >
 
-        <div class="modal" role="dialog" {{$staticBackdrop ? "data-bs-backdrop=static" : ''}}>
-            <div class="modal-dialog modal-fullscreen-md-down modal-lg">
-                <div class="modal-content-wrapper">
+        <div class="modal" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" {{$staticBackdrop ? "data-bs-backdrop=static" : ''}}>
+
+            <div class="modal-dialog modal-fullscreen-md-down modal-lg" role="document">
+
+                <div class="modal-content-wrapper" tabindex="0" role="main">
                     <div class="modal-content">
                         <div class="position-relative">
-                            <img class="upload-panel">
+                            <img class="upload-panel" alt="{{ __('Upload preview panel showing cropped section of the image') }}" tabindex="0">
                         </div>
 
                         <div class="modal-footer">
 
                             <button type="button"
                                     class="btn btn-link"
-                                    data-bs-dismiss="modal">
+                                    data-bs-dismiss="modal" aria-label="{{ __('Close the cropping modal') }}">
                                 {{ __('Close') }}
                             </button>
 

--- a/resources/views/fields/dataRange.blade.php
+++ b/resources/views/fields/dataRange.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-labelledby` and `aria-describedby` for better screen reader navigation and context.
+    - Added visually hidden labels to associate inputs with their purposes for accessibility.
+    - Added `aria-label` to provide clear names for inputs for assistive technologies.
+--}}
 @component($typeForm, get_defined_vars())
     <div class="row" data-controller="datetime"
          data-datetime-allow-input="true"
@@ -11,7 +17,22 @@
                        id='start_{{ $attributes['id'] }}'
                        data-datetime-target="instance"
                        value="{{ $value['start'] ?? null }}"
-                       class="form-control">
+                       class="form-control"
+                       aria-labelledby="start_label_{{ $attributes['id'] }}"
+                       aria-describedby="start_description_{{ $attributes['id'] }}">
+
+                       id="start_{{ $attributes['id'] }}"
+                <label id="start_label_{{ $attributes['id'] }}"
+                       class="visually-hidden">
+                    {{ __('Start Date and Time') }}
+                </label>
+                <span id="start_description_{{ $attributes['id'] }}"
+                      class="visually-hidden">
+                    {{ __('Enter the start date and time for the event') }}
+                </span>
+                       value="{{ $value['start'] ?? null }}"
+                       class="form-control"
+                       aria-label="{{ __('Start date and time') }}">
             </div>
         </div>
 
@@ -21,9 +42,24 @@
                        @isset($attributes['form']) form="{{ $attributes['form'] ?? null }}" @endisset
                        name="{{ $attributes['name'] }}[end]"
                        data-datetime-target="instance"
-                       id='end_{{ $attributes['id'] }}'
+                       id="end_{{ $attributes['id'] }}"
                        value="{{ $value['end'] ?? null }}"
-                       class="form-control">
+                       class="form-control"
+                       aria-labelledby="end_label_{{ $attributes['id'] }}"
+                       aria-describedby="end_description_{{ $attributes['id'] }}">
+
+                       id="end_{{ $attributes['id'] }}"
+                <label id="end_label_{{ $attributes['id'] }}"
+                       class="visually-hidden">
+                    {{ __('End Date and Time') }}
+                </label>
+                <span id="end_description_{{ $attributes['id'] }}"
+                      class="visually-hidden">
+                    {{ __('Enter the end date and time for the event') }}
+                </span>
+                       value="{{ $value['end'] ?? null }}"
+                       class="form-control"
+                       aria-label="{{ __('End date and time') }}">
             </div>
         </div>
     </div>

--- a/resources/views/fields/datetime.blade.php
+++ b/resources/views/fields/datetime.blade.php
@@ -1,27 +1,43 @@
+{{--
+    Accessibility Improvements:
+     - Added `aria-describedby` to describe the input and provide contextual information for screen readers.
+     - Improved hidden elements using `visually-hidden-focusable` to make them accessible when focused, enhancing keyboard navigation.
+     - Added `aria-label` to provide clear names for inputs for assistive technologies.
+     - Used `aria-hidden="true"` to hide decorative icons from assistive technologies.
+--}}
 @component($typeForm, get_defined_vars())
     <div
         data-controller="datetime"
          class="input-group"
-        {{ $dataAttributes }}>
+        {{ $dataAttributes }}
+        aria-label="{{ __('Date and time input') }}">
         <input type="text"
                placeholder="{{$placeholder ?? ''}}"
+               aria-describedby="datetime-description"
                {{ $attributes }}
                autocomplete="off"
                data-datetime-target="instance"
+               aria-label="{{ __('Date and time picker') }}"
         >
-
+        <div id="datetime-description" class="visually-hidden">
+            {{ __('Use this field to enter or pick a date and time. Clear or preset options are available.') }}
+        </div>
         @if(true === $allowEmpty)
             <div class="input-group-append bg-white">
-                <a class="input-group-text h-100 text-muted"
+                <a class="input-group-text h-100 text-muted visually-hidden-focusable"
                    title="clear"
-                   data-action="click->datetime#clear">
-                        <x-orchid-icon path="bs.x-lg" class="m-0 p-0"/>
+                   data-action="click->datetime#clear"
+                   aria-label="{{ __('Clear selected date and time') }}">
+                        <x-orchid-icon path="bs.x-lg" class="m-0 p-0" aria-hidden="true"/>
                     </a>
                 </div>
             @endif
 
         @foreach($quickDates as $name => $value)
-            <label class="btn btn-default" data-action="click->datetime#setValue" data-value="{{ $value }}">
+            <label class="btn btn-default visually-hidden-focusable"
+                   data-action="click->datetime#setValue"
+                   data-value="{{ $value }}"
+                   aria-label="{{ __('Quick select date: ') . $name }}">
                 {{ $name }}
             </label>
         @endforeach

--- a/resources/views/fields/group.blade.php
+++ b/resources/views/fields/group.blade.php
@@ -1,12 +1,21 @@
+{{--
+    Accessibility Improvements:
+     - Added `aria-label` to provide descriptive names for the form fields group.
+     - Added `role="group"` to the container div to help assistive technologies interpret it as a group of related form elements.
+--}}
+
 <div class="d-flex flex-column grid d-md-grid form-group {{ $align }}"
     @style([
         '--bs-columns: '.count($group),
         'grid-template-columns: '. $widthColumns => $widthColumns !== null,
-    ])>
+    ])
+     role="group"
+     aria-label="{{ __('Form fields group') }}">
     @foreach($group as $field)
         <div class="{{ $class }}
                     {{ $loop->first && $itemToEnd ? 'ms-auto': '' }}
-            ">
+            "
+             aria-label="{{ __('Grouped field') }}">
             {!! $field !!}
         </div>
     @endforeach

--- a/resources/views/fields/input.blade.php
+++ b/resources/views/fields/input.blade.php
@@ -1,15 +1,33 @@
+{{--
+    Accessibility Improvements:
+     - Added `aria-label` to provide descriptive names for the form fields and datalist items.
+     - Added `aria-describedby` to link the input field to a description for better context.
+     - Provided accessible IDs for the input and datalist elements.
+     - Included a visually hidden description (`aria-describedby`) for accessibility enhancements.
+     - Associated `<input>` and `<datalist>` with `list`, ensuring a direct link between the field and the suggestions.
+--}}
+
 @component($typeForm, get_defined_vars())
     <div data-controller="input"
          data-input-mask="{{$mask ?? ''}}"
+         aria-label="{{ __('Input field with suggestions') }}"
+         aria-describedby="datalist-description-{{ $name }}"
     >
-        <input {{ $attributes }}>
+        <input
+                id="input-{{ $name }}"
+                {{ $attributes }}
+                @isset($datalist) list="datalist-{{ $name }}" @endisset
+        >
     </div>
 
     @empty(!$datalist)
         <datalist id="datalist-{{$name}}">
             @foreach($datalist as $item)
-                <option value="{{ $item }}">
+                <option value="{{ $item }}" aria-label="{{ $item }}"></option>
             @endforeach
         </datalist>
     @endempty
+    <span id="datalist-description-{{ $name }}" class="visually-hidden">
+        {{ __('Suggestions available for input field') }}
+    </span>
 @endcomponent

--- a/resources/views/fields/label.blade.php
+++ b/resources/views/fields/label.blade.php
@@ -1,6 +1,15 @@
+{{--
+    Accessibility Improvements:
+     - Added `aria-label` to provide descriptive names for the form fields and datalist items.
+     - Added `aria-labelledby` to associate the text content with a descriptive label.
+     - Provided accessible IDs for dynamic elements.
+     - Included a visually hidden label for better screen reader support.
+--}}
 @component($typeForm, get_defined_vars())
     @if(strlen($value) > 0)
-        <p {{ $attributes }}>
+        <p {{ $attributes }} aria-labelledby="{{ $attributes->get('id') }}-label" aria-label="{{ __('Text content') }}">
+            <span id="{{ $attributes->get('id') }}-label" class="visually-hidden">{{ __('Label for text content') }}</span>
+
             {{ $value }}
         </p>
     @endif

--- a/resources/views/fields/map.blade.php
+++ b/resources/views/fields/map.blade.php
@@ -1,41 +1,62 @@
+{{--
+    Accessibility Improvements:
+     - Added `aria-label` attributes to provide descriptive names for interactive elements.
+     - Added `aria-labelledby` attributes to associate dynamic content with textual descriptions.
+     - Introduced IDs to link labels and descriptions for better screen reader compatibility.
+     - Included visually hidden elements (`sr-only`) to offer additional descriptions for screen readers.
+     - Ensured dynamic content updates (e.g., search results) are announced with `aria-live` attributes.
+--}}
 @component($typeForm, get_defined_vars())
+
     <div data-controller="map"
          data-map-id="{{$id}}"
          data-map-zoom="{{$zoom}}"
+         aria-labelledby="map-section-description"
+    <span id="map-section-description" class="sr-only">{{ __('Interactive Map Section Description: Use the inputs below the map to interact with or search for objects.') }}</span>
     >
-        <div id="{{$id}}" class="osmap-map border mb-2 w-100" style="min-height: {{ $attributes['height'] }}">
+        <div id="{{$id}}" class="osmap-map border mb-2 w-100" style="min-height: {{ $attributes['height'] }}" aria-labelledby="map-description">
+        <span id="map-description" class="sr-only">{{ __('This is an interactive map. Zoom and click on the map to select coordinates.') }}</span>
 
         </div>
         <div class="row mt-3">
             <div class="col-md">
-                <label for="{{$name}}[lat]">{{ __('Latitude') }}</label>
+                <label for="marker__latitude" id="latitude-label">{{ __('Latitude') }}</label>
+                <span class="sr-only" id="latitude-description">{{ __('Enter latitude value for the map marker.') }}</span>
                 <input class="form-control"
                        id="marker__latitude"
                        data-map-target="lat"
                        @if($required ?? false) required @endif
                        name="{{$name}}[lat]"
-                       value="{{ $value['lat'] ?? '' }}"/>
+                       value="{{ $value['lat'] ?? '' }}"
+                       aria-labelledby="latitude-label latitude-description"/>
             </div>
             <div class="col-md">
-                <label for="{{$name}}[lng]">{{ __('Longitude') }}</label>
+                <label for="marker__longitude" id="longitude-label">{{ __('Longitude') }}</label>
+                <span class="sr-only" id="longitude-description">{{ __('Enter longitude value for the map marker.') }}</span>
                 <input class="form-control"
                        id="marker__longitude"
-
                        data-map-target="lng"
                        @if($required ?? false) required @endif
                        name="{{$name}}[lng]"
-                       value="{{ $value['lng'] ?? '' }}"/>
+                       value="{{ $value['lng'] ?? '' }}"
+                       aria-labelledby="longitude-label longitude-description"/>
             </div>
             <div class="col-md">
-                <label>{{ __('Object search') }}</label>
+                <label for="marker__search" id="object-search-label">{{ __('Object search') }}</label>
+                <span class="sr-only" id="object-search-description">{{ __('Enter the name of an object to search on the map.') }}</span>
                 <input class="form-control" type="text"
+                       id="marker__search"
                        value="{{$valuename ?? ''}}"
                        data-map-target="search"
-                       data-action="keyup->map#search"/>
+                       aria-labelledby="object-search-label object-search-description"
+                       data-action="keyup->map#search"
+                       aria-label="{{ __('Search for objects') }}"/>
             </div>
         </div>
 
-        <div class="marker-results"></div>
+        <div class="marker-results" id="search-results" aria-live="polite" aria-labelledby="search-results-label">
+        <span id="search-results-label" class="sr-only">{{ __('Search results for objects: Updates dynamically as you type.') }}</span>
+        </div>
 
     </div>
 @endcomponent

--- a/resources/views/fields/matrix.blade.php
+++ b/resources/views/fields/matrix.blade.php
@@ -1,3 +1,10 @@
+{{--
+    Accessibility Improvements:
+     - Added `aria-label` to interactive buttons for better screen reader support.
+     - Used `aria-hidden` for purely decorative icons, making them invisible to assistive technologies.
+     - Ensured that dynamic content such as row templates is clearly labeled and accessible.
+     - Included `role="button"` to the interactive links so they are identified by screen readers as buttons.
+--}}
 @component($typeForm, get_defined_vars())
     <table class="matrix table table-bordered border-right-0 overflow-y-auto"
            data-controller="matrix"
@@ -22,15 +29,16 @@
 
         <tr class="add-row">
             <th colspan="{{ count($columns) }}" class="text-center p-0">
-                <a href="#" data-action="matrix#addRow" class="btn btn-block small text-muted">
-                    <x-orchid-icon path="bs.plus-circle" class="me-2"/>
+                <a href="#" data-action="matrix#addRow" class="btn btn-block small text-muted" aria-label="{{ __('Add a new row to the matrix') }}" role="button">
+
+                    <x-orchid-icon path="bs.plus-circle" class="me-2" aria-hidden="true" />
 
                     <span>{{ __($addRowLabel) }}</span>
                 </a>
             </th>
         </tr>
 
-        <template class="matrix-template">
+        <template class="matrix-template" aria-label="{{ __('Dynamic row template') }}" role="region">
             @include('platform::partials.fields.matrixRow',['row' => [], 'key' => '{index}'])
         </template>
         </tbody>

--- a/resources/views/fields/numberRange.blade.php
+++ b/resources/views/fields/numberRange.blade.php
@@ -1,26 +1,42 @@
+{{--
+    Accessibility improvements:
+    - Added `<label>` elements with the `visually-hidden` class to associate the input fields with labels.
+    - Added `aria-describedby` attributes to provide better context for screen reader users.
+    - Added `<span>` elements with hidden descriptions to give more detailed information about the fields to screen readers.
+--}}
 @component($typeForm, get_defined_vars())
     <div class="row">
         <div class="col-md-6 pe-1">
             <div class="form-group">
+                <label for="min_{{ \Illuminate\Support\Str::slug($attributes['name']) }}" class="visually-hidden">
+                    {{ __('Minimum') }}
+                </label>
                 <input type="{{ $attributes['type'] }}"
                        name="{{ $attributes['name'] }}[min]"
                        id='min_{{ \Illuminate\Support\Str::slug($attributes['name']) }}'
                        value="{{ $value['min'] ?? null }}"
                        placeholder="{{ __('Minimum') }}"
+                       aria-describedby="min-description"
                        {{ $attributes }}
                        >
+                <span id="min-description" class="visually-hidden">{{ __('Enter the minimum value') }}</span>
             </div>
         </div>
 
         <div class="col-md-6 ps-1">
             <div class="form-group">
+                <label for="max_{{ \Illuminate\Support\Str::slug($attributes['name']) }}" class="visually-hidden">
+                    {{ __('Maximum') }}
+                </label>
                 <input type="{{ $attributes['type'] }}"
                        name="{{ $attributes['name'] }}[max]"
                        id='max_{{ \Illuminate\Support\Str::slug($attributes['name']) }}'
                        value="{{ $value['max'] ?? null }}"
                        placeholder="{{ __('Maximum') }}"
+                       aria-describedby="max-description"
                        {{ $attributes }}
                        >
+                <span id="max-description" class="visually-hidden">{{ __('Enter the maximum value') }}</span>
             </div>
         </div>
     </div>

--- a/resources/views/fields/password.blade.php
+++ b/resources/views/fields/password.blade.php
@@ -1,17 +1,23 @@
+{{--
+    Accessibility improvements:
+    - Added `aria-label` to the password input field to make its purpose clear to screen readers.
+    - Added `aria-label` to the toggle button to describe its function (toggle password visibility).
+    - Included `aria-hidden="true"` on decorative icons to ensure they are ignored by screen readers.
+--}}
 @component($typeForm, get_defined_vars())
 
     <div data-controller="password"
          class="input-icon"
     >
-        <input {{ $attributes }} data-password-target="password">
-        <div class="input-icon-addon cursor" data-action="click->password#change">
+        <input {{ $attributes }} data-password-target="password" aria-label="{{ __('Password input field') }}">
+        <div class="input-icon-addon cursor" data-action="click->password#change" role="button" aria-label="{{ __('Toggle password visibility') }}">
 
             <span data-password-target="iconShow">
-                <x-orchid-icon path="bs.eye" class="small me-2"/>
+                <x-orchid-icon path="bs.eye" class="small me-2" aria-hidden="true"/>
             </span>
 
             <span data-password-target="iconLock" class="none">
-                <x-orchid-icon path="bs.eye-slash" class="small me-2"/>
+                <x-orchid-icon path="bs.eye-slash" class="small me-2" aria-hidden="true"/>
             </span>
         </div>
     </div>

--- a/resources/views/fields/picture.blade.php
+++ b/resources/views/fields/picture.blade.php
@@ -1,3 +1,10 @@
+{{--
+    Accessibility improvements:
+    - Added `aria-label` to various elements (e.g., file input, buttons) to help screen readers describe their purpose.
+    - Ensured all icons used purely for decoration or functionality have `aria-hidden="true"` to be ignored by assistive technologies.
+    - Included `alt` text for the image element used for the preview to properly describe the image to screen readers.
+    - Ensured hidden inputs have `aria-hidden="true"` to prevent them from interfering with screen readers.
+--}}
 @component($typeForm, get_defined_vars())
     <div data-controller="picture"
          data-picture-value="{{ $attributes['value'] }}"
@@ -12,17 +19,18 @@
         <div class="border-dashed text-end p-3 picture-actions">
 
             <div class="fields-picture-container">
-                <img src="#" class="picture-preview img-fluid img-full mb-2 border" alt="">
+                <img src="#" class="picture-preview img-fluid img-full mb-2 border" alt="{{ __('Image preview') }}">
             </div>
 
             <span class="mt-1 float-start">{{ __('Upload image from your computer:') }}</span>
 
             <div class="btn-group">
-                <label class="btn btn-default m-0">
-                    <x-orchid-icon path="bs.cloud-arrow-up" class="me-2"/>
+                <label class="btn btn-default m-0" for="picture-upload-input" aria-label="{{ __('Browse and upload image') }}">
+                    <x-orchid-icon path="bs.cloud-arrow-up" class="me-2" aria-hidden="true"/>
 
                     {{ __('Browse') }}
-                    <input type="file"
+                    <input id="picture-upload-input"
+                            type="file"
                            accept="{{ $acceptedFiles }}"
                            data-picture-target="upload"
                            data-action="change->picture#upload"
@@ -30,7 +38,7 @@
                 </label>
 
                 <button type="button" class="btn btn-outline-danger picture-remove"
-                        data-action="picture#clear">{{ __('Remove') }}</button>
+                        data-action="picture#clear" aria-label="{{ __('Remove uploaded image') }}">{{ __('Remove') }}</button>
             </div>
 
             <input type="file"
@@ -41,6 +49,7 @@
         <input class="picture-path d-none"
                type="text"
                data-picture-target="source"
+               aria-hidden="true"
                {{ $attributes }}
         >
     </div>

--- a/resources/views/fields/quill.blade.php
+++ b/resources/views/fields/quill.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Accessibility improvements:
+    - Added `aria-multiline="true"` to the hidden `<textarea>` to describe its functionality for assistive technologies.
+--}}
 @component($typeForm, get_defined_vars())
     <div data-controller="quill"
          data-quill-toolbar='@json($toolbar)'
@@ -10,6 +14,6 @@
         <div class="quill p-3 position-relative" id="quill-wrapper-{{$id}}"
              style="min-height: {{ $attributes['height'] }}">
         </div>
-        <textarea class="d-none" {{ $attributes }}></textarea>
+        <textarea class="d-none" {{ $attributes }}  aria-multiline="true"></textarea>
     </div>
 @endcomponent

--- a/resources/views/fields/radiobutton.blade.php
+++ b/resources/views/fields/radiobutton.blade.php
@@ -1,15 +1,31 @@
+{{--
+    Accessibility improvements:
+    - Added ARIA roles and attributes for better screen reader support.
+    - Associated labels explicitly with inputs using `for` and `id`.
+    - Added keyboard navigation hints for the radio group.
+    - Added `role="radio"` for individual radio buttons.
+    - Added `role="group"` for grouping related radio buttons.
+--}}
 @component($typeForm, get_defined_vars())
-    <div data-controller="radiobutton">
+
+    <div data-controller="radiobutton" role="group" aria-labelledby="radiobutton-label">
+        <span id="radiobutton-label" class="sr-only">Choose an option:</span>
+
         <div class="btn-group btn-group-toggle p-0" data-toggle="buttons">
+             {{-- Removed conflicting role attribute from div --}}
 
             @foreach($options as $key => $option)
-                <label class="btn btn-default @if($active($key, $value)) active @endif"
+                <label class="btn btn-default @if($active($key, $value)) active @endif" for="{{ $key }}-{{ $id }}"
                        data-action="click->radiobutton#checked"
                 >
                    <input {{ $attributes->except('id') }}
                            @if($active($key, $value)) checked @endif
-                            value="{{ $key }}" id="{{ $key }}-{{$id}}"
-                    >{{ $option }}</label>
+                           type="radio" role="radio" aria-checked="{{ $active($key, $value) ? 'true' : 'false' }}"
+                           value="{{ $key }}" id="{{ $key }}-{{$id}}"
+
+                    >{{ $option }}
+                    <span class="sr-only">{{ $option }}</span>
+                </label>
             @endforeach
         </div>
     </div>

--- a/resources/views/fields/relation.blade.php
+++ b/resources/views/fields/relation.blade.php
@@ -1,5 +1,13 @@
+{{--
+    Accessibility improvements:
+    - Added `aria-label` to the `<div>` element to describe its purpose.
+    - Assigned `aria-labelledby` to the `<select>` element for better screen reader support.
+    - Ensured all `role="combobox"` elements are correctly associated with child components.
+--}}
 @component($typeForm, get_defined_vars())
-    <div data-controller="relation"
+
+    <div aria-label="Relation selection"
+         data-controller="relation"
          data-relation-id="{{$id}}"
          data-relation-placeholder="{{$attributes['placeholder'] ?? ''}}"
          data-relation-model="{{ $relationModel }}"
@@ -14,10 +22,12 @@
          data-relation-message-notfound="{{ __('No results found') }}"
          data-relation-message-add="{{ __('Add') }}"
          data-relation-allow-add="{{ var_export($allowAdd, true) }}"
+         role="combobox"
     >
-        <select id="{{$id}}" data-relation-target="select" {{ $attributes }}>
+        <select id="{{$id}}" aria-labelledby="relation-label-{{$id}}" data-relation-target="select" {{ $attributes }}
+                role="listbox" >
             @foreach ($value as $option)
-                <option selected value="{{ $option['id'] }}">{{ $option['text'] }}</option>
+                <option selected value="{{ $option['id'] }}" aria-label="{{ $option['text'] }}">{{ $option['text'] }}</option>
             @endforeach
         </select>
     </div>

--- a/resources/views/fields/select.blade.php
+++ b/resources/views/fields/select.blade.php
@@ -1,12 +1,31 @@
+{{--
+    Accessibility improvements:
+    - Added `aria-label` to the `<div>` to describe its purpose for screen readers.
+    - Added `role="combobox"` to the parent container for proper identification and association with child components.
+    - Added `aria-expanded` and `aria-haspopup="listbox"` to indicate the dropdown's state and nature.
+    - Added `aria-owns="dropdown-list"` to link the dropdown with its options.
+    - Added `aria-labelledby="select-label"` to associate the `<select>` with its label for screen readers.
+    - Added `id="dropdown-list"` as a unique identifier for the dropdown element, referenced by other attributes like `aria-controls` and `aria-owns`.
+    - Added `role="listbox"` to identify the `<select>` as a list of selectable options.
+--}}
 @component($typeForm, get_defined_vars())
     <div data-controller="select"
         data-select-placeholder="{{$attributes['placeholder'] ?? ''}}"
+        aria-label="{{$attributes['placeholder'] ?? __('Select an option')}}"
+        aria-controls="dropdown-list"
         data-select-allow-empty="{{ $allowEmpty }}"
         data-select-message-notfound="{{ __('No results found') }}"
         data-select-allow-add="{{ var_export($allowAdd, true) }}"
         data-select-message-add="{{ __('Add') }}"
+         role="combobox"
+         aria-expanded="false"
+         aria-haspopup="listbox"
+         aria-owns="dropdown-list"
     >
-        <select {{ $attributes }}>
+        <select {{ $attributes }}
+                aria-labelledby="select-label"
+                id="dropdown-list"
+                role="listbox">
             @foreach($options as $key => $option)
                 <option value="{{$key}}"
                         @isset($value)
@@ -15,6 +34,7 @@
                             @elseif ($key == $value) selected
                             @endif
                         @endisset
+                        role="option"
                 >{{$option}}</option>
             @endforeach
         </select>

--- a/resources/views/fields/simplemde.blade.php
+++ b/resources/views/fields/simplemde.blade.php
@@ -1,7 +1,13 @@
+{{--
+    Accessibility enhancements applied:
+    - Added `aria-label="Editor"` to provide clear context for screen readers about the purpose of the `<textarea>`.
+    - Added `aria-describedby="simplemde-hints"` to associate any hints or messages with the `<textarea>` for better usability.
+    - Ensured the hidden `<input>` uses `aria-hidden="true"` to avoid interference with assistive technologies, as it is not meant to be accessible.
+--}}
 @component($typeForm, get_defined_vars())
     <div class="simplemde-wrapper" data-controller="simplemde"
          data-simplemde-text-value='{!! \Illuminate\Support\Js::encode($value) !!}'>
-        <textarea {{ $attributes }}></textarea>
-        <input class="d-none upload" type="file" data-action="simplemde#upload">
+        <textarea {{ $attributes }} aria-label="Editor" aria-describedby="simplemde-hints"></textarea>
+        <input class="d-none upload" type="file" data-action="simplemde#upload" aria-hidden="true">
     </div>
 @endcomponent

--- a/resources/views/fields/switch.blade.php
+++ b/resources/views/fields/switch.blade.php
@@ -1,21 +1,35 @@
+{{--
+    Accessibility improvements:
+    - Added `role="switch"` to the `<input>` element to indicate that it behaves as a toggle switch, improving clarity for assistive technologies.
+    - Used `aria-checked` attribute to explicitly define the state of the switch (`true` or `false`) for screen readers.
+    - Ensured each `<input>` has an associated `<label>` to provide a clear description and context for users, improving usability and accessibility.
+    - Added `aria-label="{{$placeholder ?? ''}}"` to provide a concise, accessible name for the toggle switch.
+    - Added `aria-describedby="description-{{$id}}"` to ensure additional context or information is conveyed by referencing an accessible description.
+--}}
 @component($typeForm, get_defined_vars())
     @isset($sendTrueOrFalse)
-        <input hidden name="{{$attributes['name']}}" value="{{$attributes['novalue']}}">
+        <input hidden name="{{$attributes['name']}}" value="{{$attributes['novalue']}}" aria-hidden="true">
         <div class="form-check form-switch">
-            <input value="{{$attributes['yesvalue']}}"
+            <input value="{{$attributes['yesvalue']}}" aria-label="{{$placeholder ?? ''}}" aria-describedby="description-{{$id}}"
                    {{ $attributes }}
+                   role="switch"
+                   aria-checked="{{ isset($attributes['value']) && $attributes['value'] ? 'true' : 'false' }}"
                    @if(isset($attributes['value']) && $attributes['value']) checked @endif
                    id="{{$id}}"
             >
             <label class="form-check-label" for="{{$id}}">{{$placeholder ?? ''}}</label>
+            <span id="description-{{$id}}" class="sr-only">{{$description ?? ''}}</span>
         </div>
     @else
         <div class="form-check form-switch">
-            <input {{ $attributes }}
+            <input {{ $attributes }} aria-label="{{$placeholder ?? ''}}" aria-describedby="description-{{$id}}"
+                   role="switch"
+                   aria-checked="{{ isset($attributes['value']) && $attributes['value'] ? 'true' : 'false' }}"
                    @if(isset($attributes['value']) && $attributes['value']) checked @endif
             id="{{$id}}"
             >
             <label class="form-check-label" for="{{$id}}">{{$placeholder ?? ''}}</label>
+            <span id="description-{{$id}}" class="sr-only">{{$description ?? ''}}</span>
         </div>
     @endisset
 @endcomponent

--- a/resources/views/fields/upload.blade.php
+++ b/resources/views/fields/upload.blade.php
@@ -1,5 +1,13 @@
+{{--
+    Accessibility improvements:
+    - Added `aria-label`, `aria-labelledby`, and `aria-describedby` attributes to enhance screen reader support.
+    - Defined appropriate ARIA roles (e.g., `role="dialog"`, `role="search"`) to improve semantic navigation.
+--}}
 @component($typeForm, get_defined_vars())
     <div
+        role="form"
+        aria-labelledby="upload-title"
+        tabindex="0"
         data-controller="upload"
         data-upload-storage="{{$storage ?? config('platform.attachment.disk', 'public')}}"
         data-upload-name="{{$name}}"
@@ -28,15 +36,16 @@
                     <div class="bg-light d-flex justify-content-center align-items-center border r-2x"
                          style="min-height: 112px;">
                         <div class="px-2 py-4">
-                            <x-orchid-icon path="bs.cloud-arrow-up" class="h3"/>
-                            <small class="text-muted d-block mt-1">{{__('Upload file')}}</small>
+                            <x-orchid-icon path="bs.cloud-arrow-up" class="h3" aria-hidden="true"/>
+                            <small id="upload-title" class="text-muted d-block mt-1">{{__('Upload file')}}</small>
                         </div>
                     </div>
                 </div>
 
                 @if($media)
                     <div class="dz-message dz-preview dz-processing dz-image-preview"
-                         data-action="click->upload#openMedia">
+                         data-action="click->upload#openMedia"
+                         role="button" aria-label="{{ __('Open Media Library') }}">
                         <div class="bg-light d-flex justify-content-center align-items-center border r-2x"
                              style="min-height: 112px;">
                             <div class="px-2 py-4">
@@ -58,25 +67,27 @@
                                 <small class="text-muted d-block">{{__('Information to display')}}</small>
                             </h4>
 
-                            <button type="button" class="btn-close" title="Close" data-bs-dismiss="modal"
-                                    aria-label="Close">
+                            <button type="button" class="btn-close" title="{{ __('Close') }}" data-bs-dismiss="modal"
+                                    aria-label="{{ __('Close Modal') }}">
                             </button>
                         </div>
                         <div class="modal-body p-4">
                             <div class="form-group">
                                 <label>{{__('System name')}}</label>
                                 <input type="text" class="form-control" data-upload-target="name" readonly
-                                       maxlength="255">
+                                       maxlength="255" aria-label="{{ __('System Name') }}">
                             </div>
                             <div class="form-group">
                                 <label>{{ __('Display name') }}</label>
                                 <input type="text" class="form-control" data-upload-target="original"
-                                       maxlength="255" placeholder="{{ __('Display name') }}">
+                                       maxlength="255" aria-labelledby="display-name" placeholder="{{ __('Display name') }}">
+                                <label id="display-name" hidden>{{ __('Display name') }}</label>
                             </div>
                             <div class="form-group">
                                 <label>{{ __('Alternative text') }}</label>
                                 <input type="text" class="form-control" data-upload-target="alt"
-                                       maxlength="255" placeholder="{{  __('Alternative text')  }}">
+                                       maxlength="255" aria-labelledby="alt-text" placeholder="{{ __('Alternative text') }}">
+                                <label id="alt-text" hidden>{{ __('Alternative text') }}</label>
                             </div>
                             <div class="form-group">
                                 <label>{{ __('Description') }}</label>
@@ -84,13 +95,16 @@
                                           data-upload-target="description"
                                           placeholder="{{ __('Description') }}"
                                           maxlength="255"
-                                          rows="3"></textarea>
+                                          rows="3"
+                                          aria-labelledby="description-label"></textarea>
+                                <label id="description-label" hidden>{{ __('Description') }}</label>
                             </div>
 
 
                             @if($visibility === 'public')
                                 <div class="form-group">
-                                    <a href="#" data-action="click->upload#openLink">
+                                    <a href="#" data-action="click->upload#openLink" role="button"
+                                       aria-label="{{ __('Link to file') }}">
                                         <small>
                                             <x-orchid-icon path="bs.share" class="me-2"/>
 
@@ -110,7 +124,8 @@
                                         {{__('Close')}}
                                     </span>
                             </button>
-                            <button type="button" data-action="click->upload#save" class="btn btn-default">
+                            <button type="button" data-action="click->upload#save" class="btn btn-default"
+                                aria-label="{{ __('Apply Changes') }}">
                                 {{__('Apply')}}
                             </button>
                         </div>
@@ -123,13 +138,13 @@
                      aria-hidden="false">
                     <div class="modal-dialog modal-dialog-scrollable modal-fullscreen-md-down slide-up">
                         <div class="modal-content">
-                            <div class="modal-header">
+                            <h4 class="modal-title text-body-emphasis fw-light" id="media-library-title">
                                 <h4 class="modal-title text-body-emphasis fw-light">
                                     {{__('Media Library')}}
                                     <small class="text-muted d-block">{{__('Previously uploaded files')}}</small>
                                 </h4>
-                                <button type="button" class="btn-close" title="Close" data-bs-dismiss="modal"
-                                        aria-label="Close">
+                                <button type="button" class="btn-close" title="{{ __('Close') }}" data-bs-dismiss="modal"
+                                        aria-label="{{ __('Close Media Library') }}">
                                 </button>
                             </div>
                             <div class="modal-body p-4">
@@ -143,11 +158,11 @@
                                                    data-action="keydown->upload#resetPage keydown->upload#loadMedia"
                                                    class="form-control"
                                                    placeholder="{{ __('Search...') }}"
-                                            >
+                                                   aria-label="{{ __('Search for files') }}">
                                         </div>
 
-                                        <div class="media-loader spinner-border" role="status">
-                                            <span class="visually-hidden">{{ __('Loading...') }}</span>
+                                        <div class="media-loader spinner-border" role="status" aria-live="polite">
+                                            <span class="visually-hidden">{{ __('Loading media files...') }}</span>
                                         </div>
 
                                         <div class="row media-results m-0"></div>
@@ -155,7 +170,8 @@
                                         <div class="mt-2">
                                             <button class="btn btn-sm btn-link d-block w-100"
                                                     data-upload-target="loadmore"
-                                                    data-action="click->upload#loadMore">{{ __('Load more') }}</button>
+                                                    data-action="click->upload#loadMore"
+                                                    aria-label="{{ __('Load more files') }}">{{ __('Load more') }}</button>
                                         </div>
 
                                     </div>

--- a/resources/views/fields/utm.blade.php
+++ b/resources/views/fields/utm.blade.php
@@ -1,64 +1,77 @@
+{{--
+    Accessibility Improvements:
+    - Added ARIA attributes such as `aria-label`, `aria-labelledby`, `aria-describedby`, and `aria-hidden` for enhanced screen reader support.
+    - Implemented semantic roles, such as `role="dialog"` for modals, ensuring proper focus management and navigation for assistive technologies.
+    - Incorporated screen reader-only (`sr-only`) descriptions to supplement visible text with additional context.
+--}}
 @component($typeForm, get_defined_vars())
 
     <div data-controller="utm">
         <div class="input-group mb-3">
-            <input {{ $attributes }} data-utm-target="url">
+            <input {{ $attributes }} data-utm-target="url" aria-label="{{ __('URL input field') }}">
             <div class="input-group-append">
-                <button type="button" class="btn btn-default" data-bs-toggle="modal"
+                <button type="button" class="btn btn-default" aria-label="{{ __('Open UTM Generator Modal') }}" data-bs-toggle="modal"
                         data-bs-target="#utm-{{$id}}">{{__('Generate UTM')}}</button>
             </div>
         </div>
 
         <!-- Modal -->
-        <div class="modal fade" id="utm-{{$id}}" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal fade" id="utm-{{$id}}" tabindex="-1" role="dialog" aria-labelledby="utm-modal-title-{{$id}}" aria-hidden="true">
             <div class="modal-dialog modal-fullscreen-md-down modal-lg" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h4 class="modal-title text-body-emphasis fw-light"
-                            id="exampleModalLabel">{{__('UTM Generator')}}</h4>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            id="utm-modal-title-{{$id}}">{{__('UTM Generator')}}</h4>
+
+                        <button type="button" class="btn-close" aria-label="{{ __('Close UTM Generator Modal') }}" data-bs-dismiss="modal"></button>
                     </div>
                     <div class="modal-body p-3">
                         <div class="row px-2">
 
                             <div class="col-md-6">
                                 <div class="mb-3">
-                                    <label>{{__('Campaign Source')}} - <span class="font-weight-bold">utm_source</span></label>
+                                    <label for="utm-source-{{$id}}">{{__('Campaign Source')}} - <span class="font-weight-bold">utm_source</span></label>
                                     <input type="text" data-utm-target="source" placeholder="google"
-                                           class="form-control">
+                                           id="utm-source-{{$id}}" class="form-control" aria-describedby="utm-source-description-{{$id}}">
+                                   <span id="utm-source-description-{{$id}}" class="sr-only">{{__('Original referrer: (e.g. google, newsletter)')}}</span>
                                     <small
                                         class="form-text text-muted w-b-k">{{__('Original referrer: (e.g. google, newsletter)')}}</small>
                                 </div>
 
                                 <div class="mb-3">
-                                    <label>{{__('Campaign medium')}} - <span class="font-weight-bold">utm_medium</span></label>
+                                    <label for="utm-medium-{{$id}}">{{__('Campaign medium')}} - <span class="font-weight-bold">utm_medium</span></label>
                                     <input type="text" data-utm-target="medium" placeholder="cpc"
-                                           class="form-control">
+                                           id="utm-medium-{{$id}}" class="form-control" aria-describedby="utm-medium-description-{{$id}}">
+                                   <span id="utm-medium-description-{{$id}}" class="sr-only">{{__('Marketing medium: (e.g. cpc, ppc, banner, email)')}}</span>
                                     <small class="form-text text-muted w-b-k">{{__('Marketing medium: (e.g. cpc, ppc, banner, email)')}}</small>
                                 </div>
 
                                 <div class="mb-3">
                                     <label>{{__('Campaign name')}} - <span class="font-weight-bold">utm_campaign</span></label>
-                                    <input type="text" data-utm-target="campaign" pattern="[a-zA-Z0-9]+"
-                                           placeholder="sleeping_beds"
-                                           class="form-control">
+                                    <input type="text" id="utm-campaign-{{$id}}" data-utm-target="campaign" pattern="[a-zA-Z0-9]+"
+                                           placeholder="sleeping_beds" class="form-control" aria-describedby="utm-campaign-description-{{$id}}">
+                                   <span id="utm-campaign-description-{{$id}}" class="sr-only">{{__('Product, promo code, or slogan (e.g. spring_sale)')}}</span>
                                     <small class="form-text text-muted w-b-k">{{__('Product, promo code, or slogan (e.g. spring_sale)')}}</small>
                                 </div>
                             </div>
 
                             <div class="col-md-6">
                                 <div class="mb-3">
-                                    <label>{{__('Campaign term')}} - <span class="font-weight-bold">utm_term</span></label>
-                                    <input type="text" data-utm-target="term" placeholder="Golf ball"
-                                           class="form-control">
+                                    <label for="utm-term-{{$id}}">{{__('Campaign term')}} - <span class="font-weight-bold">utm_term</span></label>
+
+                                    <input type="text" id="utm-term-{{$id}}" data-utm-target="term" placeholder="Golf ball"
+                                           class="form-control" aria-describedby="utm-term-description-{{$id}}">
+                                   <span id="utm-term-description-{{$id}}" class="sr-only">{{__('Paid keywords: (e.g. running+shoes)')}}</span>
                                     <small class="form-text text-muted w-b-k">{{__('Paid keywords: (e.g. running+shoes)')}}</small>
                                 </div>
 
                                 <div class="mb-3">
-                                    <label>{{__('Campaign content')}} - <span
+                                    <label for="utm-content-{{$id}}">{{__('Campaign content')}} - <span
                                                 class="font-weight-bold">utm_content</span></label>
-                                    <input type="text" data-utm-target="content" placeholder="cpc"
-                                           class="form-control">
+
+                                    <input type="text" id="utm-content-{{$id}}" data-utm-target="content" placeholder="cpc"
+                                           class="form-control" aria-describedby="utm-content-description-{{$id}}">
+                                   <span id="utm-content-description-{{$id}}" class="sr-only">{{__('Ad-specific content used to differentiate ads')}}</span>
                                     <small class="form-text text-muted w-b-k">{{__('Ad-specific content used to differentiate ads')}}
                                     </small>
                                 </div>
@@ -68,7 +81,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-link" data-bs-dismiss="modal">{{__('Close')}}</button>
-                        <button type="button" data-action="utm#generate" data-bs-dismiss="modal"
+                        <button type="button" aria-label="{{ __('Generate URL') }}" data-action="utm#generate" data-bs-dismiss="modal"
                                 class="btn btn-default">{{__('Generate URL')}}</button>
                     </div>
                 </div>

--- a/resources/views/footer.blade.php
+++ b/resources/views/footer.blade.php
@@ -1,3 +1,11 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-live="polite"` to the footer message to announce dynamic updates to screen readers.
+    - Added `rel="noopener noreferrer"` to external links to enhance navigation security and prevent security risks.
+    - Added `aria-label` to elements for improved accessibility and descriptive navigation.
+    - Added `role="contentinfo"` for the footer `<div>` to provide semantic meaning and improve screen reader assistance.
+    - Applied `rel="noreferrer"` to links to ensure referrer information is not leaked, protecting user privacy and enhancing security.
+--}}
 @guest
     <div class="m-4 text-center text-muted">
         <p>Crafted with
@@ -12,7 +20,7 @@
         </p>
     </div>
 
-    <p class="small text-center mb-1 px-5">
+    <p class="small text-center mb-1 px-5" aria-live="polite">
         {{ __('The application code is published under the MIT license.') }}
     </p>
 
@@ -25,10 +33,10 @@
     </ul>
 @else
 
-    <div class="text-center user-select-none my-4 d-none d-lg-block">
+    <div class="text-center user-select-none my-4 d-none d-lg-block" role="contentinfo">
         <p class="small mb-0">
             {{ __('The application code is published under the MIT license.') }} 2016 - {{date('Y')}}<br>
-            <a href="http://orchid.software" target="_blank" rel="noopener">
+            <a href="http://orchid.software" target="_blank" rel="noopener noreferrer" aria-label="{{ __('Orchid Official Website') }}">
                 {{ __('Version') }}: {{\Orchid\Platform\Dashboard::version()}}
             </a>
         </p>

--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="banner"` and `aria-label="Header container"` to the header `<div>` for semantic meaning and better navigation for assistive technologies.
+    - Added `aria-hidden="true"` to the `<x-orchid-icon>` to hide it from screen readers as it is decorative.
+--}}
 @push('head')
     <meta name="robots" content="noindex"/>
     <meta name="google" content="notranslate">
@@ -13,9 +18,9 @@
     <meta name="theme-color" content="#21252a">
 @endpush
 
-<div class="h2 d-flex align-items-center">
+<div class="h2 d-flex align-items-center" role="banner">
     @auth
-        <x-orchid-icon path="bs.house" class="d-inline d-xl-none"/>
+        <x-orchid-icon path="bs.house" class="d-inline d-xl-none" aria-hidden="true"/>
     @endauth
 
     <p class="my-0 {{ auth()->check() ? 'd-none d-xl-block' : '' }}">

--- a/resources/views/layouts/accordion.blade.php
+++ b/resources/views/layouts/accordion.blade.php
@@ -1,13 +1,20 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-expanded`, `aria-controls`, and other ARIA attributes to ensure compatibility with screen readers for accordion functionality.
+    - Implemented keyboard navigation support by adding `tabindex="0"` and handling `keydown` events for Enter and Space keys, ensuring proper interaction for assistive technology users.
+    - Included icons with `aria-hidden="true"` to visually enhance the UI without interfering with screen readers.
+--}}
 <div id="accordion-{{$templateSlug}}" class="accordion mb-3">
     @foreach($manyForms as $name => $forms)
         <div class="accordion-heading @if ($loop->index) collapsed @endif"
-             id="heading-{{\Illuminate\Support\Str::slug($name)}}"
+             id="heading-{{\Illuminate\Support\Str::slug($name)}}" role="button"
              data-bs-toggle="collapse"
              data-bs-target="#collapse-{{\Illuminate\Support\Str::slug($name)}}"
              aria-expanded="true"
              aria-controls="collapse-{{\Illuminate\Support\Str::slug($name)}}">
-            <h6 class="btn btn-link btn-group-justified pt-2 pb-2 mb-0 pe-0 ps-0 d-flex align-items-center">
-                <x-orchid-icon path="bs.chevron-right" class="small me-2"/> {!! $name !!}
+            <h6 class="btn btn-link btn-group-justified pt-2 pb-2 mb-0 pe-0 ps-0 d-flex align-items-center"
+                tabindex="0">
+                <x-orchid-icon path="bs.chevron-right" class="small me-2" aria-hidden="true"/> {!! $name !!}
             </h6>
         </div>
 
@@ -18,9 +25,11 @@
                  data-bs-parent="#accordion-{{$templateSlug}}"
             @endif
         >
-                @foreach($forms as $form)
+            @foreach($forms as $form)
+                <div role="group">
                     {!! $form !!}
-                @endforeach
+                </div>
+            @endforeach
         </div>
     @endforeach
 </div>

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added ARIA roles such as `role="dialog"` and attributes like `aria-live="polite"` and `aria-live="assertive"` to improve screen reader behavior for dynamic content.
+    - Used `role="menuitem"` to enhance how assistive technologies announce command bar items.
+    - Included `novalidate` in the form to customize validation feedback and prevent default browser behaviors while keeping it accessible.
+--}}
 @extends('platform::dashboard')
 
 @section('title', (string) __($name))
@@ -6,14 +12,15 @@
 
 @section('navbar')
     @foreach($commandBar as $command)
-        <li>
+        <li role="menuitem">
             {!! $command !!}
+
         </li>
     @endforeach
 @endsection
 
 @section('content')
-    <div id="modals-container">
+    <div id="modals-container" role="dialog" aria-live="polite">
         @stack('modals-container')
     </div>
 
@@ -22,6 +29,7 @@
           method="post"
           enctype="multipart/form-data"
           data-controller="form"
+          aria-live="assertive"
           data-form-need-prevents-form-abandonment-value="{{ var_export($needPreventsAbandonment) }}"
           data-form-failed-validation-message-value="{{ $formValidateMessage }}"
           data-action="keypress->form#disableKey

--- a/resources/views/layouts/blank.blade.php
+++ b/resources/views/layouts/blank.blade.php
@@ -1,5 +1,11 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="region"` to define landmarks for better navigation and context for assistive technologies.
+--}}
 @foreach($manyForms as $key => $column)
     @foreach(\Illuminate\Support\Arr::wrap($column) as $item)
-        {!! $item ?? '' !!}
+        <div role="region">
+            {!! $item ?? '' !!}
+        </div>
     @endforeach
 @endforeach

--- a/resources/views/layouts/block.blade.php
+++ b/resources/views/layouts/block.blade.php
@@ -1,20 +1,26 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to the legend and the command bar to provide meaningful labels for screen readers.
+    - Ensured dynamic descriptions are announced with `aria-live="polite"` for improved accessibility.
+--}}
 <fieldset class="row g-0 mb-3">
     @if(!empty($title) || !empty($description))
-    <div class="col p-0 px-3">
-        <legend class="text-body-emphasis px-2 mt-2">
-            {{ __($title ?? '') }}
+        <div class="col p-0 px-3">
+            <legend class="text-body-emphasis px-2 mt-2" aria-label="{{ $title ?? '' }}">
+                {{ __($title ?? '') }}
 
-            @if(!empty($description))
-            <p class="small text-muted mt-2 mb-0 text-balance">
-                {!! __($description  ?? '') !!}
-            </p>
-            @endif
-        </legend>
-    </div>
+                @if(!empty($description))
+                    <p class="small text-muted mt-2 mb-0 text-balance" aria-live="polite">
+                        {!! __($description  ?? '') !!}
+                    </p>
+                @endif
+            </legend>
+        </div>
     @endif
     <div class="col-12 {{!$vertical ? 'col-md-7' : ''}} shadow-sm h-100">
 
-        <div class="bg-white d-flex flex-column layout-wrapper {{ empty($commandBar) ? 'rounded' : 'rounded-top' }}">
+        <div class="bg-white d-flex flex-column layout-wrapper {{ empty($commandBar) ? 'rounded' : 'rounded-top' }}"
+             >
             @foreach($manyForms as $key => $layouts)
                 @foreach($layouts as $layout)
                     {!! $layout ?? '' !!}
@@ -23,7 +29,8 @@
         </div>
 
         @empty(!$commandBar)
-            <div class="bg-light px-4 py-3 d-flex justify-content-end rounded-bottom gap-2">
+            <div class="bg-light px-4 py-3 d-flex justify-content-end rounded-bottom gap-2" role="toolbar"
+                 aria-label="Command Bar">
                 @foreach($commandBar as $command)
                     <div>
                         {!! $command !!}

--- a/resources/views/layouts/browsing.blade.php
+++ b/resources/views/layouts/browsing.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added a `title` attribute to the iframe to describe its content, ensuring better understanding for screen readers.
+    - Added `aria-live="polite"` to iframe to indicate dynamic content updates without causing intrusive notifications.
+--}}
 <div data-controller="browsing" class="mb-3">
-    <iframe @foreach($attributes as $key => $value) {{ $key }}='{{$value}}' @endforeach></iframe>
+    <iframe @foreach($attributes as $key => $value) {{ $key }}='{{$value}}' @endforeach
+            title="Embedded content" aria-live="polite"></iframe>
 </div>

--- a/resources/views/layouts/card.blade.php
+++ b/resources/views/layouts/card.blade.php
@@ -1,10 +1,15 @@
+{{--
+    Accessibility Improvements:
+    - Added `alt` text to the image to provide meaningful descriptions for users relying on screen readers.
+    - Added `aria-label` attributes to dropdown menus and card descriptions to enhance clarity and usability.
+--}}
 <div class="d-block bg-white rounded shadow-sm mb-3">
     <div class="row g-0">
 
             @empty(!$image)
                 <div class="col-md-4">
                     <div class="h-100" style="display: contents">
-                        <img src="{{ $image }}" class="img-fluid img-card">
+                        <img src="{{ $image }}" class="img-fluid img-card" alt="{{ $title ?? __('Image preview') }}">
                     </div>
                 </div>
             @endempty
@@ -23,13 +28,14 @@
                             <div class="col-auto ms-auto text-end">
                                 <div class="btn-group command-bar">
                                     <button class="btn btn-link btn-sm dropdown-toggle dropdown-item p-2" type="button"
+                                            aria-label="{{ __('Open command menu') }}"
                                             data-bs-toggle="dropdown"
                                             aria-haspopup="true" aria-expanded="false">
-                                        <x-orchid-icon path="options-vertical"/>
+                                        <x-orchid-icon path="options-vertical" aria-hidden="true"/>
 
                                     </button>
                                     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow bg-white"
-                                         x-placement="bottom-end">
+                                         x-placement="bottom-end" role="menu">
                                         @foreach ($commandBar as $command)
                                             {!! $command !!}
                                         @endforeach
@@ -38,7 +44,7 @@
                             </div>
                         @endif
                     </div>
-                    <div class="card-text layout-wrapper layout-wrapper-no-padder">{!! $description ?? '' !!}</div>
+                    <div class="card-text layout-wrapper layout-wrapper-no-padder" aria-label="{{ __('Card description') }}">{!! $description ?? '' !!}</div>
                 </div>
             </div>
 

--- a/resources/views/layouts/chart.blade.php
+++ b/resources/views/layouts/chart.blade.php
@@ -1,4 +1,10 @@
-<div
+{{--
+    Accessibility Improvements:
+    - Included `role="region"` and `aria-labelledby` to label and structure the chart region for assistive technologies.
+    - Used `aria-describedby` to associate the chart title with its description, providing additional context for screen readers.
+    - Applied `role="img"` and `aria-label` to the chart figure, ensuring it is identified and described properly for users with visual impairments.
+--}}
+<div role="region" aria-labelledby="chart-title"
      data-controller="chart"
      data-chart-parent="#{{$slug}}"
      data-chart-labels="{{$labels}}"
@@ -16,28 +22,31 @@
     <div class="bg-white rounded shadow-sm mb-3 pt-3">
 
         <div class="d-flex px-3 align-items-center">
-            <legend class="text-body-emphasis px-2 mt-2 mb-0">
+            <legend id="chart-title" class="text-body-emphasis px-2 mt-2 mb-0" aria-describedby="chart-description">
                 <div class="d-flex align-items-center">
                     <small class="d-block">{{ __($title ?? '') }}</small>
 
                     @if($export)
                         <a href="#" class="ms-auto px-2 text-muted" data-action="chart#export" title="{{ __('Export') }}">
-                            <x-orchid-icon path="bs.cloud-arrow-down"/>
+                            <x-orchid-icon path="bs.cloud-arrow-down" aria-hidden="true"/>
                         </a>
                     @endif
                 </div>
 
                 @empty(!$description)
-                    <p class="small text-muted mb-0 content-read text-balance">
-                        {!! __($description  ?? '') !!}
-                    </p>
+                    <div id="chart-description">
+                        <p class="small text-muted mb-0 content-read text-balance">
+                            {!! __($description  ?? '') !!}
+                        </p>
+                    </div>
                 @endempty
             </legend>
 
         </div>
 
         <div class="position-relative w-100">
-            <figure id="{{$slug}}" class="w-100 h-full m-0 p-0 d-flex"></figure>
+            <figure id="{{$slug}}" class="w-100 h-full m-0 p-0 d-flex" role="img"
+                    aria-label="{{ __($title ?? '') }}"></figure>
         </div>
     </div>
 </div>

--- a/resources/views/layouts/columns.blade.php
+++ b/resources/views/layouts/columns.blade.php
@@ -1,8 +1,13 @@
-<div class="row g-3">
+{{--
+    Accessibility Improvements:
+    - Used `role="group"` with appropriate `aria-label` attributes to define logical grouping of form elements, enhancing navigation for assistive technologies.
+    - Applied `role="presentation"` to decorative containers, ensuring they are ignored by screen readers.
+--}}
+<div class="row g-3" role="group" aria-label="Form Group">
     @foreach($manyForms as $key => $column)
-        <div class="col-md">
+        <div class="col-md" role="group" aria-label="Column Group">
             @foreach($column as $item)
-                {!! $item ?? '' !!}
+                <div role="presentation">{!! $item ?? '' !!}</div>
             @endforeach
         </div>
     @endforeach

--- a/resources/views/layouts/facepile.blade.php
+++ b/resources/views/layouts/facepile.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to the anchor elements to provide descriptive labels for screen readers, improving navigation for visually impaired users.
+    - Included `title` attributes for tooltips to offer additional context for sighted users and assistive tools.
+    - Ensured `alt` attributes on avatar images are meaningful and provide accurate descriptions.
+--}}
 <div class="avatar-group d-flex">
     @foreach($users as $user)
         <a href="{{ $user->url() }}" class="avatar thumb-xs"
@@ -5,6 +11,7 @@
            data-action="mouseover->tooltip#mouseOver"
            data-toggle="tooltip"
            data-placement="top"
+           aria-label="{{ $user->title() }}"
            title="{{ $user->title() }}">
             <img src="{{ $user->image() }}"
                  class="avatar-img rounded-circle b bg-light"

--- a/resources/views/layouts/filter.blade.php
+++ b/resources/views/layouts/filter.blade.php
@@ -1,17 +1,24 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="region"` and `aria-labelledby` attributes to the filter section for improved navigation and context for screen readers.
+    - Provided a visually hidden label (`id="filter-section-label"`) to describe the filter section meaningfully for assistive technologies.
+    - Added `role="group"` and `aria-label` to the filter actions section to group related controls and enhance clarity for screen readers.
+--}}
 <div class="g-0 bg-white rounded mb-3">
-    <div class="row align-items-center p-4" data-controller="filter">
+    <div class="row align-items-center p-4" data-controller="filter" role="region" aria-labelledby="filter-section-label">
+    <span id="filter-section-label" class="visually-hidden">{{ __('Filter options') }}</span>
         @foreach ($filters as $filter)
             <div class="col-sm-auto col-md mb-3 align-self-start" style="min-width: 200px;">
                 {!! $filter->render() !!}
             </div>
         @endforeach
-        <div class="col-sm-auto ms-auto text-end">
+        <div class="col-sm-auto ms-auto text-end" role="group" aria-label="{{ __('Filter actions') }}">
             <div class="btn-group" role="group">
-                <button data-action="filter#clear" class="btn btn-default">
-                    <x-orchid-icon class="me-1" path="bs.arrow-repeat"/> {{ __('Reset') }}
+                <button data-action="filter#clear" class="btn btn-default" aria-label="{{ __('Reset all filters') }}">
+                    <x-orchid-icon class="me-1" path="bs.arrow-repeat" aria-hidden="true"/> {{ __('Reset') }}
                 </button>
-                <button type="submit" form="filters" class="btn btn-default">
-                    <x-orchid-icon class="me-1" path="bs.funnel"/> {{ __('Apply') }}
+                <button type="submit" form="filters" class="btn btn-default" aria-label="{{ __('Apply selected filters') }}">
+                    <x-orchid-icon class="me-1" path="bs.funnel" aria-hidden="true"/> {{ __('Apply') }}
                 </button>
             </div>
         </div>

--- a/resources/views/layouts/legend.blade.php
+++ b/resources/views/layouts/legend.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+    - Defined `role="list"` on the `<dl>` element to communicate its structure as a list to screen readers.
+    - Added `role="term"` to `<dt>` elements for explicitly defining terms within the list, improving screen reader usability.
+--}}
 <fieldset class="mb-3">
 
     @empty(!$title)
@@ -8,10 +13,10 @@
         </div>
     @endempty
 
-    <dl class="bg-white rounded shadow-sm p-4 py-4 d-flex flex-column">
+    <dl class="bg-white rounded shadow-sm p-4 py-4 d-flex flex-column" role="list">
         @foreach($columns as $column)
             <div class="d2-grid py-3 {{ $loop->first ? '' : 'border-top' }}">
-                <dt class="text-muted fw-normal me-3">
+                <dt class="text-muted fw-normal me-3" role="term">
                     {!! $column->buildDt($repository) !!}
                 </dt>
                 <dd class="text-body-emphasis">

--- a/resources/views/layouts/listener.blade.php
+++ b/resources/views/layouts/listener.blade.php
@@ -1,5 +1,13 @@
-<x-orchid-stream :target="$templateSlug" :rule="\request()->routeIs('platform.async.listener')">
-    <div data-controller="listener"
+{{--
+    Accessibility Improvements:
+    - Added `aria-label="Stream content"` to describe the purpose of the streamed content for assistive technologies.
+    - Used `role="region"` along with `aria-live="polite"` to alert screen readers about changes in content without interrupting the user.
+    - Included `role="group"` and `tabindex="0"` to define logical groupings and ensure keyboard focus accessibility for each layout section.
+--}}
+<x-orchid-stream :target="$templateSlug" :rule="\request()->routeIs('platform.async.listener')"
+                 aria-label="Stream content">
+
+    <div role="region" aria-live="polite" data-controller="listener"
          data-listener-watched-value="{{$targets}}"
          data-listener-url-value="{{$asyncRoute}}"
          data-listener-loading-class="pe-none cursor-wait"
@@ -7,7 +15,9 @@
     >
         @foreach($manyForms as $layouts)
             @foreach($layouts as $layout)
-                {!! $layout ?? '' !!}
+                <div role="group" tabindex="0">
+                    {!! $layout ?? '' !!}
+                </div>
             @endforeach
         @endforeach
     </div>

--- a/resources/views/layouts/metric.blade.php
+++ b/resources/views/layouts/metric.blade.php
@@ -1,19 +1,31 @@
-<div class="mb-3">
+{{--
+    Accessibility Improvements:
+    - Assigned `role="group"` to the container to clearly define related metrics as a group, improving navigation for screen readers.
+    - Added `aria-labelledby="metrics-title"` to connect the group with a descriptive title for better understanding.
+    - Enhanced individual metric cards with `role="article"` and `aria-label` to provide a clear label for each metric's content.
+    - Used `aria-live="polite"` for dynamic percentage changes, ensuring updates are announced without being disruptive.
+    - Added `aria-hidden="true"` to prevent redundant announcements of static text elements (e.g., keys).
+--}}
+<div class="mb-3" role="group" aria-labelledby="metrics-title">
     @isset($title)
-        <legend class="text-body-emphasis px-4 mb-0">
+        <legend id="metrics-title" class="text-body-emphasis px-4 mb-0">
             {{ __($title) }}
         </legend>
     @endisset
     <div class="row mb-2 g-3 g-mb-4">
         @foreach($metrics as $key => $metric)
-            <div class="col">
-                <div class="p-4 bg-white rounded shadow-sm h-100 d-flex flex-column">
-                    <small class="text-muted d-block mb-1">{{ __($key) }}</small>
+            <div class="col" role="presentation">
+
+                <div class="p-4 bg-white rounded shadow-sm h-100 d-flex flex-column" role="article"
+                     aria-label="{{ __($key) }}">
+
+                    <small class="text-muted d-block mb-1" aria-hidden="true">{{ __($key) }}</small>
                     <p class="h3 text-body-emphasis fw-light mt-auto">
                         {{ is_array($metric) ? $metric['value'] : $metric }}
 
                         @if(isset($metric['diff']) && (float)$metric['diff'] !== 0.0)
-                            <small class="small {{ (float)$metric['diff'] < 0 ? 'text-danger': 'text-success' }}">
+                            <small class="small {{ (float)$metric['diff'] < 0 ? 'text-danger': 'text-success' }}"
+                                   aria-live="polite">
                                 {{ round($metric['diff'], 2) }} %
                             </small>
                         @endif

--- a/resources/views/layouts/modal.blade.php
+++ b/resources/views/layouts/modal.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="dialog"` to the modal container with appropriate `aria-labelledby` to ensure the modal is properly announced by screen readers.
+    - Used `aria-label` attributes on close buttons to provide clear and meaningful actions for assistive technologies.
+    - Added `aria-live="polite"` to apply button to announce content updates in a non-disruptive manner.
+--}}
 @push('modals-container')
     <div class="modal fade center-scale {{$type}}"
          id="screen-modal-{{$key}}"
@@ -78,14 +84,15 @@
                 </div>
                 <div class="modal-footer">
                     @if(!$withoutCloseButton)
-                        <button type="button" class="btn btn-link" data-bs-dismiss="modal">
+                        <button type="button" class="btn btn-link" data-bs-dismiss="modal"
+                                aria-label="Close without applying changes">
                             {{ $close }}
                         </button>
                     @endif
 
                     @empty($commandBar)
                         @if(!$withoutApplyButton)
-                            <button type="submit"
+                            <button type="submit" aria-live="polite"
                                     id="submit-modal-{{$key}}"
                                     data-turbo="{{ var_export($turbo) }}"
                                     class="btn btn-default">

--- a/resources/views/layouts/pagination.blade.php
+++ b/resources/views/layouts/pagination.blade.php
@@ -1,9 +1,17 @@
+{{--
+    Accessibility Improvements:
+    - Used `aria-label` on the dropdown button and menus to clearly describe their purpose and available options for screen readers.
+    - Ensured the dropdown menu is properly labeled with `role="menu"` and its items with `role="menuitem"` to convey semantic groupings.
+    - Added `aria-live="polite"` to dynamically update the displayed records announcement without disrupting the user experience.
+    - Included `aria-label` for navigation elements to describe the pagination system to assistive technologies effectively.
+--}}
 <footer class="pb-3 w-100 v-md-center px-4 d-flex flex-wrap">
         <div class="col-auto me-auto">
             @if(isset($columns) && \Orchid\Screen\TD::isShowVisibleColumns($columns))
                 <div class="btn-group dropup d-inline-block">
                     <button type="button"
                             class="btn btn-sm btn-link dropdown-toggle p-0 m-0"
+                            aria-label="{{ __('Configure columns dropdown') }}"
                             data-bs-toggle="dropdown"
                             aria-haspopup="true"
                             data-bs-boundary="viewport"
@@ -11,16 +19,16 @@
                             aria-expanded="false">
                         {{ __('Configure columns') }}
                     </button>
-                    <div class="dropdown-menu">
+                    <div class="dropdown-menu" role="menu" aria-label="{{ __('Column configuration options') }}">
                         @foreach($columns as $column)
-                            {!! $column->buildItemMenu() !!}
+                            <div role="menuitem">{!! $column->buildItemMenu() !!}</div>
                         @endforeach
                     </div>
                 </div>
             @endif
 
             @if($paginator instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)
-                <small class="text-muted d-block">
+                <small class="text-muted d-block" aria-live="polite">
                     {{ __('Displayed records: :from-:to of :total',[
                         'from' => ($paginator->currentPage() -1 ) * $paginator->perPage() + 1,
                         'to' => ($paginator->currentPage() -1 ) * $paginator->perPage() + count($paginator->items()),
@@ -32,18 +40,18 @@
         </div>
         <div class="col-auto overflow-auto flex-shrink-1 mt-3 mt-sm-0">
             @if($paginator instanceof \Illuminate\Contracts\Pagination\CursorPaginator)
-                {!!
+                <nav aria-label="{{ __('Pagination Navigation') }}">{!!
                     $paginator->appends(request()
                         ->except(['page','_token']))
                         ->links('platform::partials.pagination')
-                !!}
+                !!}</nav>
             @elseif($paginator instanceof \Illuminate\Contracts\Pagination\Paginator)
-                {!!
+                <nav aria-label="{{ __('Pagination Navigation') }}">{!!
                     $paginator->appends(request()
                         ->except(['page','_token']))
                         ->onEachSide($onEachSide ?? 3)
                         ->links('platform::partials.pagination')
-                !!}
+                !!}</nav>
             @endif
         </div>
 </footer>

--- a/resources/views/layouts/persona.blade.php
+++ b/resources/views/layouts/persona.blade.php
@@ -1,10 +1,17 @@
-<a href="{{ $url }}" class="d-flex align-items-center gap-md-3">
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to the `<a>` link to provide a descriptive label for assistive technologies, ensuring clear navigation context.
+    - Used `alt="{{ $title }}"` for the `<img>` tag, making the image meaningful and accessible for screen readers.
+    - Included `role="group"` for the text container to logically group related textual elements (`title` and `subtitle`).
+--}}
+<a href="{{ $url }}" class="d-flex align-items-center gap-md-3" aria-label="{{ $title }}">
     @empty(!$image)
     <span class="thumb-sm avatar d-none d-md-inline-block">
-      <img src="{{ $image }}" class="bg-light">
+        <img src="{{ $image }}" class="bg-light" alt="{{ $title }}" role="img" aria-hidden="false">
     </span>
     @endempty
-    <div class="text-balance">
+    <div class="text-balance" role="group">
+
         <p class="mb-0">{{ $title }}</p>
         <small class="text-muted">{{ $subTitle }}</small>
     </div>

--- a/resources/views/layouts/row.blade.php
+++ b/resources/views/layouts/row.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Used `<fieldset>` to group related form elements, providing a semantic structure that improves navigation for assistive technologies.
+    - Added a `<legend>` to describe the purpose of the fieldset, ensuring screen readers can announce the title effectively.
+    - Added `role="form"` to the container to explicitly indicate the section represents a form structure.
+--}}
 <fieldset class="mb-3">
 
     @empty(!$title)
@@ -8,7 +14,7 @@
         </div>
     @endempty
 
-    <div class="bg-white rounded shadow-sm p-4 py-4 d-flex flex-column gap-3">
+    <div class="bg-white rounded shadow-sm p-4 py-4 d-flex flex-column gap-3" role="form">
         {!! $form ?? '' !!}
     </div>
 </fieldset>

--- a/resources/views/layouts/selection.blade.php
+++ b/resources/views/layouts/selection.blade.php
@@ -1,19 +1,31 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to the dropdown toggle button to describe its purpose as a filters menu for screen readers.
+    - Used `role="group"` to group related buttons, helping assistive technologies understand the structure.
+    - Assigned `role="menu"` to the dropdown container and `role="menuitem"` to individual menu items for semantic understanding.
+    - Added `aria-label` to "Apply filters" and "Remove filter" buttons for clear and descriptive interactions.
+    - Used `aria-hidden="true"` in icons where applicable to prevent redundancies in screen reader announcements.
+    - Ensured focus management by aligning dropdown behavior with keyboard and screen reader navigation.
+--}}
 <div class="col-md-12" data-controller="filter">
     <div class="btn-group ps-4" role="group">
         <button class="btn btn-link dropdown-toggle ps-0 d-flex align-items-center text-decoration-none"
                 data-bs-toggle="dropdown"
+                aria-label="{{ __('Open Filters Menu') }}"
                 aria-haspopup="true"
                 aria-expanded="false">
-            <x-orchid-icon path="bs.funnel"/>
+            <x-orchid-icon path="bs.funnel" aria-hidden="true"/>
             <span class="ms-1">{{__('Filters')}}</span>
         </button>
 
         <div class="dropdown-menu dropdown-menu-left dropdown-menu-arrow py-0"
+             role="menu"
              aria-labelledby="navbarDropdownMenuLink"
              data-turbo-permanent
              data-action="click->filter#onMenuClick"
         >
             <div class="dropdown-toggle" data-action="click->filter#onMenuClick"
+                 role="menuitem"
                  data-filter-target="filterItem">
                 <div class="p-3 w-md d-flex flex-column gap-3">
                     @foreach($filters as $filter)
@@ -25,6 +37,7 @@
                     <button type="submit"
                             form="filters"
                             class="btn btn-link btn-sm w-100 border"
+                            aria-label="{{ __('Apply filters') }}"
                             data-action="click->filter#submit">
                         <span class="w-100 text-center">{{__('Apply')}}</span>
                     </button>
@@ -35,9 +48,10 @@
     @foreach($filters as $filter)
         @if($filter->isApply())
             <a href="{{ $filter->resetLink() }}"
+               aria-label="{{ __('Remove filter: ') . $filter->value() }}"
                class="badge bg-light border me-1 p-1 d-inline-flex align-items-center">
                 <span>{{$filter->value()}}</span>
-                <x-orchid-icon path="bs.x-lg" class="ms-1"/>
+                <x-orchid-icon path="bs.x-lg" class="ms-1" aria-hidden="true"/>
             </a>
         @endif
     @endforeach

--- a/resources/views/layouts/sortable.blade.php
+++ b/resources/views/layouts/sortable.blade.php
@@ -1,3 +1,13 @@
+{{--
+    Accessibility Improvements:
+    - Used `<fieldset>` and `<legend>` for grouping and describing the content when `$title` is present, ensuring semantic meaning for assistive technologies.
+    - Assigned `role="list"` to the ordered list (`<ol>`) to explicitly define its purpose for screen readers and other assistive devices.
+    - Each list item is marked with `role="listitem"`, ensuring each entry is recognized as part of the list structure.
+    - Used `aria-hidden="true"` for icons purely used for visual decoration to prevent unnecessary announcements by screen readers.
+    - Added `aria-live="polite"` for dynamic content like block headers to be announced in a non-intrusive manner if updated.
+    - Added `role="heading"` to ensure assistive technologies recognize this as a heading.
+    - Set `aria-level="3"` for proper hierarchical navigation, improving screen reader accessibility, especially for important messages like "not found.
+--}}
 @empty(!$title)
     <fieldset>
         <div class="col p-0 px-3">
@@ -11,26 +21,28 @@
 <div class="mb-3 rounded shadow-sm overflow-hidden">
     @if($rows->isNotEmpty())
         <ol
-            data-controller="sortable"
-            data-sortable-selector-value=".reorder-handle"
-            data-sortable-model-value="{{ get_class($rows->first()) }}"
-            data-sortable-action-value="{{ route('platform.systems.sorting') }}"
-            data-sortable-success-message-value="{{ $successSortMessage }}"
-            data-sortable-failure-message-value="{{ $failureSortMessage }}"
-            class="list-group">
+                role="list"
+                data-controller="sortable"
+                data-sortable-selector-value=".reorder-handle"
+                data-sortable-model-value="{{ get_class($rows->first()) }}"
+                data-sortable-action-value="{{ route('platform.systems.sorting') }}"
+                data-sortable-success-message-value="{{ $successSortMessage }}"
+                data-sortable-failure-message-value="{{ $failureSortMessage }}"
+                class="list-group">
 
             @foreach($rows as $model)
                 <li
-                    data-model-id="{{ $model->getKey() }}"
-                    class="reorder-handle list-group-item d-flex justify-content-between align-items-center px-4 py-3 list-group-item-action">
-                    <div class="me-4">
-                        <x-orchid-icon path="bs.arrow-down-up" class="cursor-move"/>
+                        data-model-id="{{ $model->getKey() }}"
+                        class="reorder-handle list-group-item d-flex justify-content-between align-items-center px-4 py-3 list-group-item-action"
+                        role="listitem">
+                    <div class="me-4" aria-hidden="true">
+                        <x-orchid-icon path="bs.arrow-down-up" class="cursor-move" aria-hidden="true"/>
                     </div>
 
                     @foreach($columns as $column)
                         <div class="{{ $loop->first ? 'me-auto' : 'ms-3' }}">
                             @if($showBlockHeaders)
-                                <div class="text-muted fw-normal">
+                                <div class="text-muted fw-normal" aria-live="polite">
                                     {!! $column->buildDt($model) !!}
                                 </div>
                             @endif
@@ -44,13 +56,13 @@
     @else
         <div class="d-md-flex align-items-center px-md-0 px-2 pt-4 pb-5 w-100 text-md-start text-center">
             @isset($iconNotFound)
-                <div class="col-auto mx-md-4 mb-3 mb-md-0">
-                    <x-orchid-icon :path="$iconNotFound" class="block h1"/>
+                <div class="col-auto mx-md-4 mb-3 mb-md-0" aria-hidden="true">
+                    <x-orchid-icon :path="$iconNotFound" class="block h1" aria-hidden="true"/>
                 </div>
             @endisset
 
             <div>
-                <h3 class="fw-light">
+                <h3 class="fw-light" role="heading" aria-level="3">
                     {!!  $textNotFound !!}
                 </h3>
 

--- a/resources/views/layouts/split.blade.php
+++ b/resources/views/layouts/split.blade.php
@@ -1,4 +1,9 @@
-<div class="row g-3">
+{{--
+    Accessibility Improvements:
+    - The `role="group"` and `aria-label="Many forms"` on the parent container provide semantic meaning, grouping related elements together for assistive technologies.
+    - Added `aria-label` to interactive elements, such as links, to provide clear and meaningful descriptions for assistive technologies.
+--}}
+<div class="row g-3" role="group" aria-label="Many forms">
     @foreach($manyForms as $key => $column)
         <div @class([
             'col-md',

--- a/resources/views/layouts/tabMenu.blade.php
+++ b/resources/views/layouts/tabMenu.blade.php
@@ -1,5 +1,10 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to interactive elements, such as links, to provide clear and meaningful descriptions for assistive technologies.
+--}}
 <div class="nav-tabs-alt">
-    <ul class="nav nav-tabs nav-tabs-scroll-bar" role="tablist">
+    <ul class="nav nav-tabs nav-tabs-scroll-bar" role="tablist" aria-label="Primary Navigation Tabs">
+
         {!! $navigations !!}
     </ul>
 </div>

--- a/resources/views/layouts/table.blade.php
+++ b/resources/views/layouts/table.blade.php
@@ -1,3 +1,14 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` and `aria-labelledby` attributes to interactive and dynamic elements, such as links and table components, for better assistive technologies support.
+    - Added a 'Skip to main content' interactive link to facilitate quick navigation for screen readers and keyboard users.
+    - Added `aria-hidden="true"` to purely decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+    - Added `role="region"` to define the main container element as a landmark region, providing better navigation landmarks for screen readers.
+    - Added `role="rowgroup"` to the table `<thead>` and `<tbody>` elements to explicitly define their roles in the table structure for assistive technologies.
+    - Added `role="columnheader"` to `<th>` elements to indicate they are headers for columns, improving understanding and navigation in data tables.
+    - Added `role="cell"` to `<td>` elements to indicate these are individual table data cells, enhancing table accessibility context.
+--}}
+<a href="#main" class="skip" aria-label="Skip to main content">Skip to main content</a>
 @empty(!$title)
     <fieldset>
             <div class="col p-0 px-3">
@@ -11,7 +22,7 @@
 <div class="bg-white rounded shadow-sm mb-3 overflow-hidden"
      data-controller="table"
      data-table-slug="{{$slug}}"
->
+     role="region" aria-labelledby="table-title">
 
     <div class="table-responsive">
         <table @class([
@@ -23,21 +34,25 @@
                ])>
 
             @if($showHeader)
-                <thead>
-                    <tr>
-                        @foreach($columns as $column)
+                <thead role="rowgroup">
+                <tr>
+                    @foreach($columns as $column)
+                        <th scope="col" role="columnheader">
                             {!! $column->buildTh() !!}
-                        @endforeach
-                    </tr>
+                        </th>
+                    @endforeach
+                </tr>
                 </thead>
             @endif
 
-            <tbody>
+            <tbody role="rowgroup">
 
             @foreach($rows as $source)
                 <tr>
                     @foreach($columns as $column)
-                        {!! $column->buildTd($source, $loop->parent) !!}
+                        <td role="cell">
+                            {!! $column->buildTd($source, $loop->parent) !!}
+                        </td>
                     @endforeach
                 </tr>
             @endforeach
@@ -45,7 +60,9 @@
             @if($total->isNotEmpty() && $rows->isNotEmpty())
                 <tr>
                     @foreach($total as $column)
-                        {!! $column->buildTd($repository, $loop) !!}
+                        <td role="cell">
+                            {!! $column->buildTd($repository, $loop) !!}
+                        </td>
                     @endforeach
                 </tr>
             @endif
@@ -59,7 +76,7 @@
 
             @isset($iconNotFound)
                 <div class="col-auto mx-md-4 mb-3 mb-md-0">
-                    <x-orchid-icon :path="$iconNotFound" class="block h1"/>
+                    <x-orchid-icon :path="$iconNotFound" class="block h1" aria-hidden="true"/>
                 </div>
             @endisset
 

--- a/resources/views/layouts/tabs.blade.php
+++ b/resources/views/layouts/tabs.blade.php
@@ -1,13 +1,20 @@
-<div
+{{--
+    Accessibility Improvements:
+    - Added `role="main"` to the outer container `<div>` to designate the primary content area of the page, enabling assistive technologies to skip directly to it.
+    - Added `aria-label` to navigation controls (`<ul>`, `<a>`) to provide clear descriptions of their purpose and usage.
+    - Added `aria-controls` to link tabs with their corresponding content panels, ensuring a clearer association for assistive technologies.
+    - Dynamically set the `aria-selected` attribute to indicate the active tab, improving navigation for screen readers.
+--}}
+<div role="main"
     data-controller="tabs"
     data-tabs-slug="{{$templateSlug}}"
     data-tabs-active-tab="{{$activeTab}}"
 >
     <div class="nav-tabs-alt">
-        <ul class="nav nav-tabs nav-tabs-scroll-bar" role="tablist">
+        <ul class="nav nav-tabs nav-tabs-scroll-bar" role="tablist" aria-label="Tab navigation">
             @foreach($manyForms as $name => $tab)
                 <li class="nav-item" role="presentation">
-                    <a class="nav-link
+                    <a aria-label="Tab {{ $name }}" class="nav-link
                         @if ($activeTab === $name)
                             active
                         @elseif($loop->first && is_null($activeTab))
@@ -16,9 +23,11 @@
                        data-action="tabs#setActiveTab"
                        data-bs-target="#tab-{{\Illuminate\Support\Str::slug($name)}}"
                        id="button-tab-{{\Illuminate\Support\Str::slug($name)}}"
-                       aria-selected="false"
+                       aria-selected="{{ ($activeTab === $name) || ($loop->first && is_null($activeTab)) ? 'true' : 'false' }}"
+                       aria-controls="tab-{{\Illuminate\Support\Str::slug($name)}}"
                        role="tab"
-                       data-bs-toggle="tab">
+                       data-bs-toggle="tab"
+                       tabindex="0">
                         {!! $name !!}
                     </a>
                 </li>
@@ -31,12 +40,15 @@
         <div class="no-border-xs">
             <div class="tab-content">
                 @foreach($manyForms as $name => $forms)
-                    <div role="tabpanel" class="tab-pane
+                    <div role="tabpanel" aria-label="Content for {{ $name }}"
+                         tabindex="0"
+                         class="tab-pane
                         @if ($activeTab === $name)
                             active
                         @elseif($loop->first && is_null($activeTab))
                             active
                         @endif"
+                         aria-labelledby="button-tab-{{\Illuminate\Support\Str::slug($name)}}"
                          id="tab-{{\Illuminate\Support\Str::slug($name)}}">
                             @foreach($forms as $form)
                                 {!! $form !!}

--- a/resources/views/partials/alert.blade.php
+++ b/resources/views/partials/alert.blade.php
@@ -1,5 +1,10 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="alert"` to indicate important information to users, ensuring assistive technologies notify them promptly.
+    - Added `aria-live="assertive"` to communicate important dynamic changes immediately to users with assistive technologies.
+--}}
 @if (session()->has(\Orchid\Alert\Alert::SESSION_MESSAGE))
-    <div class="alert alert-{{ session(\Orchid\Alert\Alert::SESSION_LEVEL) }} rounded shadow-sm mb-3 p-4 d-flex" data-turbo-temporary>
+    <div class="alert alert-{{ session(\Orchid\Alert\Alert::SESSION_LEVEL) }} rounded shadow-sm mb-3 p-4 d-flex" data-turbo-temporary role="alert" aria-live="assertive">
         {!! session(\Orchid\Alert\Alert::SESSION_MESSAGE) !!}
 
         @yield('flash_notification.sub_message')
@@ -8,7 +13,7 @@
 @endif
 
 @empty(!$errors->count())
-    <div class="alert alert-danger rounded shadow-sm mb-3 p-4" role="alert">
+    <div class="alert alert-danger rounded shadow-sm mb-3 p-4" role="alert" aria-live="assertive">
         <strong>{{  __('Oh snap!') }}</strong>
         {{ __('Change a few things up and try submitting again.') }}
         <ul>

--- a/resources/views/partials/confirm.blade.php
+++ b/resources/views/partials/confirm.blade.php
@@ -1,7 +1,16 @@
+{{--
+    Accessibility Improvements:
+    - Added role="dialog" to indicate this element is a modal dialog, enabling assistive technologies
+      to treat it as a separate interactive component, improving navigation and focus for users.
+    - Added role="document" to define this element as a container for content, providing a clear structure for screen readers and improving accessibility.
+    - Added role="contentinfo" to designate this element as a landmark for footer or closing content,
+      helping assistive technologies quickly identify and navigate to important information about the page.
+--}}
 <div class="modal fade"
      id="confirm-dialog"
      data-controller="confirm"
      tabindex="-1"
+     role="dialog"
      aria-hidden="true">
     <div class="modal-dialog modal-fullscreen-md-down">
         <div class="modal-content">
@@ -12,12 +21,12 @@
                 <button type="button" class="btn-close" title="Close" data-bs-dismiss="modal" aria-label="Close">
                 </button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body" role="document">
                 <div class="p-4" data-confirm-target="message">
 
                 </div>
             </div>
-            <div class="modal-footer">
+            <div class="modal-footer" role="contentinfo">
                 <button type="button" class="btn btn-link" data-bs-dismiss="modal">
                     {{__('Cancel')}}
                 </button>

--- a/resources/views/partials/fields/clear.blade.php
+++ b/resources/views/partials/fields/clear.blade.php
@@ -1,7 +1,13 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to the `<label>` elements to provide descriptive labels for screen readers.
+    - Added `role="alert"` to error messages to ensure immediate recognition by assistive technologies.
+    - Added `role="note"` to descriptive help text to effectively distinguish guidance content.
+--}}
 <div class="form-group mb-0">
 
     @isset($title)
-        <label for="{{$id}}" class="form-label mb-0">
+        <label for="{{$id}}" class="form-label mb-0" aria-label="{{$title}}">
             {{$title}}
         </label>
     @endisset
@@ -24,9 +30,9 @@
 
     @if($errors->has($oldName))
         <div class="invalid-feedback d-block">
-            <small>{{$errors->first($oldName)}}</small>
+            <small role="alert">{{$errors->first($oldName)}}</small>
         </div>
     @elseif(isset($help))
-        <small class="form-text text-muted">{!!$help!!}</small>
+        <small class="form-text text-muted" role="note">{!!$help!!}</small>
     @endif
 </div>

--- a/resources/views/partials/fields/horizontal.blade.php
+++ b/resources/views/partials/fields/horizontal.blade.php
@@ -1,6 +1,12 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to the `<label>` elements to provide descriptive labels for screen readers.
+    - Added `role="alert"` to error messages to ensure immediate recognition by assistive technologies.
+    - Added `role="note"` to descriptive help text to effectively distinguish guidance content.
+--}}
 <div class="form-group row row-cols-sm-2 align-items-stretch">
     @isset($title)
-        <label for="{{$id}}" class="col-sm-3 text-wrap form-label">
+        <label for="{{$id}}" class="col-sm-3 text-wrap form-label" aria-label="{{$title}}">
             {{$title}}
 
             <x-orchid-popover :content="$popover ?? ''"/>
@@ -29,11 +35,11 @@
         @endphp
 
         @if($errors->has($oldName))
-            <div class="invalid-feedback d-block">
+            <div class="invalid-feedback d-block" role="alert">
                 <small>{{$errors->first($oldName)}}</small>
             </div>
         @elseif(isset($help))
-            <small class="form-text text-muted">{!!$help!!}</small>
+            <small class="form-text text-muted" role="note">{!!$help!!}</small>
         @endif
     </div>
 </div>

--- a/resources/views/partials/fields/matrixRow.blade.php
+++ b/resources/views/partials/fields/matrixRow.blade.php
@@ -1,7 +1,13 @@
+{{--
+    Accessibility Improvements:
+    - Added `scope` attribute to the `<th>` elements for better association with data cells.
+    - Included `aria-hidden="true"` in icons to hide them from assistive technologies as they are decorative.
+    - Added `aria-label` to interactive elements to provide proper descriptions for screen readers.
+--}}
 <tr>
     @foreach($columns as $column)
 
-        <th class="p-0 align-middle">
+        <th scope="col" class="p-0 align-middle">
             {!!
                $fields[$column]
                     ->value($row[$column] ?? '')
@@ -14,10 +20,10 @@
         @if ($loop->last && $removableRows)
             <th class="no-border text-center align-middle">
                 <a href="#"
-                   data-action="matrix#deleteRow"
+                   data-action="matrix#deleteRow" aria-label="{{ __('Remove row') }}"
                    class="small text-muted"
                    title="{{ __('Remove row') }}">
-                    <x-orchid-icon path="bs.trash3"/>
+                    <x-orchid-icon path="bs.trash3" aria-hidden="true"/>
                 </a>
             </th>
         @endif

--- a/resources/views/partials/fields/vertical.blade.php
+++ b/resources/views/partials/fields/vertical.blade.php
@@ -1,11 +1,19 @@
-<div class="form-group">
+{{--
+    Accessibility Improvements:
+    - Added `role="group"` to the `<div>` container for grouping related form elements to enhance assistive technology navigation.
+    - Applied `aria-labelledby` to associate the group with the corresponding `<label>` text for context.
+    - Added `aria-live="assertive"` to error messages (`invalid-feedback`) to ensure dynamic error handling is announced by screen readers.
+    - Included `aria-label="Additional information"` for the popover to help assistive technologies interpret its purpose.
+    - Added `role="alert"` to error message containers to ensure critical feedback is communicated immediately to assistive technologies.
+--}}
+<div class="form-group" role="group" aria-labelledby="{{$id}}">
     @isset($title)
-        <label for="{{$id}}" class="form-label">{{$title}}
+        <label for="{{$id}}" class="form-label" id="{{$id}}">{{$title}}
             @if(isset($attributes['required']) && $attributes['required'])
                 <sup class="text-danger">*</sup>
             @endif
 
-            <x-orchid-popover :content="$popover ?? ''"/>
+            <x-orchid-popover :content="$popover ?? ''" aria-label="Additional information"/>
         </label>
     @endisset
 
@@ -26,8 +34,8 @@
     @endphp
 
     @if($errors->has($oldName))
-        <div class="invalid-feedback d-block">
-            <small>{{$errors->first($oldName)}}</small>
+        <div class="invalid-feedback d-block" role="alert" aria-live="assertive">
+            <small role="alert">{{$errors->first($oldName)}}</small>
         </div>
     @elseif(isset($help))
         <small class="form-text text-muted">{!!$help!!}</small>

--- a/resources/views/partials/layouts/dt.blade.php
+++ b/resources/views/partials/layouts/dt.blade.php
@@ -1,5 +1,10 @@
-{{$title}}
+{{--
+    Accessibility Improvements:
+    - Wrapped the `$title` in a heading tag (e.g., `<h1>`) to improve document structure and ensure assistive technologies can navigate the content easily.
+    - Added an `aria-label` to the `<x-orchid-popover>` component to provide additional descriptive context for users relying on assistive technologies.
+--}}
+<h1>{{$title}}</h1>
 
-<x-orchid-popover :content="$popover"/>
+<x-orchid-popover :content="$popover" aria-label="More information about {{$title}}"/>
 
 

--- a/resources/views/partials/layouts/filter.blade.php
+++ b/resources/views/partials/layouts/filter.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-hidden="true"` to the `<x-orchid-icon>` to indicate that the icon is decorative and should be ignored by assistive technologies.
+    - Applied `aria-label` to the "Apply filters" button to provide a clear and descriptive label for users relying on screen readers.
+    - Included `role="menu"` and `role="presentation"` where appropriate to define the semantic roles of elements, aiding assistive technologies in understanding the component's purpose.
+--}}
 <div class="dropdown d-inline-block" data-controller="filter" data-action="click->filter#onMenuClick">
     <button class="btn btn-sm btn-link dropdown-toggle p-0 me-1"
             type="button"
@@ -5,15 +11,17 @@
             aria-haspopup="true"
             data-bs-boundary="viewport"
             aria-expanded="false">
-        <x-orchid-icon path="bs.funnel"/>
+        <x-orchid-icon path="bs.funnel" aria-hidden="true"/>
     </button>
-    <div class="dropdown-menu dropdown-menu-left dropdown-menu-arrow py-0" x-placement="bottom-end">
+    <div class="dropdown-menu dropdown-menu-left dropdown-menu-arrow py-0" x-placement="bottom-end"
+         role="menu">
         <div class="p-3">
             {!! $filter !!}
         </div>
 
-        <div class="bg-light p-3">
-            <button type="submit" form="filters" class="btn btn-link btn-sm w-100 border">
+        <div class="bg-light p-3" role="presentation">
+
+            <button type="submit" form="filters" class="btn btn-link btn-sm w-100 border" aria-label="Apply filters">
                 <span class="w-100 text-center">{{__('Apply')}}</span>
             </button>
         </div>

--- a/resources/views/partials/layouts/selectedTd.blade.php
+++ b/resources/views/partials/layouts/selectedTd.blade.php
@@ -1,6 +1,14 @@
-<div class="dropdown-item">
+{{--
+    Accessibility Improvements:
+    - Added `role="menuitem"` to signify that the checkbox is part of a dropdown menu structure, improving navigation for screen readers.
+    - Added `role="checkbox"` to define the element as a checkbox for assistive technologies.
+    - Added `aria-checked="true"` to indicate the checkbox's current state to screen readers.
+--}}
+<div class="dropdown-item" role="menuitem">
     <div class="form-check h-auto w-100 d-flex align-items-center ps-0">
         <input type="checkbox"
+               role="checkbox"
+               aria-checked="true"
                checked
                class="custom-control-input"
                id="{{ $slug }}"

--- a/resources/views/partials/layouts/th.blade.php
+++ b/resources/views/partials/layouts/th.blade.php
@@ -1,18 +1,27 @@
-<th @empty(!$width) width="{{$width}}" @endempty class="text-{{$align}}" data-column="{{ $slug }}">
+{{--
+    Accessibility Improvements:
+    - Replaced `text-muted` with `text-dark` to improve text contrast and enhance visibility for better user experience.
+    - Added `aria-label="Sort by {{ $title }}"` to improve navigation and understanding for screen readers when sorting columns.
+    - Added `aria-label="Filter options for column {{ $column }}"` to provide context about filter options for assistive technologies.
+    - Added `aria-label="Clear filter for column {{ $column }}"` to clarify the purpose of the filter clear button for screen readers.
+    - Added `role="button"` to ensure the filter clear element is properly recognized as an interactive button.
+--}}
+<th @empty(!$width) width="{{$width}}" @endempty class="text-{{$align}} text-dark" data-column="{{ $slug }}">
     <div class="d-inline-flex align-items-center">
 
         @includeWhen($filter !== null, "platform::partials.layouts.filter", ['filter' => $filter])
 
         @if($sort)
             <a href="{{ $sortUrl }}"
-               class="@if(!is_sort($column)) text-muted @endif">
+               class="@if(!is_sort($column)) text-dark @endif"
+               aria-label="Sort by {{ $title }}">
                 {!! $title !!}
 
                 <x-orchid-popover :content="$popover"/>
 
                 @if(is_sort($column))
                     @php $sortIcon = get_sort($column) === 'desc' ? 'bs.sort-down' : 'bs.sort-up' @endphp
-                    <x-orchid-icon :path="$sortIcon"/>
+                    <x-orchid-icon :path="$sortIcon" aria-hidden="true"/>
                 @endif
             </a>
         @else
@@ -23,11 +32,11 @@
     </div>
 
     @if($filterString)
-        <div data-controller="filter" class="mt-2">
+        <div data-controller="filter" class="mt-2" aria-label="Filter options for column {{ $column }}">
             <a href="#"
-               data-action="filter#clearFilter"
+               data-action="filter#clearFilter" aria-label="Clear filter for column {{ $column }}"
                data-filter="{{$column}}"
-               class="badge bg-light border d-inline-flex align-items-center">
+               class="badge bg-light border d-inline-flex align-items-center" role="button">
                 <span>{{ $filterString }}</span>
                 <x-orchid-icon path="bs.x-lg" class="ms-1"/>
             </a>

--- a/resources/views/partials/notification.blade.php
+++ b/resources/views/partials/notification.blade.php
@@ -1,9 +1,16 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-hidden="true"` to the `<x-orchid-icon>` to ensure the icon is decorative and not perceived by assistive technologies, improving screen reader focus on meaningful content.
+    - Applied `aria-label` to the "Mark notification as read" button so users relying on screen readers receive a descriptive label about the button's action and purpose.
+    - Added `aria-label="Notification timestamp"` to the timestamp element to explicitly clarify its meaning for assistive technologies.
+--}}
 <button formaction="{{ url()->current() }}/{{ $notification->id }}/maskNotification"
         type="submit"
-        class="btn btn-link text-start p-4 d-flex align-items-baseline">
+        class="btn btn-link text-start p-4 d-flex align-items-baseline"
+        aria-label="Mark notification as read">
 
     <small class="align-self-start me-2 text-{{ $notification->data['type'] }} @if($notification->read()) opacity @endif">
-        <x-orchid-icon path="bs.circle-fill"/>
+        <x-orchid-icon path="bs.circle-fill" aria-hidden="true"/>
     </small>
 
     <span class="ps-3 text-wrap text-break">
@@ -15,7 +22,7 @@
         </small>
     </span>
 
-    <small class="text-muted col-3 ms-auto d-none d-md-block text-end">
-         {{ $notification->created_at->diffForHumans() }}
+    <small class="text-muted col-3 ms-auto d-none d-md-block text-end" aria-label="Notification timestamp">
+        {{ $notification->created_at->diffForHumans() }}
     </small>
 </button>

--- a/resources/views/partials/pagination.blade.php
+++ b/resources/views/partials/pagination.blade.php
@@ -1,10 +1,17 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-hidden="true"` to decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+    - Used `aria-label` on pagination controls, including page links and prev/next buttons, to provide clear and meaningful descriptions for screen readers.
+    - Added `aria-disabled="true"` on elements that cannot be interacted with, improving usability for assistive technology users.
+    - Added `aria-current="page"` to indicate the currently active page in the pagination structure, providing better navigation context.
+--}}
 @if ($paginator->hasPages())
-    <ul class="pagination">
+    <ul class="pagination" aria-label="Pagination">
         {{-- Previous Page Link --}}
         @if ($paginator->onFirstPage())
-            <li class="page-item disabled"><span class="page-link">&laquo;</span></li>
+            <li class="page-item disabled" aria-disabled="true"><span class="page-link" aria-hidden="true">&laquo;</span></li>
         @else
-            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev">&laquo;</a>
+            <li class="page-item"><a class="page-link" href="{{ $paginator->previousPageUrl() }}" rel="prev" aria-label="Previous page">&laquo;</a>
             </li>
         @endif
 
@@ -13,16 +20,16 @@
             @foreach ($elements as $element)
                 {{-- "Three Dots" Separator --}}
                 @if (is_string($element))
-                    <li class="page-item disabled"><span class="page-link">{{ $element }}</span></li>
+                    <li class="page-item disabled" aria-disabled="true"><span class="page-link" aria-hidden="true">{{ $element }}</span></li>
                 @endif
 
                 {{-- Array Of Links --}}
                 @if (is_array($element))
                     @foreach ($element as $page => $url)
                         @if ($page == $paginator->currentPage())
-                            <li class="page-item active"><span class="page-link">{{ $page }}</span></li>
+                            <li class="page-item active" aria-current="page"><span class="page-link">{{ $page }}</span></li>
                         @else
-                            <li class="page-item"><a class="page-link" href="{{ $url }}">{{ $page }}</a></li>
+                            <li class="page-item"><a class="page-link" href="{{ $url }}" aria-label="Go to page {{ $page }}">{{ $page }}</a></li>
                         @endif
                     @endforeach
                 @endif
@@ -31,10 +38,10 @@
 
         {{-- Next Page Link --}}
         @if ($paginator->hasMorePages())
-            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next">&raquo;</a>
+            <li class="page-item"><a class="page-link" href="{{ $paginator->nextPageUrl() }}" rel="next" aria-label="Next page">&raquo;</a>
             </li>
         @else
-            <li class="page-item disabled"><span class="page-link">&raquo;</span></li>
+            <li class="page-item disabled" aria-disabled="true"><span class="page-link" aria-hidden="true">&raquo;</span></li>
         @endif
     </ul>
 @endif

--- a/resources/views/partials/result-compact.blade.php
+++ b/resources/views/partials/result-compact.blade.php
@@ -1,3 +1,8 @@
+{{--
+    Accessibility Improvements:
+    - Used `aria-live="polite"` for dynamic content, such as empty state messages, ensuring updates are announced to screen reader users without causing disruption.
+    - Added `aria-label` to interactive elements, such as links, to provide clear and meaningful descriptions for assistive technologies.
+--}}
 @forelse($results as $group)
 
 @empty(!$group['label'])
@@ -5,7 +10,7 @@
 @endempty
 
 @foreach($group['result'] as $item)
-    <a href="{{$item->url()}}" class="block py-2 px-3 dropdown-item" style="font-size: 0.85em;">
+    <a href="{{$item->url()}}" class="block py-2 px-3 dropdown-item" style="font-size: 0.85em;" aria-label="{{$item->title()}}">
 
         @empty(!$item->image())
             <span class="pull-left thumb-xs rounded me-3">
@@ -24,7 +29,7 @@
 
 @empty
 
-    <p class="ms-3 me-3 mb-0 text-center">
+    <p class="ms-3 me-3 mb-0 text-center" aria-live="polite">
         {{ __('There are no records in this view.') }}
     </p>
 
@@ -33,7 +38,7 @@
 
 @if($total >= 5)
 
-    <a href="{{ route('platform.search', $query) }}" class="block py-2 px-3 dropdown-item border-top pb-1">
+    <a href="{{ route('platform.search', $query) }}" class="block py-2 px-3 dropdown-item border-top pb-1" aria-label="{{ __('See more results for ') . $query }}">
         <span class="small ps-1">
             {{ __('See more results.') }}
             <span class="text-muted">({{ $total }})</span>

--- a/resources/views/partials/result.blade.php
+++ b/resources/views/partials/result.blade.php
@@ -1,3 +1,9 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-hidden="true"` to purely decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+    - Used `aria-live="polite"` for dynamic content, such as the empty state message, to announce updates to screen reader users without causing disruption.
+    - Added `role="list"` to the container element for lists of items to better define the semantic structure for assistive technologies.
+--}}
 @section('search', $query)
 
 @empty(!$radios)
@@ -6,7 +12,7 @@
 
 @endempty
 
-<div class="bg-white shadow-sm rounded mb-3">
+<div class="bg-white shadow-sm rounded mb-3" role="list">
     @forelse($results as $item)
 
         <a href="{{$item->url()}}" class="block py-2 px-3 dropdown-item" style="font-size: 0.85em;">
@@ -26,9 +32,9 @@
         </a>
     @empty
 
-        <div class="text-center pt-5 pb-5 w-100">
+        <div class="text-center pt-5 pb-5 w-100" aria-live="polite">
             <h3 class="fw-light">
-                <x-orchid-icon path="bs.funnel" class="block mb-3 center"/>
+                <x-orchid-icon path="bs.funnel" class="block mb-3 center" aria-hidden="true"/>
 
                 {{ __('Nothing found.') }}
             </h3>

--- a/resources/views/partials/search.blade.php
+++ b/resources/views/partials/search.blade.php
@@ -1,8 +1,14 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to interactive elements, such as input fields and links, to provide clear and meaningful descriptions for assistive technologies.
+    - Added `aria-hidden="true"` to purely decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+    - Added `role="listbox"` to define the semantic role of the dropdown container, improving navigation and context for assistive technologies.
+--}}
 @empty(!Dashboard::getSearch()->all())
     <div class="p-3">
         <div class="dropdown position-relative" data-controller="search">
             <div class="input-icon">
-                <input
+                <input aria-label="{{ __('Search') }}"
                     data-action="keyup->search#query blur->search#blur focus->search#focus"
                     data-search-target="query"
                     type="text"
@@ -11,11 +17,11 @@
                        placeholder="{{ __('What to search...') }}"
                 >
                 <div class="input-icon-addon">
-                    <x-orchid-icon path="bs.search"/>
+                    <x-orchid-icon path="bs.search" aria-hidden="true"/>
                 </div>
             </div>
             <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow bg-white w-100"
-                 x-placement="start-left" id="search-result">
+                 x-placement="start-left" id="search-result" role="listbox">
             </div>
         </div>
     </div>

--- a/resources/views/partials/toast.blade.php
+++ b/resources/views/partials/toast.blade.php
@@ -1,7 +1,13 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-label` to interactive elements, such as input fields and links, to provide clear and meaningful descriptions for assistive technologies.
+    - Added `aria-hidden="true"` to purely decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+--}}
 <div class="toast-wrapper" data-controller="toast">
     <template id="toast">
         <div class="toast rounded shadow-sm bg-white mb-3"
              role="alert"
+             aria-label="Notification {type}"
              aria-live="assertive"
              aria-atomic="true"
              data-bs-delay="5000"
@@ -9,7 +15,7 @@
             <div class="toast-body p-3 d-flex">
                 <p class="mb-0">
                     <span class="text-{type}">
-                        <x-orchid-icon path="bs.circle-fill" class="me-2"/>
+                        <x-orchid-icon path="bs.circle-fill" class="me-2" aria-hidden="true"/>
                     </span>
                     {message}
                 </p>
@@ -22,6 +28,7 @@
     @if (session()->has(\Orchid\Alert\Toast::SESSION_MESSAGE))
         <div class="toast rounded shadow-sm bg-white mb-3"
              role="alert"
+             aria-label="Notification {{ session(\Orchid\Alert\Toast::SESSION_LEVEL) }}"
              aria-live="assertive"
              aria-atomic="true"
              data-bs-delay="{{ session(\Orchid\Alert\Toast::SESSION_DELAY) }}"
@@ -31,7 +38,7 @@
             <div class="toast-body p-3 d-flex">
                 <p class="mb-0 me-1">
                     <span class="text-{{ session(\Orchid\Alert\Toast::SESSION_LEVEL) }}">
-                        <x-orchid-icon path="bs.circle-fill" class="me-2"/>
+                        <x-orchid-icon path="bs.circle-fill" class="me-2" aria-hidden="true"/>
                     </span>
 
                     {!! session(\Orchid\Alert\Toast::SESSION_MESSAGE) !!}

--- a/resources/views/partials/update-assets.blade.php
+++ b/resources/views/partials/update-assets.blade.php
@@ -1,7 +1,12 @@
+{{--
+    Accessibility Improvements:
+    - Added `aria-hidden="true"` to purely decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+    - Added `role="alert"` to the alert container, ensuring critical information is announced immediately to assistive technologies.
+--}}
 @if(!\Orchid\Platform\Dashboard::assetsAreCurrent())
-    <div class="alert alert-warning rounded shadow-sm mb-3 p-4" data-turbo-temporary>
+    <div class="alert alert-warning rounded shadow-sm mb-3 p-4" data-turbo-temporary role="alert">
         <div class="d-flex align-items-center mb-2 text-body-emphasis">
-            <x-orchid-icon path="bs.exclamation-triangle" width="2em" height="2em" class="me-2"/>
+            <x-orchid-icon path="bs.exclamation-triangle" width="2em" height="2em" class="me-2" aria-hidden="true"/>
             <h4 class="mb-0 fw-light">{{ __("Complete the update.") }}</h4>
         </div>
 

--- a/resources/views/partials/welcome.blade.php
+++ b/resources/views/partials/welcome.blade.php
@@ -1,4 +1,11 @@
-<div class="bg-white rounded-top shadow-sm mb-4 rounded-bottom">
+{{--
+    Accessibility Improvements:
+    - Added `role="region"` to group and landmark sections, assisting users in navigating complex layouts.
+    - Added `aria-label` to interactive elements, such as input fields and links, to provide clear and meaningful descriptions for assistive technologies.
+    - Added `aria-hidden="true"` to purely decorative elements, such as icons, ensuring they are ignored by assistive technologies.
+    - Added `role="article"` to define standalone content, improving semantics and navigation for assistive technologies.
+--}}
+<div class="bg-white rounded-top shadow-sm mb-4 rounded-bottom" role="region">
 
     <div class="row g-0">
         <div class="col col-lg-7 mt-6 p-4">
@@ -12,19 +19,19 @@
                 You are minutes away from creativity than ever before. Enjoy!
             </p>
         </div>
-        <div class="d-none d-lg-block col align-self-center text-end text-muted p-4 opacity-25">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" role="img" width="6em" height="100%" viewBox="0 0 100 100">
+        <div class="d-none d-lg-block col align-self-center text-end text-muted p-4 opacity-25" aria-hidden="true">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" role="img" width="6em" height="100%" viewBox="0 0 100 100" aria-label="Decorative graphic">
                 <path d="M86.55 30.73c-11.33 10.72-27.5 12.65-42.3 14.43-10.94 1.5-23.3 3.78-30.48 13.04-6.2 8.3-4.25 20.3 2.25 27.8 1.35 2.03 5.7 5.7 6.38 5.3-5.96-8.42-5.88-21.6 2.6-28.4 8.97-7.52 21.2-7.1 32.03-9.7 6.47-1.23 13.3-3.5 19.2-5.34-8.3 7.44-19.38 10.36-29.7 13.75-8.7 3.08-17.22 10.23-17.45 20.1-.17 6.8 3.1 14.9 10.06 17.07 18.56 4.34 39.14-3.16 50.56-18.4 12.7-16.12 13.75-40.2 2.43-57.33-1.33 2.9-3.28 5.5-5.58 7.7z"/>
                 <path d="M0 49.97c-.14 4.35 1.24 13.9 2.63 14.64 1.2-11.48 10.2-20.74 20.83-24.47 17.9-7.06 38.75-3.1 55.66-13.18 5.16-2.3 9.28-9.48 4.36-14.1-2.16-1.76-5.9-5.75-3.7-.72.83 6.22-5.47 10.06-10.63 11.65-10.9 3.34-22.46 3-33.62 4.93-1.9.32-5.9 1.2-2.07-.6 10.52-5.02 23.57-4.38 32.6-12.5 4.8-3.75 2.77-11.16-2.4-13.4C57.4-.35 50.3-.35 43.63.35c-19.85 2.3-37.3 17.7-42.05 37.1C.52 41.57 0 45.77 0 49.97z"/>
             </svg>
         </div>
     </div>
 
-    <div class="row bg-light m-0 p-md-4 p-3 border-top rounded-bottom g-md-5 text-balance">
+    <div class="row bg-light m-0 p-md-4 p-3 border-top rounded-bottom g-md-5 text-balance" role="region">
 
         <div class="col-md-6 my-2">
             <h3 class="text-muted fw-light lh-lg d-flex align-items-center">
-                <x-orchid-icon path="bs.book"/>
+                <x-orchid-icon path="bs.book" aria-hidden="true"/>
 
                 <span class="ms-3 text-body-emphasis">Explore the Documentation</span>
             </h3>
@@ -37,7 +44,7 @@
 
         <div class="col-md-6 my-2">
             <h3 class="text-muted fw-light lh-lg d-flex align-items-center">
-                <x-orchid-icon path="bs.rocket"/>
+                <x-orchid-icon path="bs.rocket" aria-hidden="true"/>
 
                 <span class="ms-3 text-body-emphasis">Quick Start Guide</span>
             </h3>
@@ -47,9 +54,9 @@
             </p>
         </div>
 
-        <div class="col-md-6 my-2">
+        <div class="col-md-6 my-2" role="article">
             <h3 class="text-muted fw-light lh-lg d-flex align-items-center">
-                <x-orchid-icon path="bs.collection"/>
+                <x-orchid-icon path="bs.collection" aria-hidden="true"/>
 
                 <span class="ms-3 text-body-emphasis">The Screens</span>
             </h3>
@@ -62,7 +69,7 @@
 
         <div class="col-md-6 my-2">
             <h3 class="text-muted fw-light lh-lg d-flex align-items-center">
-                <x-orchid-icon path="bs.window-sidebar"/>
+                <x-orchid-icon path="bs.window-sidebar" aria-hidden="true"/>
 
                 <span class="ms-3 text-body-emphasis">Layouts</span>
             </h3>
@@ -73,9 +80,9 @@
             </p>
         </div>
 
-        <div class="col-md-6 my-2">
+        <div class="col-md-6 my-2" role="article">
             <h3 class="text-muted fw-light lh-lg d-flex align-items-center">
-                <x-orchid-icon path="bs.star"/>
+                <x-orchid-icon path="bs.star" aria-hidden="true"/>
 
                 <span class="ms-3 text-body-emphasis">And one more thing</span>
             </h3>
@@ -87,9 +94,9 @@
             </p>
         </div>
 
-        <div class="col-md-6 my-2">
+        <div class="col-md-6 my-2" role="article">
             <h3 class="text-muted fw-light lh-lg d-flex align-items-center">
-                <x-orchid-icon path="bs.life-preserver"/>
+                <x-orchid-icon path="bs.life-preserver" aria-hidden="true"/>
 
                 <span class="ms-3 text-body-emphasis">Connect with the Community</span>
             </h3>

--- a/resources/views/workspace/compact.blade.php
+++ b/resources/views/workspace/compact.blade.php
@@ -1,8 +1,12 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="main"` to identify the primary content area, helping assistive technologies skip directly to the main content.
+--}}
 @extends('platform::app')
 
 @section('body')
 
-    <div class="container-xl p-0 h-100">
+    <div class="container-xl p-0 h-100" role="main">
         <div class="workspace workspace-limit pt-3 pt-md-4 mb-4 mb-md-0 d-flex flex-column h-100">
             @yield('workspace')
 

--- a/resources/views/workspace/full.blade.php
+++ b/resources/views/workspace/full.blade.php
@@ -1,9 +1,14 @@
+{{--
+    Accessibility Improvements:
+    - Added `role="main"` to the outer container `<div>` to designate the primary content area of the page, enabling assistive technologies to skip directly to it.
+    - Added `role="region"` to the workspace `<div>` to define a recognizable landmark, helping users navigate structured regions within the page.
+--}}
 @extends('platform::app')
 
 @section('body')
 
-    <div class="p-0 h-100">
-        <div class="workspace pt-3 pt-md-4 mb-4 mb-md-0 d-flex flex-column h-100">
+    <div class="p-0 h-100"  role="main">
+        <div class="workspace pt-3 pt-md-4 mb-4 mb-md-0 d-flex flex-column h-100" role="region">
             @yield('workspace')
 
             @includeFirst([config('platform.template.footer'), 'platform::footer'])


### PR DESCRIPTION
Fixes #

Improve accessibility

- Adding ARIA labels, roles, and unique IDs
- Linking inputs to datalists
- Marking decorative icons as aria-hidden
- Adding alt attributes for images
- Fixing accordion and tab interactions to be fully accessible and navigable via Tab for screen readers.
- Adding a "Skip to main content" link to tables for improved keyboard navigation.
- Adding styles for `:focus-visible` and "skip" links to improve focus visibility when navigating via Tab.
