### PR TITLE
Added Simple Persistent Notification Sending

### DIFF
--- a/src/Platform/Notifications/DashboardMessage.php
+++ b/src/Platform/Notifications/DashboardMessage.php
@@ -37,6 +37,18 @@ class DashboardMessage extends Notification implements Arrayable
     }
 
     /**
+     * Create a new element.
+     *
+     * @param mixed ...$arguments
+     *
+     * @return static
+     */
+    public static function make(...$arguments): static
+    {
+        return new static(...$arguments);
+    }
+
+    /**
      * Set the title of the message.
      *
      * @param string $title The title to be set.

--- a/src/Platform/Notifications/DashboardMessage.php
+++ b/src/Platform/Notifications/DashboardMessage.php
@@ -5,21 +5,18 @@ declare(strict_types=1);
 namespace Orchid\Platform\Notifications;
 
 use Carbon\Carbon;
-use Illuminate\Notifications\Messages\DatabaseMessage;
+use Illuminate\Notifications\Notification;
 use Orchid\Support\Color;
+use Illuminate\Contracts\Support\Arrayable;
 
-class DashboardMessage extends DatabaseMessage
+class DashboardMessage extends Notification implements Arrayable
 {
     /**
      * The data that should be stored with the notification.
      *
      * @var array
      */
-    public $data = [
-        'title'   => '',
-        'action'  => '#', // URL for the "View" button
-        'message' => '',
-    ];
+    public array $data = [];
 
     /**
      * Create a new instance of DashboardMessage with the given data.
@@ -29,11 +26,14 @@ class DashboardMessage extends DatabaseMessage
     public function __construct(array $data = [])
     {
         $default = [
-            'time' => Carbon::now(), // The timestamp this message was created.
-            'type' => Color::INFO->name(), // The type of message (INFO, WARNING, SUCCESS, or ERROR).
+            'title'   => '',
+            'action'  => '#', // URL for the "View" button
+            'message' => '',
+            'time'    => Carbon::now(), // The timestamp this message was created.
+            'type'    => Color::INFO->name(), // The type of message (INFO, WARNING, SUCCESS, or ERROR).
         ];
 
-        parent::__construct(array_merge($default, $data));
+        $this->data = array_merge($default, $data);
     }
 
     /**
@@ -91,5 +91,37 @@ class DashboardMessage extends DatabaseMessage
         $this->data['type'] = $color->name();
 
         return $this;
+    }
+
+    /**
+     * Get the notification channels.
+     *
+     * @param mixed $notifiable
+     *
+     * @return array
+     */
+    public function via(mixed $notifiable)
+    {
+        return [DashboardChannel::class];
+    }
+
+    /**
+     * Get the instance as an array for dashboard.
+     *
+     * @return array
+     */
+    public function toDashboard(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Convert the notification instance to an array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return $this->data;
     }
 }

--- a/src/Platform/Notifications/DashboardMessage.php
+++ b/src/Platform/Notifications/DashboardMessage.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Orchid\Platform\Notifications;
 
 use Carbon\Carbon;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Notifications\Notification;
 use Orchid\Support\Color;
-use Illuminate\Contracts\Support\Arrayable;
 
 class DashboardMessage extends Notification implements Arrayable
 {

--- a/tests/Feature/Platform/NotificationTest.php
+++ b/tests/Feature/Platform/NotificationTest.php
@@ -6,12 +6,34 @@ namespace Orchid\Tests\Feature\Platform;
 
 use Orchid\Platform\Models\User;
 use Orchid\Platform\Notifications\DashboardMessage;
+use Orchid\Support\Color;
 use Orchid\Tests\App\Notifications\TaskCompleted;
 use Orchid\Tests\TestFeatureCase;
 
 class NotificationTest extends TestFeatureCase
 {
-    public function testViewNotification(): void
+    public function testNotificationForInnerClass():void
+    {
+        $user = $this->createAdminUser();
+        $user->notify(new DashboardMessage([
+            'title'   => 'Simple Notification',
+            'action'  => '#',
+            'message' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+            'type'    => Color::INFO->name(),
+        ]));
+
+        $response = $this
+            ->actingAs($user)
+            ->get(route('platform.notifications'));
+
+        $response
+            ->assertOk()
+            ->assertSee('Simple Notification')
+            ->assertSee('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+    }
+
+
+    public function testNotificationForNotificationClass(): void
     {
         $response = $this
             ->actingAs($this->createNotifyUser())
@@ -22,7 +44,7 @@ class NotificationTest extends TestFeatureCase
             ->assertSee('Task Completed');
     }
 
-    public function testMaskAllAsRead(): void
+    public function testMarkAllNotificationsAsRead(): void
     {
         $user = $this->createNotifyUser();
 
@@ -38,7 +60,7 @@ class NotificationTest extends TestFeatureCase
             ->assertDontSee('Mask all as read');
     }
 
-    public function testRemove(): void
+    public function testDeleteAllNotifications(): void
     {
         $user = $this->createNotifyUser();
 
@@ -55,7 +77,7 @@ class NotificationTest extends TestFeatureCase
             ->assertDontSee('Task Completed');
     }
 
-    public function testMaskReadNotification(): void
+    public function testMarkSingleNotificationAsRead(): void
     {
         $user = $this->createNotifyUser();
         $notification = $user
@@ -74,7 +96,7 @@ class NotificationTest extends TestFeatureCase
         $this->assertTrue($notification->read());
     }
 
-    public function testShowAPIUnread(): void
+    public function testAPIReturnsUnreadNotifications(): void
     {
         $response = $this
             ->actingAs($this->createNotifyUser())

--- a/tests/Feature/Platform/NotificationTest.php
+++ b/tests/Feature/Platform/NotificationTest.php
@@ -19,7 +19,7 @@ class NotificationTest extends TestFeatureCase
             ->title('Simple Notification')
             ->action('#')
             ->message('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
-            ->type(Color::INFO->name())
+            ->type(Color::INFO)
         );
 
         $response = $this

--- a/tests/Feature/Platform/NotificationTest.php
+++ b/tests/Feature/Platform/NotificationTest.php
@@ -15,12 +15,12 @@ class NotificationTest extends TestFeatureCase
     public function testNotificationForInnerClass():void
     {
         $user = $this->createAdminUser();
-        $user->notify(new DashboardMessage([
-            'title'   => 'Simple Notification',
-            'action'  => '#',
-            'message' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-            'type'    => Color::INFO->name(),
-        ]));
+        $user->notify(DashboardMessage::make()
+            ->title('Simple Notification')
+            ->action('#')
+            ->message('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+            ->type(Color::INFO->name())
+        );
 
         $response = $this
             ->actingAs($user)

--- a/tests/Feature/Platform/NotificationTest.php
+++ b/tests/Feature/Platform/NotificationTest.php
@@ -12,7 +12,7 @@ use Orchid\Tests\TestFeatureCase;
 
 class NotificationTest extends TestFeatureCase
 {
-    public function testNotificationForInnerClass():void
+    public function testNotificationForInnerClass(): void
     {
         $user = $this->createAdminUser();
         $user->notify(DashboardMessage::make()
@@ -31,7 +31,6 @@ class NotificationTest extends TestFeatureCase
             ->assertSee('Simple Notification')
             ->assertSee('Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
     }
-
 
     public function testNotificationForNotificationClass(): void
     {


### PR DESCRIPTION
Sometimes I don't want to create a full event using the `artisan make:notification` command just for small messages in the admin panel. It would be great to have the option to send notifications like this:

```php
$user->notify(DashboardMessage::make()
    ->title('Simple Notification')
    ->action('#')
    ->message('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
    ->type(Color::INFO)
);
```