### PR TITLE
Fix: Added the "confirm" attribute to the property translations

### DIFF
--- a/src/Screen/Actions/Button.php
+++ b/src/Screen/Actions/Button.php
@@ -62,6 +62,17 @@ class Button extends Action
     ];
 
     /**
+     * A set of attributes for the assignment
+     * of which will automatically translate them.
+     *
+     * @var array
+     */
+    protected $translations = [
+        'name',
+        'confirm',
+    ];
+
+    /**
      * Button constructor.
      */
     public function __construct()


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Pass the text for translation to the "confirm" method of the "Button" class

Before:

```php
            Button::make('Title')
                ->icon('bs.trash3')
                ->confirm(__('Conformation'))
                ->method('destroy')
                ->canSee($this->model->exists),
```

After:

```php
            Button::make('Title')
                ->icon('bs.trash3')
                ->confirm('Conformation')
                ->method('destroy')
                ->canSee($this->model->exists),
```

