### PR TITLE
Error Notifications Are Not Passing Correctly in Attach

### DIFF
--- a/resources/views/fields/attach.blade.php
+++ b/resources/views/fields/attach.blade.php
@@ -14,8 +14,8 @@
          data-attach-upload-url-value="{{ $uploadUrl ?? route('platform.systems.files.upload') }}"
          data-attach-sort-url-value="{{ $sortUrl ?? route('platform.systems.files.sort') }}"
 
-         data-uploader-error-size-value="{{ __('File ":name" is too large to upload') }}"
-         data-uploader-error-type-value="{{ __('The attached file must be an image') }}"
+         data-attach-error-size-value="{{ $errorMaxSizeMessage }}"
+         data-attach-error-type-value="{{ $errorTypeMessage }}"
 
          data-action="
              drop->attach#dropFiles:prevent


### PR DESCRIPTION
The values specified for the `Attach` field (`Attach::make(...)->errorTypeMessage('...')->errorMaxSizeMessage('...')`) are not being passed correctly.  

I haven't tested the functionality of `errorMaxSizeMessage` yet, nor have I verified other aspects. However, it seems that nothing is broken, and everything else works as expected. :)