### PR TITLE
[15.0] Refactor `Dashboard` class into independent traits for better modularity

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -69,7 +69,7 @@ jobs:
 
 
       - name: Execute tests (Unit and Feature tests) via PHPUnit 🧪
-        run: vendor/bin/phpunit  --no-coverage --disable-coverage-ignore
+        run: vendor/bin/phpunit  --no-coverage --disable-coverage-ignore --order-by=random
 
   dusk:
     runs-on: ubuntu-latest
@@ -105,7 +105,7 @@ jobs:
 
 
       - name: Execute Unit Tests
-        run: vendor/bin/phpunit --testsuite=Browser --no-coverage
+        run: vendor/bin/phpunit --testsuite=Browser --no-coverage --order-by=random
         env:
           CI: true
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,7 +26,14 @@
         <UndefinedClass>
             <errorLevel type="suppress">
                 <referencedClass name="Laravel\Octane\Events\RequestReceived" />
+                <referencedClass name="Orchid\Support\Attributes\ClearsOctaneState" />
             </errorLevel>
         </UndefinedClass>
+
+        <UndefinedAttributeClass>
+            <errorLevel type="suppress">
+                <referencedClass name="Orchid\Support\Attributes\ClearsOctaneState" />
+            </errorLevel>
+        </UndefinedAttributeClass>
     </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -26,14 +26,7 @@
         <UndefinedClass>
             <errorLevel type="suppress">
                 <referencedClass name="Laravel\Octane\Events\RequestReceived" />
-                <referencedClass name="Orchid\Support\Attributes\ClearsOctaneState" />
             </errorLevel>
         </UndefinedClass>
-
-        <UndefinedAttributeClass>
-            <errorLevel type="suppress">
-                <referencedClass name="Orchid\Support\Attributes\ClearsOctaneState" />
-            </errorLevel>
-        </UndefinedAttributeClass>
     </issueHandlers>
 </psalm>

--- a/resources/views/footer.blade.php
+++ b/resources/views/footer.blade.php
@@ -29,7 +29,7 @@
         <p class="small mb-0">
             {{ __('The application code is published under the MIT license.') }} 2016 - {{date('Y')}}<br>
             <a href="http://orchid.software" target="_blank" rel="noopener">
-                {{ __('Version') }}: {{\Orchid\Platform\Dashboard::version()}}
+                {{ __('Version') }}: {{ Dashboard::version() }}
             </a>
         </p>
     </div>

--- a/resources/views/partials/update-assets.blade.php
+++ b/resources/views/partials/update-assets.blade.php
@@ -1,4 +1,4 @@
-@if(!\Orchid\Platform\Dashboard::assetsAreCurrent())
+@if(!Dashboard::assetsAreCurrent())
     <div class="alert alert-warning rounded shadow-sm mb-3 p-4" data-turbo-temporary>
         <div class="d-flex align-items-center mb-2 text-body-emphasis">
             <x-orchid-icon path="bs.exclamation-triangle" width="2em" height="2em" class="me-2"/>

--- a/src/Access/RoleAccess.php
+++ b/src/Access/RoleAccess.php
@@ -8,8 +8,8 @@ use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Models\User;
+use Orchid\Support\Facades\Dashboard;
 
 trait RoleAccess
 {

--- a/src/Access/RoleAccess.php
+++ b/src/Access/RoleAccess.php
@@ -8,7 +8,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Models\User;
 
 trait RoleAccess

--- a/src/Access/UserAccess.php
+++ b/src/Access/UserAccess.php
@@ -12,7 +12,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\AddRoleEvent;
 use Orchid\Platform\Events\RemoveRoleEvent;
 use Orchid\Platform\Models\Role;

--- a/src/Access/UserAccess.php
+++ b/src/Access/UserAccess.php
@@ -12,10 +12,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\AddRoleEvent;
 use Orchid\Platform\Events\RemoveRoleEvent;
 use Orchid\Platform\Models\Role;
+use Orchid\Support\Facades\Dashboard;
 
 trait UserAccess
 {

--- a/src/Attachment/Attachable.php
+++ b/src/Attachment/Attachable.php
@@ -6,7 +6,7 @@ namespace Orchid\Attachment;
 
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 
 /**
  * This trait is used to relate or attach multiple files with Eloquent models.

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -13,9 +13,9 @@ use Illuminate\Support\Str;
 use Orchid\Attachment\Contracts\Engine;
 use Orchid\Attachment\Engines\Generator;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\ReplicateFileEvent;
 use Orchid\Platform\Events\UploadFileEvent;
+use Orchid\Support\Facades\Dashboard;
 
 /**
  * This class represents an uploaded file that can be saved to the disk

--- a/src/Attachment/File.php
+++ b/src/Attachment/File.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Str;
 use Orchid\Attachment\Contracts\Engine;
 use Orchid\Attachment\Engines\Generator;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\ReplicateFileEvent;
 use Orchid\Platform\Events\UploadFileEvent;
 

--- a/src/Attachment/Models/Attachment.php
+++ b/src/Attachment/Models/Attachment.php
@@ -15,7 +15,7 @@ use Orchid\Attachment\MimeTypes;
 use Orchid\Filters\Filterable;
 use Orchid\Filters\Types\Like;
 use Orchid\Platform\Concerns\Sortable;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Models\User;
 use Orchid\Screen\AsSource;
 

--- a/src/Attachment/Models/Attachment.php
+++ b/src/Attachment/Models/Attachment.php
@@ -15,9 +15,9 @@ use Orchid\Attachment\MimeTypes;
 use Orchid\Filters\Filterable;
 use Orchid\Filters\Types\Like;
 use Orchid\Platform\Concerns\Sortable;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Models\User;
 use Orchid\Screen\AsSource;
+use Orchid\Support\Facades\Dashboard;
 
 /**
  * Class Attachment.

--- a/src/Platform/Commands/InstallCommand.php
+++ b/src/Platform/Commands/InstallCommand.php
@@ -7,9 +7,9 @@ namespace Orchid\Platform\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Traits\Conditionable;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\InstallEvent;
 use Orchid\Platform\Providers\ConsoleServiceProvider;
+use Orchid\Support\Facades\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:install')]

--- a/src/Platform/Commands/InstallCommand.php
+++ b/src/Platform/Commands/InstallCommand.php
@@ -7,7 +7,7 @@ namespace Orchid\Platform\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Traits\Conditionable;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\InstallEvent;
 use Orchid\Platform\Providers\ConsoleServiceProvider;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Platform/Configuration/ManagesMenu.php
+++ b/src/Platform/Configuration/ManagesMenu.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Illuminate\Support\Collection;
+use Orchid\Screen\Actions\Menu;
+
+trait ManagesMenu
+{
+    /**
+     * The collection of menu items.
+     *
+     * @var Collection<Menu>
+     */
+    private ?Collection $menuItems;
+
+    /**
+     * @return Collection<Menu>
+     */
+    public function menu(): Collection
+    {
+        $this->menuItems = $this->menuItems ?? collect();
+
+        return $this->menuItems;
+    }
+
+    /**
+     * Register a menu element with the Dashboard.
+     *
+     * @param Menu $menu The menu element to add.
+     *
+     * @return $this
+     */
+    public function registerMenuElement(Menu $menu): static
+    {
+        if ($menu->get('sort', 0) === 0) {
+            $menu->sort($this->menu->count() + 1);
+        }
+
+        $this->menu()->add($menu);
+
+        return $this;
+    }
+
+    /**
+     * Render the menu as a string for display.
+     *
+     * @throws \Throwable If rendering fails.
+     *
+     * @return string The rendered menu HTML.
+     */
+    public function renderMenu(): string
+    {
+        return $this->menu()
+            ->sort(fn (Menu $current, Menu $next) => $current->get('sort', 0) <=> $next->get('sort', 0))
+            ->map(fn (Menu $menu) => (string) $menu->render())
+            ->implode('');
+    }
+
+    /**
+     * Check if the menu is empty.
+     *
+     * @return bool True if the menu is empty, otherwise false.
+     */
+    public function isEmptyMenu(): bool
+    {
+        return $this->menu()->isEmpty();
+    }
+
+    /**
+     * Add submenu items to a menu element identified by its slug.
+     *
+     * @param string $slug The slug of the menu element to update.
+     * @param Menu[] $list Array of submenu items to add.
+     *
+     * @return $this
+     */
+    public function addMenuSubElements(string $slug, array $list): static
+    {
+        $this->menuItems = $this->menu()
+            ->map(fn (Menu $menu) => $slug === $menu->get('slug')
+                ? $menu->list($list)
+                : $menu);
+
+        return $this;
+    }
+}

--- a/src/Platform/Configuration/ManagesMenu.php
+++ b/src/Platform/Configuration/ManagesMenu.php
@@ -3,7 +3,7 @@
 namespace Orchid\Platform\Configuration;
 
 use Orchid\Screen\Actions\Menu;
-use Orchid\Support\Attributes\ClearsOctaneState;
+use Orchid\Support\Attributes\FlushOctaneState;
 
 trait ManagesMenu
 {
@@ -12,7 +12,7 @@ trait ManagesMenu
      *
      * @var array<Menu>
      */
-    #[ClearsOctaneState]
+    #[FlushOctaneState]
     protected array $menuItems = [];
 
     /**

--- a/src/Platform/Configuration/ManagesModelOptions.php
+++ b/src/Platform/Configuration/ManagesModelOptions.php
@@ -6,14 +6,19 @@ use Illuminate\Support\Arr;
 
 trait ManagesModelOptions
 {
+    protected array $registeredReplaceModels = [];
+
     /**
      * Get the model instance for a given key or class name.
      *
+     * @param string      $key
+     * @param string|null $default
+     *
      * @return mixed
      */
-    public static function modelClass(string $key, ?string $default = null)
+    public function modelClass(string $key, ?string $default = null): mixed
     {
-        $model = static::model($key, $default);
+        $model = $this->model($key, $default);
 
         return class_exists($model) ? new $model : $model;
     }
@@ -21,16 +26,18 @@ trait ManagesModelOptions
     /**
      * Get the class name for a given Dashboard model.
      */
-    public static function model(string $key, ?string $default = null): string
+    public function model(string $key, ?string $default = null): string
     {
-        return Arr::get(static::$options, 'models.'.$key, $default ?? $key);
+        return Arr::get($this->registeredReplaceModels, $key, $default ?? $key);
     }
 
     /**
      * Get the user model class name.
      */
-    public static function useModel(string $key, string $custom): void
+    public function useModel(string $key, string $custom): static
     {
-        static::$options['models'][$key] = $custom;
+       $this->registeredReplaceModels[$key] = $custom;
+
+       return $this;
     }
 }

--- a/src/Platform/Configuration/ManagesModelOptions.php
+++ b/src/Platform/Configuration/ManagesModelOptions.php
@@ -36,8 +36,8 @@ trait ManagesModelOptions
      */
     public function useModel(string $key, string $custom): static
     {
-       $this->registeredReplaceModels[$key] = $custom;
+        $this->registeredReplaceModels[$key] = $custom;
 
-       return $this;
+        return $this;
     }
 }

--- a/src/Platform/Configuration/ManagesModelOptions.php
+++ b/src/Platform/Configuration/ManagesModelOptions.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Illuminate\Support\Arr;
+
+trait ManagesModelOptions
+{
+    /**
+     * Get the model instance for a given key or class name.
+     *
+     * @return mixed
+     */
+    public static function modelClass(string $key, ?string $default = null)
+    {
+        $model = static::model($key, $default);
+
+        return class_exists($model) ? new $model : $model;
+    }
+
+    /**
+     * Get the class name for a given Dashboard model.
+     */
+    public static function model(string $key, ?string $default = null): string
+    {
+        return Arr::get(static::$options, 'models.'.$key, $default ?? $key);
+    }
+
+    /**
+     * Get the user model class name.
+     */
+    public static function useModel(string $key, string $custom): void
+    {
+        static::$options['models'][$key] = $custom;
+    }
+}

--- a/src/Platform/Configuration/ManagesPackage.php
+++ b/src/Platform/Configuration/ManagesPackage.php
@@ -6,12 +6,14 @@ use Composer\InstalledVersions;
 
 trait ManagesPackage
 {
+    protected static string $composerPackage = 'orchid/platform';
+
     /**
      * Get the version number of the application.
      */
     public static function version(): string
     {
-        return InstalledVersions::getVersion('orchid/platform');
+        return InstalledVersions::getVersion(static::$composerPackage);
     }
 
     /**
@@ -19,7 +21,7 @@ trait ManagesPackage
      */
     public static function path(string $path = ''): string
     {
-        $current = InstalledVersions::getInstallPath('orchid/platform');
+        $current = InstalledVersions::getInstallPath(static::$composerPackage);
 
         return realpath($current.($path ? DIRECTORY_SEPARATOR.$path : $path));
     }

--- a/src/Platform/Configuration/ManagesPackage.php
+++ b/src/Platform/Configuration/ManagesPackage.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Composer\InstalledVersions;
+
+trait ManagesPackage
+{
+    /**
+     * Get the version number of the application.
+     */
+    public static function version(): string
+    {
+        return InstalledVersions::getVersion('orchid/platform');
+    }
+
+    /**
+     * The real path to the package files.
+     */
+    public static function path(string $path = ''): string
+    {
+        $current = InstalledVersions::getInstallPath('orchid/platform');
+
+        return realpath($current.($path ? DIRECTORY_SEPARATOR.$path : $path));
+    }
+}

--- a/src/Platform/Configuration/ManagesPermissions.php
+++ b/src/Platform/Configuration/ManagesPermissions.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Illuminate\Support\Collection;
+use Orchid\Platform\ItemPermission;
+
+trait ManagesPermissions
+{
+    /**
+     * Collection of permissions for the application.
+     *
+     * @var Collection
+     */
+    private $permission;
+
+    /**
+     * Registers a ItemPermission that defines authentication permissions.
+     *
+     * @return $this
+     */
+    public function registerPermissions(ItemPermission $permission): self
+    {
+        if (empty($permission->group)) {
+            return $this;
+        }
+
+        $old = $this->permission->get('all')
+            ->get($permission->group, []);
+
+        $this->permission->get('all')
+            ->put($permission->group, array_merge_recursive($old, $permission->items));
+
+        return $this;
+    }
+
+    /**
+     * Retrieve permissions based on specified groups.
+     *
+     * @param array|string $groups
+     */
+    public function getPermission($groups = []): Collection
+    {
+        $all = $this->permission->get('all')
+            ->when(! empty($groups), fn (Collection $collection) => $collection->only($groups));
+
+        $removed = $this->permission->get('removed');
+
+        if (! $removed->count()) {
+            return $all;
+        }
+
+        return $all->map(static function ($group) use ($removed) {
+            foreach ($group[key($group)] as $key => $item) {
+                if ($removed->contains($item)) {
+                    unset($group[key($group)]);
+                }
+            }
+
+            return $group;
+        });
+    }
+
+    /**
+     * Get all registered permissions with the enabled state.
+     *
+     * @param array|string $groups
+     */
+    public function getAllowAllPermission($groups = []): Collection
+    {
+        return $this->getPermission($groups)
+            ->collapse()
+            ->reduce(static fn (Collection $permissions, array $item) => $permissions->put($item['slug'], true), collect());
+    }
+
+    /**
+     * Remove a specific permission by key.
+     *
+     * @return $this
+     */
+    public function removePermission(string $key): self
+    {
+        $this->permission->get('removed')->push($key);
+
+        return $this;
+    }
+}

--- a/src/Platform/Configuration/ManagesResources.php
+++ b/src/Platform/Configuration/ManagesResources.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+trait ManagesResources
+{
+    /**
+     * Collection of JS and CSS resources for the panel.
+     *
+     * @var Collection
+     */
+    public $resources;
+
+    /**
+     * Register a resource with the given key.
+     *
+     * @param string|array $value
+     */
+    public function registerResource(string $key, $value): self
+    {
+        $item = $this->resources->get($key, []);
+
+        $this->resources[$key] = array_merge($item, Arr::wrap($value));
+
+        return $this;
+    }
+
+    /**
+     * Return CSS\JS.
+     *
+     * @param null $key
+     *
+     * @return array|Collection|mixed
+     */
+    public function getResource($key = null)
+    {
+        if ($key === null) {
+            return $this->resources;
+        }
+
+        return $this->resources->get($key);
+    }
+
+    /**
+     * Determine published assets are up-to-date.
+     *
+     * @throws \RuntimeException
+     *
+     * @return bool
+     */
+    public static function assetsAreCurrent(): bool
+    {
+        $publishedPath = public_path('vendor/orchid/mix-manifest.json');
+
+        throw_unless(File::exists($publishedPath), new RuntimeException('Orchid assets are not published. Please run: `php artisan orchid:publish`'));
+
+        return File::get($publishedPath) === File::get(__DIR__.'/../../public/mix-manifest.json');
+    }
+}

--- a/src/Platform/Configuration/ManagesScreens.php
+++ b/src/Platform/Configuration/ManagesScreens.php
@@ -4,6 +4,7 @@ namespace Orchid\Platform\Configuration;
 
 use Illuminate\Support\Facades\App;
 use Orchid\Screen\Screen;
+use Orchid\Support\Attributes\ClearsOctaneState;
 
 trait ManagesScreens
 {
@@ -12,7 +13,8 @@ trait ManagesScreens
      *
      * @var Screen|null
      */
-    private ?Screen $currentScreen;
+    #[ClearsOctaneState]
+    private ?Screen $currentScreen = null;
 
     /**
      * Determines whether the current request is a partial request or not.
@@ -21,6 +23,7 @@ trait ManagesScreens
      *
      * @var bool Set to true if the current request is a partial request, false otherwise.
      */
+    #[ClearsOctaneState]
     private bool $partialRequest = false;
 
     /**
@@ -36,9 +39,9 @@ trait ManagesScreens
     /**
      * Get the current screen instance.
      *
-     * @return $this
+     * @return static The current instance to allow method chaining.
      */
-    public function setCurrentScreen(Screen $screen, bool $partialRequest = false): self
+    public function setCurrentScreen(Screen $screen, bool $partialRequest = false): static
     {
         $this->currentScreen = $screen;
         $this->partialRequest = $partialRequest;

--- a/src/Platform/Configuration/ManagesScreens.php
+++ b/src/Platform/Configuration/ManagesScreens.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Illuminate\Support\Facades\App;
+use Orchid\Screen\Screen;
+
+trait ManagesScreens
+{
+    /**
+     * The current screen instance.
+     *
+     * @var Screen|null
+     */
+    private ?Screen $currentScreen;
+
+    /**
+     * Determines whether the current request is a partial request or not.
+     * A partial request is a request that only loads a specific part of the page, such as a modal window or a section of content,
+     * instead of loading the entire page.
+     *
+     * @var bool Set to true if the current request is a partial request, false otherwise.
+     */
+    private bool $partialRequest = false;
+
+    /**
+     * Get the current screen instance.
+     *
+     * @return Screen|null The current screen instance or null if not set.
+     */
+    public function getCurrentScreen(): ?Screen
+    {
+        return $this->currentScreen;
+    }
+
+    /**
+     * Get the current screen instance.
+     *
+     * @return $this
+     */
+    public function setCurrentScreen(Screen $screen, bool $partialRequest = false): self
+    {
+        $this->currentScreen = $screen;
+        $this->partialRequest = $partialRequest;
+
+        App::singleton($screen::class, static fn () => $screen);
+        App::rebinding($screen::class, static fn () => app($screen::class));
+
+        return $this;
+    }
+
+    /**
+     * Determines whether the current request is a partial request or not.
+     *
+     * A partial request is a request that only loads a specific part of the page, such as a modal window or a section of content,
+     * instead of loading the entire page. This method returns a boolean value indicating whether the current request is a partial
+     * request or not, based on the value of the $partialRequest property.
+     *
+     * @return bool True if the current request is a partial request, false otherwise.
+     */
+    public function isPartialRequest(): bool
+    {
+        return $this->partialRequest;
+    }
+}

--- a/src/Platform/Configuration/ManagesScreens.php
+++ b/src/Platform/Configuration/ManagesScreens.php
@@ -4,7 +4,7 @@ namespace Orchid\Platform\Configuration;
 
 use Illuminate\Support\Facades\App;
 use Orchid\Screen\Screen;
-use Orchid\Support\Attributes\ClearsOctaneState;
+use Orchid\Support\Attributes\FlushOctaneState;
 
 trait ManagesScreens
 {
@@ -13,7 +13,7 @@ trait ManagesScreens
      *
      * @var Screen|null
      */
-    #[ClearsOctaneState]
+    #[FlushOctaneState]
     private ?Screen $currentScreen = null;
 
     /**
@@ -23,7 +23,7 @@ trait ManagesScreens
      *
      * @var bool Set to true if the current request is a partial request, false otherwise.
      */
-    #[ClearsOctaneState]
+    #[FlushOctaneState]
     private bool $partialRequest = false;
 
     /**

--- a/src/Platform/Configuration/ManagesSearch.php
+++ b/src/Platform/Configuration/ManagesSearch.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Orchid\Platform\Configuration;
+
+use Illuminate\Support\Collection;
+
+trait ManagesSearch
+{
+    /**
+     * Registers a set of models for which full-text search is required.
+     *
+     * @return $this
+     */
+    public function registerSearch(array $models): static
+    {
+        static::$options['search'] = array_merge($models, static::$options['search'] ?? []);
+
+        return $this;
+    }
+
+    /**
+     * Get the list of searchable models, ensuring uniqueness and resolving model instances.
+     *
+     * @return Collection The collection of searchable models.
+     */
+    public function getSearch(): Collection
+    {
+        return collect(static::$options['search'])
+            ->unique()
+            ->transform(static fn ($model) => is_object($model) ? $model : resolve($model));
+    }
+}

--- a/src/Platform/Configuration/ManagesSearch.php
+++ b/src/Platform/Configuration/ManagesSearch.php
@@ -7,13 +7,22 @@ use Illuminate\Support\Collection;
 trait ManagesSearch
 {
     /**
+     * A registry of all registered permissions, grouped by category.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected static array $registeredSearchModels = [];
+
+    /**
      * Registers a set of models for which full-text search is required.
      *
-     * @return $this
+     * @param array $models
+     *
+     * @return static
      */
     public function registerSearch(array $models): static
     {
-        static::$options['search'] = array_merge($models, static::$options['search'] ?? []);
+        static::$registeredSearchModels = array_merge(static::$registeredSearchModels, $models);
 
         return $this;
     }
@@ -25,7 +34,7 @@ trait ManagesSearch
      */
     public function getSearch(): Collection
     {
-        return collect(static::$options['search'])
+        return collect(static::$registeredSearchModels)
             ->unique()
             ->transform(static fn ($model) => is_object($model) ? $model : resolve($model));
     }

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -6,7 +6,7 @@ namespace Orchid\Platform;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
-use Orchid\Support\Attributes\ClearsOctaneState;
+use Orchid\Support\Attributes\FlushOctaneState;
 
 class Dashboard
 {
@@ -43,7 +43,7 @@ class Dashboard
 
         foreach ($properties as $property) {
             foreach ($property->getAttributes() as $attribute) {
-                if ($attribute->getName() !== ClearsOctaneState::class) {
+                if ($attribute->getName() !== FlushOctaneState::class) {
                     continue;
                 }
 

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -47,7 +47,7 @@ class Dashboard
                     continue;
                 }
 
-               $property->setValue($this, $property->getDefaultValue());
+                $property->setValue($this, $property->getDefaultValue());
             }
         }
     }

--- a/src/Platform/Dashboard.php
+++ b/src/Platform/Dashboard.php
@@ -5,18 +5,19 @@ declare(strict_types=1);
 namespace Orchid\Platform;
 
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
-use Orchid\Screen\Actions\Menu;
-use Orchid\Screen\Screen;
-use RuntimeException;
 
 class Dashboard
 {
-    use Macroable;
+    use Configuration\ManagesMenu,
+        Configuration\ManagesModelOptions,
+        Configuration\ManagesPackage,
+        Configuration\ManagesPermissions,
+        Configuration\ManagesResources,
+        Configuration\ManagesScreens,
+        Configuration\ManagesSearch,
+        Macroable;
 
     /**
      * The current Orchid version.
@@ -43,43 +44,6 @@ class Dashboard
     ];
 
     /**
-     * The collection of menu items.
-     *
-     * @var Collection<Menu>
-     */
-    public $menu;
-
-    /**
-     * Collection of JS and CSS resources for the panel.
-     *
-     * @var Collection
-     */
-    public $resources;
-
-    /**
-     * Collection of permissions for the application.
-     *
-     * @var Collection
-     */
-    private $permission;
-
-    /**
-     * The current screen instance.
-     *
-     * @var Screen|null
-     */
-    private $currentScreen;
-
-    /**
-     * Determines whether the current request is a partial request or not.
-     * A partial request is a request that only loads a specific part of the page, such as a modal window or a section of content,
-     * instead of loading the entire page.
-     *
-     * @var bool Set to true if the current request is a partial request, false otherwise.
-     */
-    private bool $partialRequest = false;
-
-    /**
      * Dashboard constructor.
      */
     public function __construct()
@@ -92,30 +56,6 @@ class Dashboard
         ]);
 
         $this->flushState();
-    }
-
-    /**
-     * Get the version number of the application.
-     */
-    public static function version(): string
-    {
-        return static::VERSION;
-    }
-
-    /**
-     * Determine published assets are up-to-date.
-     *
-     * @throws \RuntimeException
-     *
-     * @return bool
-     */
-    public static function assetsAreCurrent(): bool
-    {
-        $publishedPath = public_path('vendor/orchid/mix-manifest.json');
-
-        throw_unless(File::exists($publishedPath), new RuntimeException('Orchid assets are not published. Please run: `php artisan orchid:publish`'));
-
-        return File::get($publishedPath) === File::get(__DIR__.'/../../public/mix-manifest.json');
     }
 
     /**
@@ -149,271 +89,7 @@ class Dashboard
     }
 
     /**
-     * Get the model instance for a given key or class name.
-     *
-     * @return mixed
-     */
-    public static function modelClass(string $key, ?string $default = null)
-    {
-        $model = static::model($key, $default);
-
-        return class_exists($model) ? new $model : $model;
-    }
-
-    /**
-     * Get the class name for a given Dashboard model.
-     */
-    public static function model(string $key, ?string $default = null): string
-    {
-        return Arr::get(static::$options, 'models.'.$key, $default ?? $key);
-    }
-
-    /**
-     * Get the user model class name.
-     */
-    public static function useModel(string $key, string $custom): void
-    {
-        static::$options['models'][$key] = $custom;
-    }
-
-    /**
-     * The real path to the package files.
-     */
-    public static function path(string $path = ''): string
-    {
-        $current = dirname(__DIR__, 2);
-
-        return realpath($current.($path ? DIRECTORY_SEPARATOR.$path : $path));
-    }
-
-    /**
-     * Registers a ItemPermission that defines authentication permissions.
-     *
-     * @return $this
-     */
-    public function registerPermissions(ItemPermission $permission): self
-    {
-        if (empty($permission->group)) {
-            return $this;
-        }
-
-        $old = $this->permission->get('all')
-            ->get($permission->group, []);
-
-        $this->permission->get('all')
-            ->put($permission->group, array_merge_recursive($old, $permission->items));
-
-        return $this;
-    }
-
-    /**
-     * Registers a set of models for which full-text search is required.
-     *
-     * @return $this
-     */
-    public function registerSearch(array $models): self
-    {
-        static::$options['search'] = array_merge($models, static::$options['search'] ?? []);
-
-        return $this;
-    }
-
-    /**
-     * Register a resource with the given key.
-     *
-     * @param string|array $value
-     */
-    public function registerResource(string $key, $value): self
-    {
-        $item = $this->resources->get($key, []);
-
-        $this->resources[$key] = array_merge($item, Arr::wrap($value));
-
-        return $this;
-    }
-
-    /**
-     * Return CSS\JS.
-     *
-     * @param null $key
-     *
-     * @return array|Collection|mixed
-     */
-    public function getResource($key = null)
-    {
-        if ($key === null) {
-            return $this->resources;
-        }
-
-        return $this->resources->get($key);
-    }
-
-    /**
-     * Get the list of searchable models, ensuring uniqueness and resolving model instances.
-     *
-     * @return Collection The collection of searchable models.
-     */
-    public function getSearch(): Collection
-    {
-        return collect(static::$options['search'])
-            ->unique()
-            ->transform(static fn ($model) => is_object($model) ? $model : resolve($model));
-    }
-
-    /**
-     * Retrieve permissions based on specified groups.
-     *
-     * @param array|string $groups
-     */
-    public function getPermission($groups = []): Collection
-    {
-        $all = $this->permission->get('all')
-            ->when(! empty($groups), fn (Collection $collection) => $collection->only($groups));
-
-        $removed = $this->permission->get('removed');
-
-        if (! $removed->count()) {
-            return $all;
-        }
-
-        return $all->map(static function ($group) use ($removed) {
-            foreach ($group[key($group)] as $key => $item) {
-                if ($removed->contains($item)) {
-                    unset($group[key($group)]);
-                }
-            }
-
-            return $group;
-        });
-    }
-
-    /**
-     * Get all registered permissions with the enabled state.
-     *
-     * @param array|string $groups
-     */
-    public function getAllowAllPermission($groups = []): Collection
-    {
-        return $this->getPermission($groups)
-            ->collapse()
-            ->reduce(static fn (Collection $permissions, array $item) => $permissions->put($item['slug'], true), collect());
-    }
-
-    /**
-     * Remove a specific permission by key.
-     *
-     * @return $this
-     */
-    public function removePermission(string $key): self
-    {
-        $this->permission->get('removed')->push($key);
-
-        return $this;
-    }
-
-    /**
-     * Get the current screen instance.
-     *
-     * @return $this
-     */
-    public function setCurrentScreen(Screen $screen, bool $partialRequest = false): self
-    {
-        $this->currentScreen = $screen;
-        $this->partialRequest = $partialRequest;
-
-        App::singleton($screen::class, static fn () => $screen);
-        App::rebinding($screen::class, static fn () => app($screen::class));
-
-        return $this;
-    }
-
-    /**
-     * Get the current screen instance.
-     *
-     * @return Screen|null The current screen instance or null if not set.
-     */
-    public function getCurrentScreen(): ?Screen
-    {
-        return $this->currentScreen;
-    }
-
-    /**
-     * Determines whether the current request is a partial request or not.
-     *
-     * A partial request is a request that only loads a specific part of the page, such as a modal window or a section of content,
-     * instead of loading the entire page. This method returns a boolean value indicating whether the current request is a partial
-     * request or not, based on the value of the $partialRequest property.
-     *
-     * @return bool True if the current request is a partial request, false otherwise.
-     */
-    public function isPartialRequest(): bool
-    {
-        return $this->partialRequest;
-    }
-
-    /**
-     * Register a menu element with the Dashboard.
-     *
-     * @param Menu $menu The menu element to add.
-     *
-     * @return $this
-     */
-    public function registerMenuElement(Menu $menu): Dashboard
-    {
-        if ($menu->get('sort', 0) === 0) {
-            $menu->sort($this->menu->count() + 1);
-        }
-
-        $this->menu->add($menu);
-
-        return $this;
-    }
-
-    /**
-     * Render the menu as a string for display.
-     *
-     * @throws \Throwable If rendering fails.
-     *
-     * @return string The rendered menu HTML.
-     */
-    public function renderMenu(): string
-    {
-        return $this->menu
-            ->sort(fn (Menu $current, Menu $next) => $current->get('sort', 0) <=> $next->get('sort', 0))
-            ->map(fn (Menu $menu) => (string) $menu->render())
-            ->implode('');
-    }
-
-    /**
-     * Check if the menu is empty.
-     *
-     * @return bool True if the menu is empty, otherwise false.
-     */
-    public function isEmptyMenu(): bool
-    {
-        return $this->menu->isEmpty();
-    }
-
-    /**
-     * Add submenu items to a menu element identified by its slug.
-     *
-     * @param string $slug The slug of the menu element to update.
-     * @param Menu[] $list Array of submenu items to add.
-     *
-     * @return $this
-     */
-    public function addMenuSubElements(string $slug, array $list): Dashboard
-    {
-        $this->menu = $this->menu
-            ->map(fn (Menu $menu) => $slug === $menu->get('slug')
-                ? $menu->list($list)
-                : $menu);
-
-        return $this;
-    }
-
-    /**
-     * Clear all persistent state information in the Dashboard.
+     * Clear all persistent state information in the Orchid.
      *
      * This method is essential for Laravel Octane to properly handle stateful requests
      * when the Dashboard is used as a singleton. It ensures that any stored data

--- a/src/Platform/Http/Controllers/AttachmentController.php
+++ b/src/Platform/Http/Controllers/AttachmentController.php
@@ -11,8 +11,8 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Orchid\Attachment\File;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\UploadedFileEvent;
+use Orchid\Support\Facades\Dashboard;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/src/Platform/Http/Controllers/AttachmentController.php
+++ b/src/Platform/Http/Controllers/AttachmentController.php
@@ -11,7 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Orchid\Attachment\File;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Events\UploadedFileEvent;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Platform/Providers/ConsoleServiceProvider.php
+++ b/src/Platform/Providers/ConsoleServiceProvider.php
@@ -20,7 +20,7 @@ use Orchid\Platform\Commands\SelectionCommand;
 use Orchid\Platform\Commands\StubPublishCommand;
 use Orchid\Platform\Commands\TableCommand;
 use Orchid\Platform\Commands\TabMenuCommand;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 
 class ConsoleServiceProvider extends ServiceProvider
 {

--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Providers;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
@@ -83,7 +84,7 @@ class FoundationServiceProvider extends ServiceProvider
      */
     public function registerOctaneEventsListen(): self
     {
-        Event::listen(fn (\Laravel\Octane\Events\RequestReceived $request) => \Orchid\Support\Facades\Dashboard::flushState());
+        Event::listen(fn (\Laravel\Octane\Events\RequestReceived $request) => \Orchid\Support\Facades\Dashboard::flush());
 
         return $this;
     }
@@ -112,7 +113,15 @@ class FoundationServiceProvider extends ServiceProvider
             ->registerTranslations()
             ->registerProviders();
 
-        $this->app->singleton(Dashboard::class, static fn () => new Dashboard);
+        $this->app->bind(
+            Dashboard::class,
+            fn(Application $app) => $app->make(Dashboard::class)
+        );
+
+        $this->app->singleton(
+            Dashboard::class,
+            static fn(Application $app) => new Dashboard
+        );
 
         $this
             ->registerScreenMacro()

--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -115,12 +115,12 @@ class FoundationServiceProvider extends ServiceProvider
 
         $this->app->bind(
             Dashboard::class,
-            fn(Application $app) => $app->make(Dashboard::class)
+            fn (Application $app) => $app->make(Dashboard::class)
         );
 
         $this->app->singleton(
             Dashboard::class,
-            static fn(Application $app) => new Dashboard
+            static fn (Application $app) => new Dashboard
         );
 
         $this

--- a/src/Platform/Providers/RouteServiceProvider.php
+++ b/src/Platform/Providers/RouteServiceProvider.php
@@ -6,7 +6,7 @@ namespace Orchid\Platform\Providers;
 
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Http\Middleware\Access;
 use Orchid\Platform\Http\Middleware\BladeIcons;
 use Orchid\Platform\Http\Middleware\Turbo;

--- a/src/Platform/Providers/RouteServiceProvider.php
+++ b/src/Platform/Providers/RouteServiceProvider.php
@@ -6,10 +6,10 @@ namespace Orchid\Platform\Providers;
 
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Route;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Platform\Http\Middleware\Access;
 use Orchid\Platform\Http\Middleware\BladeIcons;
 use Orchid\Platform\Http\Middleware\Turbo;
+use Orchid\Support\Facades\Dashboard;
 
 class RouteServiceProvider extends ServiceProvider
 {

--- a/src/Screen/Fields/Attach.php
+++ b/src/Screen/Fields/Attach.php
@@ -6,10 +6,10 @@ namespace Orchid\Screen\Fields;
 
 use Illuminate\Support\Arr;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 use Orchid\Support\Assert;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Support\Init;
 
 /**

--- a/src/Screen/Fields/Attach.php
+++ b/src/Screen/Fields/Attach.php
@@ -6,7 +6,7 @@ namespace Orchid\Screen\Fields;
 
 use Illuminate\Support\Arr;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 use Orchid\Support\Assert;

--- a/src/Screen/Fields/Picture.php
+++ b/src/Screen/Fields/Picture.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Orchid\Screen\Fields;
 
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Screen\Field;
 use Orchid\Support\Init;
 

--- a/src/Screen/Fields/Picture.php
+++ b/src/Screen/Fields/Picture.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Orchid\Screen\Fields;
 
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Screen\Field;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Support\Init;
 
 /**

--- a/src/Screen/Fields/Upload.php
+++ b/src/Screen/Fields/Upload.php
@@ -6,9 +6,9 @@ namespace Orchid\Screen\Fields;
 
 use Illuminate\Support\Arr;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Support\Facades\Dashboard;
 use Orchid\Screen\Field;
 use Orchid\Support\Assert;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Support\Init;
 
 /**

--- a/src/Screen/Fields/Upload.php
+++ b/src/Screen/Fields/Upload.php
@@ -6,7 +6,7 @@ namespace Orchid\Screen\Fields;
 
 use Illuminate\Support\Arr;
 use Orchid\Attachment\Models\Attachment;
-use Orchid\Platform\Dashboard;
+use Orchid\Support\Facades\Dashboard;
 use Orchid\Screen\Field;
 use Orchid\Support\Assert;
 use Orchid\Support\Init;

--- a/src/Support/Attributes/FlushOctaneState.php
+++ b/src/Support/Attributes/FlushOctaneState.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Support\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class FlushOctaneState
+{
+
+}

--- a/src/Support/Attributes/FlushOctaneState.php
+++ b/src/Support/Attributes/FlushOctaneState.php
@@ -7,7 +7,4 @@ namespace Orchid\Support\Attributes;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_PROPERTY)]
-class FlushOctaneState
-{
-
-}
+class FlushOctaneState {}

--- a/src/Support/Blade.php
+++ b/src/Support/Blade.php
@@ -63,6 +63,7 @@ class Blade
 
         return resolve($class, $data);
     }
+
     /**
      * Get information about a component
      *

--- a/src/Support/Blade.php
+++ b/src/Support/Blade.php
@@ -15,11 +15,6 @@ class Blade
     private static array $components = [];
 
     /**
-     * The component tag compiler instance.
-     */
-    private static ComponentTagCompiler $compiler;
-
-    /**
      * Used to render a Blade component from a class and an array of data
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
@@ -68,7 +63,6 @@ class Blade
 
         return resolve($class, $data);
     }
-
     /**
      * Get information about a component
      *
@@ -97,7 +91,7 @@ class Blade
      */
     private static function compiler(): ComponentTagCompiler
     {
-        return static::$compiler ??= new ComponentTagCompiler(
+        return new ComponentTagCompiler(
             app('blade.compiler')->getClassComponentAliases(),
             app('blade.compiler')->getClassComponentNamespaces(),
             app('blade.compiler')

--- a/src/Support/Facades/Dashboard.php
+++ b/src/Support/Facades/Dashboard.php
@@ -20,7 +20,7 @@ use Orchid\Screen\Screen;
  * @method        static      configure(array $options)
  * @method        static      option(string $key, ?string $default = null)
  * @method static mixed       modelClass(string $key, string $default = null)
- * @method        static      model(string $key, string $default = null)
+ * @method static string      model(string $key, string $default = null)
  * @method        static      useModel(string $key, string $custom)
  * @method static bool        checkUpdate()
  * @method static self        setCurrentScreen(Screen $screen, bool $partialRequest = false)

--- a/src/Support/Presenter.php
+++ b/src/Support/Presenter.php
@@ -17,7 +17,7 @@ abstract class Presenter
      *
      * @var object
      */
-    protected $entity;
+    protected object $entity;
 
     /**
      * Create a new instance of the presenter.

--- a/tests/Unit/DashboardTest.php
+++ b/tests/Unit/DashboardTest.php
@@ -22,7 +22,8 @@ class DashboardTest extends TestUnitCase
 
     public function testIsModelDefault(): void
     {
-        $class = Dashboard::modelClass('UnknownClass', User::class);
+        $dashboard = new Dashboard;
+        $class = $dashboard->modelClass('UnknownClass', User::class);
 
         $default = new User;
 
@@ -31,27 +32,13 @@ class DashboardTest extends TestUnitCase
 
     public function testIsModelCustomNotFound(): void
     {
-        Dashboard::useModel(User::class, 'MyCustomClass');
+        $dashboard = new Dashboard;
 
-        $user = Dashboard::modelClass(User::class);
+        $dashboard->useModel(User::class, 'MyCustomClass');
+
+        $user = $dashboard->modelClass(User::class);
 
         $this->assertEquals('MyCustomClass', $user);
-    }
-
-    public function testIsModelConfigure(): void
-    {
-        Dashboard::configure([
-            'models' => [
-                User::class => 'MyCustomClass',
-            ],
-        ]);
-
-        $class = Dashboard::model(User::class);
-        $option = Dashboard::option('models.'.User::class);
-
-        $this->assertEquals('MyCustomClass', $class);
-        $this->assertEquals('MyCustomClass', $option);
-        $this->assertEquals(null, Dashboard::option('random'));
     }
 
     public function testIsRegisterResource(): void
@@ -143,12 +130,12 @@ class DashboardTest extends TestUnitCase
     protected function setUp(): void
     {
         parent::setUp();
-        Dashboard::configure([]);
+        \Orchid\Support\Facades\Dashboard::flush();
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
-        Dashboard::configure([]);
+        \Orchid\Support\Facades\Dashboard::flush();
     }
 }

--- a/tests/Unit/MetricsTest.php
+++ b/tests/Unit/MetricsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Tests\Unit;
 
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 use Orchid\Metrics\GroupCollection;
 use Orchid\Platform\Models\User;
 use Orchid\Tests\TestUnitCase;
@@ -221,7 +221,7 @@ class MetricsTest extends TestUnitCase
         });
 
         /* Carbon Language */
-        \Carbon\Carbon::setLocale('ru');
+        Carbon::setLocale('ru');
 
         $period = User::sumByDays('id', $start)->showDaysOfWeek()->toChart('Users');
 
@@ -261,5 +261,12 @@ class MetricsTest extends TestUnitCase
             'labels'  => $period->pluck('label')->toArray(),
             'values'  => $period->pluck('value')->toArray(),
         ], $period->toChart('Users'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setLocale('en');
+
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
I plan to split the `Dashboard` class into independent traits to make the architecture more flexible and easier to maintain. To achieve this, I will likely need to move away from methods like `configure`, with each trait storing only its own values.

However, one key consideration is that each trait will be responsible for its own data, which will require careful management of state and likely the use of enumerations to organize values.

Currently, this is still a work in progress.