### PR TITLE
Support passing Eloquent models as action parameters

### DIFF
--- a/src/Screen/Actions/Button.php
+++ b/src/Screen/Actions/Button.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Orchid\Screen\Actions;
 
+use Illuminate\Contracts\Routing\UrlRoutable;
 use Orchid\Screen\Action;
 use Orchid\Support\Facades\Dashboard;
-use Illuminate\Contracts\Routing\UrlRoutable;
 
 /**
  * Class Button.
@@ -123,6 +123,7 @@ class Button extends Action
      * Sets the parameters for the action.
      *
      * @param array|object $parameters
+     *
      * @return $this
      */
     public function parameters(array|object $parameters): static
@@ -134,17 +135,18 @@ class Button extends Action
      * Normalizes parameters before setting them.
      *
      * @param array|object $parameters
+     *
      * @return array|object
      */
     protected function prepareActionParameters(array|object $parameters): array|object
     {
-        if(!is_array($parameters)) {
+        if (! is_array($parameters)) {
             return $parameters;
         }
 
         return collect($parameters)
             ->filter(fn ($value) => filled($value))
-            ->map(fn($value) => $this->extractRouteKey($value))
+            ->map(fn ($value) => $this->extractRouteKey($value))
             ->all();
     }
 
@@ -152,6 +154,7 @@ class Button extends Action
      * Extracts key from Eloquent model if applicable.
      *
      * @param mixed $value
+     *
      * @return mixed
      */
     protected function extractRouteKey(mixed $value): mixed

--- a/src/Screen/Actions/Button.php
+++ b/src/Screen/Actions/Button.php
@@ -6,6 +6,7 @@ namespace Orchid\Screen\Actions;
 
 use Orchid\Screen\Action;
 use Orchid\Support\Facades\Dashboard;
+use Illuminate\Contracts\Routing\UrlRoutable;
 
 /**
  * Class Button.
@@ -121,17 +122,41 @@ class Button extends Action
     /**
      * Sets the parameters for the action.
      *
-     * @param array|object $parameters The array or object containing the parameters.
-     *
+     * @param array|object $parameters
      * @return $this
      */
     public function parameters(array|object $parameters): static
     {
-        $parameters = is_array($parameters)
-            ? collect($parameters)->filter(fn ($value) => filled($value))->all()
-            : $parameters;
+        return $this->set('parameters', $this->prepareActionParameters($parameters));
+    }
 
-        return $this->set('parameters', $parameters);
+    /**
+     * Normalizes parameters before setting them.
+     *
+     * @param array|object $parameters
+     * @return array|object
+     */
+    protected function prepareActionParameters(array|object $parameters): array|object
+    {
+        if(!is_array($parameters)) {
+            return $parameters;
+        }
+
+        return collect($parameters)
+            ->filter(fn ($value) => filled($value))
+            ->map(fn($value) => $this->extractRouteKey($value))
+            ->all();
+    }
+
+    /**
+     * Extracts key from Eloquent model if applicable.
+     *
+     * @param mixed $value
+     * @return mixed
+     */
+    protected function extractRouteKey(mixed $value): mixed
+    {
+        return $value instanceof UrlRoutable ? $value->getRouteKey() : $value;
     }
 
     /**

--- a/tests/Unit/Screen/Actions/ButtonTest.php
+++ b/tests/Unit/Screen/Actions/ButtonTest.php
@@ -205,7 +205,7 @@ class ButtonTest extends TestFieldsUnitCase
         $view = self::renderField($button);
 
         $this->assertStringContainsString(
-            'formaction="http://127.0.0.1:8001/test?user='. $user->getKey(),
+            'formaction="http://127.0.0.1:8001/test?user='.$user->getKey(),
             $view
         );
     }

--- a/tests/Unit/Screen/Actions/ButtonTest.php
+++ b/tests/Unit/Screen/Actions/ButtonTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Tests\Unit\Screen\Fields;
 
+use Orchid\Platform\Models\User;
 use Orchid\Screen\Actions\Button;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
 
@@ -187,6 +188,24 @@ class ButtonTest extends TestFieldsUnitCase
 
         $this->assertStringContainsString(
             'formaction="http://127.0.0.1:8001/test?id=1',
+            $view
+        );
+    }
+
+    public function testButtonMethodParametersAcceptsEloquentModel(): void
+    {
+        $user = User::factory()->create();
+
+        $button = Button::make('About')
+            ->parameters([
+                'user' => $user,
+            ])
+            ->method('test');
+
+        $view = self::renderField($button);
+
+        $this->assertStringContainsString(
+            'formaction="http://127.0.0.1:8001/test?user='. $user->getKey(),
             $view
         );
     }


### PR DESCRIPTION
When passing Eloquent models to the `method()` or `parameters()` call, 
the system now automatically extracts the model key using `getKey()`. 

This allows writing cleaner code like:

```php
    ->parameters(['user' => $user])
```

instead of:
```php
    ->parameters(['user' => $user->id])
```
Includes a test case to verify that Eloquent models are properly resolved to their primary key in form action URLs.