### PR TITLE
Resolve #2971: Improve table header text contrast for accessibility

### DIFF
--- a/resources/views/partials/layouts/th.blade.php
+++ b/resources/views/partials/layouts/th.blade.php
@@ -1,11 +1,11 @@
-<th @empty(!$width) width="{{$width}}" @endempty class="text-{{$align}}" data-column="{{ $slug }}">
+<th @empty(!$width) width="{{$width}}" @endempty class="text-{{$align}} text-dark" data-column="{{ $slug }}">
     <div class="d-inline-flex align-items-center">
 
         @includeWhen($filter !== null, "platform::partials.layouts.filter", ['filter' => $filter])
 
         @if($sort)
             <a href="{{ $sortUrl }}"
-               class="@if(!is_sort($column)) text-muted @endif">
+               class="@if(!is_sort($column)) text-dark @endif">
                 {!! $title !!}
 
                 <x-orchid-popover :content="$popover"/>


### PR DESCRIPTION
Fixes #2971

## Proposed Changes

- Added the `text-dark` class to `<th>` elements to improve the contrast and accessibility of table headers.
- Replaced the `text-muted` class with `text-dark` on `<a>` elements to enhance link visibility and readability.
