### PR TITLE
Added variable for change command bar position

### DIFF
--- a/resources/views/layouts/block.blade.php
+++ b/resources/views/layouts/block.blade.php
@@ -1,20 +1,29 @@
 <fieldset class="row g-0 mb-3">
     @if(!empty($title) || !empty($description))
-    <div class="col p-0 px-3">
-        <legend class="text-body-emphasis px-2 mt-2">
-            {{ __($title ?? '') }}
+        <div class="col p-0 px-3">
+            <legend class="text-body-emphasis px-2 mt-2">
+                {{ __($title ?? '') }}
 
-            @if(!empty($description))
-            <p class="small text-muted mt-2 mb-0 text-balance">
-                {!! __($description  ?? '') !!}
-            </p>
-            @endif
-        </legend>
-    </div>
+                @if(!empty($description))
+                    <p class="small text-muted mt-2 mb-0 text-balance">
+                        {!! __($description  ?? '') !!}
+                    </p>
+                @endif
+            </legend>
+        </div>
     @endif
     <div class="col-12 {{!$vertical ? 'col-md-7' : ''}} shadow-sm h-100">
+        @if($commandBar && $topCommandBar)
+            <div class="bg-light px-4 py-3 d-flex justify-content-end rounded-top gap-2">
+                @foreach($commandBar as $command)
+                    <div>
+                        {!! $command !!}
+                    </div>
+                @endforeach
+            </div>
+        @endif
 
-        <div class="bg-white d-flex flex-column layout-wrapper {{ empty($commandBar) ? 'rounded' : 'rounded-top' }}">
+        <div class="bg-white d-flex flex-column layout-wrapper {{ empty($commandBar) ? 'rounded' : ($topCommandBar ? 'rounded-bottom' : 'rounded-top') }}">
             @foreach($manyForms as $key => $layouts)
                 @foreach($layouts as $layout)
                     {!! $layout ?? '' !!}
@@ -22,7 +31,7 @@
             @endforeach
         </div>
 
-        @empty(!$commandBar)
+        @if($commandBar && !$topCommandBar)
             <div class="bg-light px-4 py-3 d-flex justify-content-end rounded-bottom gap-2">
                 @foreach($commandBar as $command)
                     <div>
@@ -30,7 +39,7 @@
                     </div>
                 @endforeach
             </div>
-        @endempty
+        @endif
     </div>
 </fieldset>
 

--- a/src/Screen/Layouts/Block.php
+++ b/src/Screen/Layouts/Block.php
@@ -27,6 +27,7 @@ abstract class Block extends Layout
      */
     protected $variables = [
         'vertical' => false,
+        'topCommandBar' => false,
     ];
 
     /**
@@ -98,11 +99,14 @@ abstract class Block extends Layout
         return $this;
     }
 
+
     /**
      * @param Action|Action[] description
      */
-    public function commands($commands): self
+    public function commands($commands, $top = false): self
     {
+        $this->variables['topCommandBar'] = $top;
+
         $this->commandBar = Arr::wrap($commands);
 
         return $this;


### PR DESCRIPTION
Fixes #

## Proposed Changes

 I suggest adding the ability to change the position of the command bar in the Layout::block(). This can be useful in some cases where commands need to be displayed at the table level or to display commands above the form they belong to. 
 
![top-commands-table](https://github.com/user-attachments/assets/dad55c96-2eee-457a-9e77-929d3ec77246)

Code example:
```php
Layout::block([
                Layout::table('table', [
                    TD::make('id', 'ID')
                        ->width('100')
                        ->render(fn (Repository $model) => // Please use view('path')
                        "<img src='https://loremflickr.com/500/300?random={$model->get('id')}'
                              alt='sample'
                              class='mw-100 d-block img-fluid rounded-1 w-100'>
                            <span class='small text-muted mt-1 mb-0'># {$model->get('id')}</span>"),

                    TD::make('name', 'Name')
                        ->width('450')
                        ->render(fn (Repository $model) => Str::limit($model->get('name'), 200)),

                    TD::make('price', 'Price')
                        ->width('100')
                        ->usingComponent(Currency::class, before: '$')
                        ->align(TD::ALIGN_RIGHT),

                    TD::make('created_at', 'Created')
                        ->width('100')
                        ->usingComponent(DateTimeSplit::class)
                        ->align(TD::ALIGN_RIGHT),
                ]),
            ])
                ->vertical()
                ->commands([
                    Button::make('Add')->icon('bs.plus'),
                    Button::make('Delete')->icon('bs.trash'),
                    Button::make('Send')->icon('bs.send'),
                ], top: true),
```
At first I wanted to add a whole system of constants, but I decided to simplify everything and just added one more optional parameter to the method.

First variant example: )))
```
    public const COMMAND_TOP = 'top';

    public const COMMAND_BOTTOM = 'bottom';

    public const BAR_TABLE_CLASSES = [
        self::COMMAND_TOP => 'rounded-bottom',
        self::COMMAND_BOTTOM => 'rounded-top',
    ];

    /**
     * @var string
     */
    protected $template = 'platform::layouts.block';

    public $commandBarPosition = self::COMMAND_BOTTOM;
    ```