### PR TITLE
Avoid PHPUnit 12 conflict by using `Attributes\DataProvider`

### DIFF
--- a/tests/Console/ArtisanTest.php
+++ b/tests/Console/ArtisanTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Orchid\Platform\Models\User;
 use Orchid\Support\Facades\Dashboard;
 use Orchid\Tests\TestConsoleCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ArtisanTest extends TestConsoleCase
 {
@@ -29,6 +30,7 @@ class ArtisanTest extends TestConsoleCase
     /**
      * @dataProvider artisanOrchidMake
      */
+    #[DataProvider('artisanOrchidMake')]
     public function testArtisanOrchidMake(string $name, string $command, string $path): void
     {
         $file = Str::random();

--- a/tests/Feature/Platform/RelationsTest.php
+++ b/tests/Feature/Platform/RelationsTest.php
@@ -10,6 +10,7 @@ use Illuminate\Testing\TestResponse;
 use Orchid\Platform\Models\User;
 use Orchid\Tests\App\EmptyUserModel;
 use Orchid\Tests\TestFeatureCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RelationsTest extends TestFeatureCase
 {
@@ -40,6 +41,7 @@ class RelationsTest extends TestFeatureCase
      *
      * @throws \Throwable
      */
+    #[DataProvider('scopeList')]
     public function testScopeModel(array $scope): void
     {
         $response = $this->getScope($scope);
@@ -57,6 +59,7 @@ class RelationsTest extends TestFeatureCase
      *
      * @throws \Throwable
      */
+    #[DataProvider('scopeList')]
     public function testAppendModel(array $scope): void
     {
         $response = $this->getScope($scope, 'full');

--- a/tests/Unit/AlertTest.php
+++ b/tests/Unit/AlertTest.php
@@ -41,7 +41,6 @@ class AlertTest extends TestUnitCase
 
     /**
      * @dataProvider getLevels
-     *
      */
     #[DataProvider('getLevels')]
     public function testShouldFlashLevelsAlert(string $level, string $css): void

--- a/tests/Unit/AlertTest.php
+++ b/tests/Unit/AlertTest.php
@@ -8,6 +8,7 @@ use Orchid\Support\Color;
 use Orchid\Support\Facades\Alert;
 use Orchid\Support\Facades\Toast;
 use Orchid\Tests\TestUnitCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Class AlertTest.
@@ -40,7 +41,9 @@ class AlertTest extends TestUnitCase
 
     /**
      * @dataProvider getLevels
+     *
      */
+    #[DataProvider('getLevels')]
     public function testShouldFlashLevelsAlert(string $level, string $css): void
     {
         Alert::$level('test');
@@ -52,6 +55,7 @@ class AlertTest extends TestUnitCase
     /**
      * @dataProvider getLevels
      */
+    #[DataProvider('getLevels')]
     public function testShouldFlashLevelsToast(string $level, string $css): void
     {
         Toast::$level('test');

--- a/tests/Unit/FieldTest.php
+++ b/tests/Unit/FieldTest.php
@@ -24,6 +24,7 @@ use Orchid\Screen\Fields\TextArea;
 use Orchid\Screen\Fields\Upload;
 use Orchid\Screen\Fields\UTM;
 use Orchid\Tests\TestUnitCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Class FieldTest.
@@ -117,6 +118,7 @@ class FieldTest extends TestUnitCase
      *
      * @throws \Throwable
      */
+    #[DataProvider('exampleFields')]
     public function testHasCorrectInstance(string $field, mixed $options): void
     {
         /** @var \Orchid\Screen\Field $field */


### PR DESCRIPTION
PHPUnit 12 drops support for docblock-based @dataProvider annotations.
This change uses PHP 8.1+ attributes to define data providers,
ensuring forward compatibility.
