### PR TITLE
Improve Accordion accessibility

### DIFF
--- a/resources/sass/core/layout.scss
+++ b/resources/sass/core/layout.scss
@@ -8,6 +8,13 @@ body {
   overflow-x: hidden;
 }
 
+a, button, .btn {
+    &:focus-visible {
+        outline: 2px auto #005fcc !important;  /* Blue outline */
+    }
+}
+
+
 
 @include media-breakpoint-up(xl) {
     .aside {

--- a/resources/views/layouts/accordion.blade.php
+++ b/resources/views/layouts/accordion.blade.php
@@ -6,9 +6,9 @@
              data-bs-target="#collapse-{{\Illuminate\Support\Str::slug($name)}}"
              aria-expanded="true"
              aria-controls="collapse-{{\Illuminate\Support\Str::slug($name)}}">
-            <h6 class="btn btn-link btn-group-justified pt-2 pb-2 mb-0 pe-0 ps-0 d-flex align-items-center">
+            <button type="button" class="btn btn-link btn-group-justified pt-2 pb-2 mb-0 pe-0 ps-0 d-flex align-items-center">
                 <x-orchid-icon path="bs.chevron-right" class="small me-2"/> {!! $name !!}
-            </h6>
+            </button>
         </div>
 
         <div id="collapse-{{\Illuminate\Support\Str::slug($name)}}"


### PR DESCRIPTION
Fixes #2941

## Proposed Changes

- Replaced `<h6>` with `<button>` to make the Accordion component more semantic and improve accessibility for screen readers.
- Added a `:focus-visible` outline style to `a`, `button`, and `.btn` elements to enhance focus visibility, specifically for keyboard users.

