### PR TITLE
Fix Laravel Version Conflict

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,8 +9,8 @@ on:
       - 'composer.json'
 
 jobs:
-  composer-validate:
-    name: composer-validate
+  composer:
+    name: composer
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,20 +25,6 @@ jobs:
 
       - name: Validate composer.json and composer.lock 👀
         run: composer validate
-
-  composer-outdated:
-    name: composer-outdated
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup PHP 🔧
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
-          coverage: none
-          tools: composer:v2
 
       - name: Install dependencies
         run: composer install --no-progress --no-suggest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,6 +26,32 @@ jobs:
       - name: Validate composer.json and composer.lock 👀
         run: composer validate
 
+  composer-outdated:
+    name: composer-outdated
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 🔧
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-progress --no-suggest
+
+      - name: Check for outdated dependencies
+        run: |
+          if [ -n "$(composer outdated --direct)" ]; then
+            echo "❌ There are outdated dependencies!"
+            composer outdated --direct
+            exit 1
+          fi
+        shell: bash
+
   psalm:
     name: psalm
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "conflict": {
-        "laravel/framework": "<10.48.25 || >=11.34.0",
+        "laravel/framework": "<=10.48.25, <=11.34.0",
         "orchestra/testbench-core": "<8.23.9",
         "nesbot/carbon": "<2.66.0"
     },


### PR DESCRIPTION
This PR addresses issue #2951, where updating to `orchid/platform` v14.45.0 caused an unexpected downgrade of `laravel/framework` and other dependencies.  

#### Changes:  
- Fixed Laravel version conflict in `composer.json` to ensure compatibility.  
- Added a check for outdated dependencies to prevent similar issues in the future.  
