### PR TITLE
Feature: Publish stubs

### DIFF
--- a/src/Platform/Commands/ChartCommand.php
+++ b/src/Platform/Commands/ChartCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:chart')]
@@ -37,7 +35,7 @@ class ChartCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/chart.stub');
+        return $this->resolveStubPath('chart.stub');
     }
 
     /**

--- a/src/Platform/Commands/FilterCommand.php
+++ b/src/Platform/Commands/FilterCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:filter')]
@@ -37,7 +35,7 @@ class FilterCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/filters.stub');
+        return $this->resolveStubPath('filters.stub');
     }
 
     /**

--- a/src/Platform/Commands/GeneratorCommand.php
+++ b/src/Platform/Commands/GeneratorCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Orchid\Platform\Commands;
+
+use Orchid\Platform\Dashboard;
+
+abstract class GeneratorCommand extends \Illuminate\Console\GeneratorCommand
+{
+    /**
+     * @param string $stub
+     *
+     * @return string
+     */
+    protected function resolveStubPath(string $stub): string
+    {
+        return file_exists($path = $this->laravel->basePath('stubs/orchid/platform/'.trim($stub, '/')))
+            ? $path
+            : Dashboard::path('stubs/'.$stub);
+    }
+}

--- a/src/Platform/Commands/ListenerCommand.php
+++ b/src/Platform/Commands/ListenerCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:listener')]
@@ -37,7 +35,7 @@ class ListenerCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/listener.stub');
+        return $this->resolveStubPath('listener.stub');
     }
 
     /**

--- a/src/Platform/Commands/PresenterCommand.php
+++ b/src/Platform/Commands/PresenterCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:presenter')]
@@ -37,7 +35,7 @@ class PresenterCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/presenter.stub');
+        return $this->resolveStubPath('presenter.stub');
     }
 
     /**

--- a/src/Platform/Commands/RowsCommand.php
+++ b/src/Platform/Commands/RowsCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:rows')]
@@ -37,7 +35,7 @@ class RowsCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/rows.stub');
+        return $this->resolveStubPath('rows.stub');
     }
 
     /**

--- a/src/Platform/Commands/ScreenCommand.php
+++ b/src/Platform/Commands/ScreenCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:screen')]
@@ -37,7 +35,7 @@ class ScreenCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/screen.stub');
+        return $this->resolveStubPath('screen.stub');
     }
 
     /**

--- a/src/Platform/Commands/SelectionCommand.php
+++ b/src/Platform/Commands/SelectionCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:selection')]
@@ -37,7 +35,7 @@ class SelectionCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/selection.stub');
+        return $this->resolveStubPath('selection.stub');
     }
 
     /**

--- a/src/Platform/Commands/StubPublishCommand.php
+++ b/src/Platform/Commands/StubPublishCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Platform\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Events\PublishingStubs;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'orchid:stub-publish')]
+class StubPublishCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'orchid:stub-publish
+                    {--existing : Publish and overwrite only the files that have already been published}
+                    {--force : Overwrite any existing files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the Orchid stubs that are available for customization';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! is_dir($stubsPath = $this->laravel->basePath('stubs/orchid/platform'))) {
+            (new Filesystem())->makeDirectory($stubsPath, recursive: true);
+        }
+
+        $stubs = [
+            __DIR__.'/../../../stubs/chart.stub'     => 'chart.stub',
+            __DIR__.'/../../../stubs/filters.stub'   => 'filters.stub',
+            __DIR__.'/../../../stubs/listener.stub'  => 'listener.stub',
+            __DIR__.'/../../../stubs/presenter.stub' => 'presenter.stub',
+            __DIR__.'/../../../stubs/rows.stub'      => 'rows.stub',
+            __DIR__.'/../../../stubs/screen.stub'    => 'screen.stub',
+            __DIR__.'/../../../stubs/selection.stub' => 'selection.stub',
+            __DIR__.'/../../../stubs/table.stub'     => 'table.stub',
+            __DIR__.'/../../../stubs/tabMenu.stub'   => 'tabMenu.stub',
+        ];
+
+        $this->laravel['events']->dispatch($event = new PublishingStubs($stubs));
+
+        foreach ($event->stubs as $from => $to) {
+            $to = $stubsPath.'/'.ltrim($to, '/');
+
+            if ((! $this->option('existing') && (! file_exists($to) || $this->option('force')))
+                || ($this->option('existing') && file_exists($to))) {
+                file_put_contents($to, file_get_contents($from));
+            }
+        }
+
+        $this->components->info('Stubs published successfully.');
+    }
+}

--- a/src/Platform/Commands/StubsCommand.php
+++ b/src/Platform/Commands/StubsCommand.php
@@ -9,15 +9,15 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Events\PublishingStubs;
 use Symfony\Component\Console\Attribute\AsCommand;
 
-#[AsCommand(name: 'orchid:stub-publish')]
-class StubPublishCommand extends Command
+#[AsCommand(name: 'orchid:stubs')]
+class StubsCommand extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'orchid:stub-publish
+    protected $signature = 'orchid:stubs
                     {--existing : Publish and overwrite only the files that have already been published}
                     {--force : Overwrite any existing files}';
 

--- a/src/Platform/Commands/TabMenuCommand.php
+++ b/src/Platform/Commands/TabMenuCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:tab-menu')]
@@ -37,7 +35,7 @@ class TabMenuCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/tabMenu.stub');
+        return $this->resolveStubPath('tabMenu.stub');
     }
 
     /**

--- a/src/Platform/Commands/TableCommand.php
+++ b/src/Platform/Commands/TableCommand.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Orchid\Platform\Commands;
 
-use Illuminate\Console\GeneratorCommand;
-use Orchid\Platform\Dashboard;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 #[AsCommand(name: 'orchid:table')]
@@ -37,7 +35,7 @@ class TableCommand extends GeneratorCommand
      */
     protected function getStub(): string
     {
-        return Dashboard::path('stubs/table.stub');
+        return $this->resolveStubPath('table.stub');
     }
 
     /**

--- a/src/Platform/Providers/ConsoleServiceProvider.php
+++ b/src/Platform/Providers/ConsoleServiceProvider.php
@@ -16,7 +16,7 @@ use Orchid\Platform\Commands\PublishCommand;
 use Orchid\Platform\Commands\RowsCommand;
 use Orchid\Platform\Commands\ScreenCommand;
 use Orchid\Platform\Commands\SelectionCommand;
-use Orchid\Platform\Commands\StubPublishCommand;
+use Orchid\Platform\Commands\StubsCommand;
 use Orchid\Platform\Commands\TableCommand;
 use Orchid\Platform\Commands\TabMenuCommand;
 use Orchid\Platform\Dashboard;
@@ -41,7 +41,7 @@ class ConsoleServiceProvider extends ServiceProvider
         ListenerCommand::class,
         PresenterCommand::class,
         TabMenuCommand::class,
-        StubPublishCommand::class,
+        StubsCommand::class,
     ];
 
     public function boot(): void

--- a/src/Platform/Providers/ConsoleServiceProvider.php
+++ b/src/Platform/Providers/ConsoleServiceProvider.php
@@ -16,6 +16,7 @@ use Orchid\Platform\Commands\PublishCommand;
 use Orchid\Platform\Commands\RowsCommand;
 use Orchid\Platform\Commands\ScreenCommand;
 use Orchid\Platform\Commands\SelectionCommand;
+use Orchid\Platform\Commands\StubPublishCommand;
 use Orchid\Platform\Commands\TableCommand;
 use Orchid\Platform\Commands\TabMenuCommand;
 use Orchid\Platform\Dashboard;
@@ -40,6 +41,7 @@ class ConsoleServiceProvider extends ServiceProvider
         ListenerCommand::class,
         PresenterCommand::class,
         TabMenuCommand::class,
+        StubPublishCommand::class,
     ];
 
     public function boot(): void


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Added command : php artisan orchid:stub-publish

After:

After executing the publishes in the structure, the modified stubs are picked up during generation.

```shell
stubs
└── orchid
    └── platform
        ├── chart.stub
        ├── filters.stub
        ├── listener.stub
        ├── presenter.stub
        ├── rows.stub
        ├── screen.stub
        ├── selection.stub
        ├── table.stub
        └── tabMenu.stub
```
