### PR TITLE
Add persistent and seconds methods to Toast notification

### DIFF
--- a/src/Alert/Toast.php
+++ b/src/Alert/Toast.php
@@ -68,9 +68,22 @@ class Toast extends Alert
     }
 
     /**
+     * Make the toast notification persistent.
+     *
+     * Disables auto-hide, keeping the notification visible until manually dismissed.
+     *
+     * @param bool $persistent Whether the toast should remain visible indefinitely.
+     * @return static
+     */
+    public function persistent(bool $persistent = true): static
+    {
+        return $this->autoHide(! $persistent);
+    }
+
+    /**
      * Set the delay option for the toast notification.
      *
-     * @param int $delay The delay in seconds
+     * @param int $delay The delay in milliseconds before hiding the toast.
      *
      * @return static
      */
@@ -79,5 +92,18 @@ class Toast extends Alert
         $this->session->flash(static::SESSION_DELAY, $delay);
 
         return $this;
+    }
+
+    /**
+     * Set the toast notification delay in seconds.
+     *
+     * Converts seconds to milliseconds and applies the delay.
+     *
+     * @param int $seconds Delay duration in seconds.
+     * @return static
+     */
+    public function seconds(int $seconds): static
+    {
+        return $this->delay($seconds * 1000);
     }
 }

--- a/src/Alert/Toast.php
+++ b/src/Alert/Toast.php
@@ -73,6 +73,7 @@ class Toast extends Alert
      * Disables auto-hide, keeping the notification visible until manually dismissed.
      *
      * @param bool $persistent Whether the toast should remain visible indefinitely.
+     *
      * @return static
      */
     public function persistent(bool $persistent = true): static
@@ -100,6 +101,7 @@ class Toast extends Alert
      * Converts seconds to milliseconds and applies the delay.
      *
      * @param int $seconds Delay duration in seconds.
+     *
      * @return static
      */
     public function seconds(int $seconds): static

--- a/tests/Unit/AlertTest.php
+++ b/tests/Unit/AlertTest.php
@@ -71,6 +71,26 @@ class AlertTest extends TestUnitCase
         self::assertEquals('3000', session('toast_notification.delay'));
     }
 
+    public function testToastShouldBePersistent(): void
+    {
+        Toast::info('Hello Alexandr!')
+            ->persistent();
+
+        self::assertEquals('Hello Alexandr!', session('toast_notification.message'));
+        self::assertEquals('false', session('toast_notification.auto_hide'));
+    }
+
+    public function testToastShouldSetDelayAndBePersistent(): void
+    {
+        Toast::info('Hello Alexandr!')
+            ->seconds(4)
+            ->persistent();
+
+        self::assertEquals('Hello Alexandr!', session('toast_notification.message'));
+        self::assertEquals('4000', session('toast_notification.delay'));
+    }
+
+
     public function testShouldFlashViewAlert(): void
     {
         Alert::view('exemplar::alert', Color::INFO, [

--- a/tests/Unit/AlertTest.php
+++ b/tests/Unit/AlertTest.php
@@ -90,7 +90,6 @@ class AlertTest extends TestUnitCase
         self::assertEquals('4000', session('toast_notification.delay'));
     }
 
-
     public function testShouldFlashViewAlert(): void
     {
         Alert::view('exemplar::alert', Color::INFO, [


### PR DESCRIPTION
### What’s New  
This PR introduces two new methods to improve the `Toast` notification system:  

- `persistent(bool $persistent = true)`: Prevents the toast from auto-hiding, keeping it visible until dismissed manually.  
- `seconds(int $seconds)`: Allows setting the toast delay in seconds instead of milliseconds for better readability.  

### Why?  
These additions provide more flexibility in managing toast notifications, making it easier to configure their behavior without manually handling milliseconds or overriding auto-hide settings.  

### Changes  
- Added the `persistent` method to toggle auto-hide behavior.  
- Added the `seconds` method to simplify delay configuration.  
- Added/updated test cases to ensure proper functionality.  

### How to Test  
Run the test suite to verify that toast notifications behave as expected with the new methods.  

This update improves usability while maintaining backward compatibility. 🚀  
