### PR TITLE
Add method labels in Tabs

### DIFF
--- a/resources/views/layouts/tabs.blade.php
+++ b/resources/views/layouts/tabs.blade.php
@@ -19,7 +19,7 @@
                        aria-selected="false"
                        role="tab"
                        data-bs-toggle="tab">
-                        {!! $name !!}
+                        {!! $labels[$name] ?? $name !!}
                     </a>
                 </li>
             @endforeach

--- a/src/Screen/Layouts/Tabs.php
+++ b/src/Screen/Layouts/Tabs.php
@@ -22,6 +22,7 @@ abstract class Tabs extends Layout
      */
     protected $variables = [
         'activeTab'    => null,
+        'labels'       => [],
     ];
 
     /**
@@ -48,6 +49,16 @@ abstract class Tabs extends Layout
     public function activeTab(string $name)
     {
         $this->variables['activeTab'] = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function labels(array $labels)
+    {
+        $this->variables['labels'] = $labels;
 
         return $this;
     }


### PR DESCRIPTION
Fixes #

## Proposed Changes

- add new feature in tabs
- new method "labels" that allows you to set custom tab names
- this may be necessary when you need to make several tabs on one page with the same labels but with different keys