### PR TITLE
Added activeAccordion method to Accordion.php

### DIFF
--- a/resources/views/layouts/accordion.blade.php
+++ b/resources/views/layouts/accordion.blade.php
@@ -1,10 +1,10 @@
 <div id="accordion-{{$templateSlug}}" class="accordion mb-3">
     @foreach($manyForms as $name => $forms)
-        <div class="accordion-heading @if ($loop->index) collapsed @endif"
+        <div class="accordion-heading @if (!isset($activeAccordion) && $loop->index || (isset($activeAccordion) && $activeAccordion !== $name)) collapsed @endif"
              id="heading-{{\Illuminate\Support\Str::slug($name)}}"
              data-bs-toggle="collapse"
              data-bs-target="#collapse-{{\Illuminate\Support\Str::slug($name)}}"
-             aria-expanded="true"
+             aria-expanded="{{ isset($activeAccordion) ? ($activeAccordion === $name ? 'true' : 'false') : (!$loop->index ? 'true' : 'false') }}"
              aria-controls="collapse-{{\Illuminate\Support\Str::slug($name)}}">
             <h6 class="btn btn-link btn-group-justified pt-2 pb-2 mb-0 pe-0 ps-0 d-flex align-items-center">
                 <x-orchid-icon path="bs.chevron-right" class="small me-2"/> {!! $name !!}
@@ -12,15 +12,15 @@
         </div>
 
         <div id="collapse-{{\Illuminate\Support\Str::slug($name)}}"
-             class="mt-2 collapse @if (!$loop->index) show @endif"
+             class="mt-2 collapse @if ((isset($activeAccordion) && $activeAccordion === $name) || (!isset($activeAccordion) && !$loop->index)) show @endif"
              aria-labelledby="heading-{{\Illuminate\Support\Str::slug($name)}}"
              @if (!$stayOpen)
                  data-bs-parent="#accordion-{{$templateSlug}}"
-            @endif
+                @endif
         >
-                @foreach($forms as $form)
-                    {!! $form !!}
-                @endforeach
+            @foreach($forms as $form)
+                {!! $form !!}
+            @endforeach
         </div>
     @endforeach
 </div>

--- a/resources/views/layouts/accordion.blade.php
+++ b/resources/views/layouts/accordion.blade.php
@@ -1,10 +1,10 @@
 <div id="accordion-{{$templateSlug}}" class="accordion mb-3">
     @foreach($manyForms as $name => $forms)
-        <div class="accordion-heading @if (!isset($activeAccordion) && $loop->index || (isset($activeAccordion) && $activeAccordion !== $name)) collapsed @endif"
+        <div class="accordion-heading @if (!in_array($name, $open)) collapsed @endif"
              id="heading-{{\Illuminate\Support\Str::slug($name)}}"
              data-bs-toggle="collapse"
              data-bs-target="#collapse-{{\Illuminate\Support\Str::slug($name)}}"
-             aria-expanded="{{ isset($activeAccordion) ? ($activeAccordion === $name ? 'true' : 'false') : (!$loop->index ? 'true' : 'false') }}"
+             aria-expanded="{{ in_array($name, $open) ? 'true' : 'false' }}"
              aria-controls="collapse-{{\Illuminate\Support\Str::slug($name)}}">
             <h6 class="btn btn-link btn-group-justified pt-2 pb-2 mb-0 pe-0 ps-0 d-flex align-items-center">
                 <x-orchid-icon path="bs.chevron-right" class="small me-2"/> {!! $name !!}
@@ -12,7 +12,7 @@
         </div>
 
         <div id="collapse-{{\Illuminate\Support\Str::slug($name)}}"
-             class="mt-2 collapse @if ((isset($activeAccordion) && $activeAccordion === $name) || (!isset($activeAccordion) && !$loop->index)) show @endif"
+             class="mt-2 collapse @if (in_array($name, $open)) show @endif"
              aria-labelledby="heading-{{\Illuminate\Support\Str::slug($name)}}"
              @if (!$stayOpen)
                  data-bs-parent="#accordion-{{$templateSlug}}"

--- a/src/Screen/Layouts/Accordion.php
+++ b/src/Screen/Layouts/Accordion.php
@@ -55,4 +55,18 @@ abstract class Accordion extends Layout
 
         return $this;
     }
+
+    /**
+     * Specifies the accordion that should be opened by default.
+     *
+     * @param string $activeAccordion
+     *
+     * @return $this
+     */
+    public function activeAccordion(string $activeAccordion): self
+    {
+        $this->variables['activeAccordion'] = $activeAccordion;
+
+        return $this;
+    }
 }

--- a/src/Screen/Layouts/Accordion.php
+++ b/src/Screen/Layouts/Accordion.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Screen\Layouts;
 
+use Illuminate\Support\Arr;
 use Orchid\Screen\Layout;
 use Orchid\Screen\Repository;
 
@@ -18,10 +19,16 @@ abstract class Accordion extends Layout
     protected $template = 'platform::layouts.accordion';
 
     /**
+     * @var bool
+     */
+    private $openSet = false;
+
+    /**
      * @var array
      */
     protected $variables = [
         'stayOpen' => false,
+        'open' => [],
     ];
 
     /**
@@ -32,6 +39,7 @@ abstract class Accordion extends Layout
     public function __construct(array $layouts = [])
     {
         $this->layouts = $layouts;
+        $this->variables['open'] = [array_key_first($this->layouts)];
     }
 
     /**
@@ -57,16 +65,21 @@ abstract class Accordion extends Layout
     }
 
     /**
-     * Specifies the accordion that should be opened by default.
+     * Set active accordion(s).
      *
-     * @param string $activeAccordion
+     * @param string|array $activeAccordion
      *
      * @return $this
      */
-    public function activeAccordion(string $activeAccordion): self
+    public function activeAccordion(string|array $activeAccordion): self
     {
-        $this->variables['activeAccordion'] = $activeAccordion;
+        $this->variables['open'] = $this->openSet
+            ? array_merge($this->variables['open'], Arr::wrap($activeAccordion))
+            : $activeAccordion;
+
+        $this->openSet = true;
 
         return $this;
     }
+
 }

--- a/src/Screen/Layouts/Accordion.php
+++ b/src/Screen/Layouts/Accordion.php
@@ -71,10 +71,12 @@ abstract class Accordion extends Layout
      *
      * @return $this
      */
-    public function activeAccordion(string|array $activeAccordion): self
+    public function open(string|array $activeAccordion): self
     {
+        $activeAccordion = Arr::wrap($activeAccordion);
+
         $this->variables['open'] = $this->openSet
-            ? array_merge($this->variables['open'], Arr::wrap($activeAccordion))
+            ? array_merge($this->variables['open'], $activeAccordion)
             : $activeAccordion;
 
         $this->openSet = true;

--- a/src/Screen/Layouts/Accordion.php
+++ b/src/Screen/Layouts/Accordion.php
@@ -19,11 +19,6 @@ abstract class Accordion extends Layout
     protected $template = 'platform::layouts.accordion';
 
     /**
-     * @var bool
-     */
-    private $openSet = false;
-
-    /**
      * @var array
      */
     protected $variables = [
@@ -73,13 +68,7 @@ abstract class Accordion extends Layout
      */
     public function open(string|array $activeAccordion): self
     {
-        $activeAccordion = Arr::wrap($activeAccordion);
-
-        $this->variables['open'] = $this->openSet
-            ? array_merge($this->variables['open'], $activeAccordion)
-            : $activeAccordion;
-
-        $this->openSet = true;
+        $this->variables['open'] = Arr::wrap($activeAccordion);
 
         return $this;
     }


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Added open method to Accordion.php. Allows you to specify which accordions should be open when the page is opened. Accepts a string and an array, if the method is not called, the first accordion will be opened by default, as it was before adding the method
