### PR TITLE
Added sizes for Matrix

### DIFF
--- a/resources/views/fields/matrix.blade.php
+++ b/resources/views/fields/matrix.blade.php
@@ -8,7 +8,7 @@
         <thead>
         <tr>
             @foreach($columns as $key => $column)
-                <th scope="col" class="text-capitalize">
+                <th scope="col" class="text-capitalize {{ $sizes !== false ? 'col-' . ($sizes[$column] ?? '') : '' }}">
                     {{ is_int($key) ? $column : $key }}
                 </th>
             @endforeach

--- a/src/Screen/Fields/Matrix.php
+++ b/src/Screen/Fields/Matrix.php
@@ -13,6 +13,7 @@ use Orchid\Screen\Field;
  * @method static keyValue(bool $keyValue)
  * @method static title(string $value = null)
  * @method static help(string $value = null)
+ * @method static sizes(array $sizes)
  */
 class Matrix extends Field
 {
@@ -38,6 +39,7 @@ class Matrix extends Field
             'key',
             'value',
         ],
+        'sizes'             => false,
     ];
 
     /**


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Added method sizes() for settings collumns width in Matrix field? using bootstrap sizes
  
  Example:
  ```php
                  \App\Orchid\Fields\Matrix::make('parts')
                    ->title('Parts')
                    ->columns(['name', 'code', 'program_code', 'notice'])
                    ->fields([
                        'name' => Input::make(),
                        'code' => Input::make(),
                        'program_code' => Input::make(),
                        'notice' => Input::make(),
                    ])
                    ->sizes([
                        'name' => 4,
                        'code' => 1,
                        'program_code' => 1,
                        'notice' => 6,
                    ]),
  ````
