### PR TITLE
Added support HTML rendering in help and title fields

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -229,6 +229,7 @@ class Field implements Fieldable, Htmlable
 
         collect($this->attributes)
             ->intersectByKeys(array_flip($this->translations))
+            ->filter(fn ($value) => is_string($value))
             ->each(function ($value, $key) use ($lang) {
                 $translation = __($value, [], $lang);
                 $this->set($key, is_string($translation) ? $translation : $value);

--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Screen\Fields;
 
+use Illuminate\Support\HtmlString;
 use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 
@@ -37,10 +38,10 @@ use Orchid\Screen\Field;
  * @method $this tabindex($value = true)
  * @method self  type($value = true)
  * @method $this value($value = true)
- * @method Input help(string $value = null)
+ * @method Input help(string|HtmlString $value = null)
  * @method $this popover(string $value = null)
  * @method $this mask($value = true)
- * @method $this title(string $value = null)
+ * @method $this title(string|HtmlString $value = null)
  * @method $this inputmode(string $value = null)
  */
 class Input extends Field

--- a/src/Screen/Fields/Input.php
+++ b/src/Screen/Fields/Input.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Orchid\Screen\Fields;
 
-use Illuminate\Support\HtmlString;
+use Illuminate\Contracts\Support\Htmlable;
 use Orchid\Screen\Concerns\Multipliable;
 use Orchid\Screen\Field;
 
@@ -38,10 +38,10 @@ use Orchid\Screen\Field;
  * @method $this tabindex($value = true)
  * @method self  type($value = true)
  * @method $this value($value = true)
- * @method Input help(string|HtmlString $value = null)
+ * @method Input help(string|Htmlable $value = null)
  * @method $this popover(string $value = null)
  * @method $this mask($value = true)
- * @method $this title(string|HtmlString $value = null)
+ * @method $this title(string|Htmlable $value = null)
  * @method $this inputmode(string $value = null)
  */
 class Input extends Field

--- a/tests/Unit/Screen/Fields/InputTest.php
+++ b/tests/Unit/Screen/Fields/InputTest.php
@@ -7,6 +7,8 @@ namespace Orchid\Tests\Unit\Screen\Fields;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithSession;
 use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
 use Orchid\Screen\Fields\Input;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
@@ -179,4 +181,38 @@ class InputTest extends TestFieldsUnitCase
             'Expected validation error message was not found in the rendered input.'
         );
     }
+
+    public function testHelpTextSupportsHtml(): void
+    {
+        $htmlHelp = new HtmlString('Your <strong>full name</strong> here, including any middle names.');
+
+        $input = Input::make('name')->help($htmlHelp);
+
+        $expected = 'Your <strong>full name</strong> here, including any middle names.';
+
+        $this->assertStringContainsString(
+            $expected,
+            self::minifyRenderField($input),
+            'HTML help text not rendered correctly.'
+        );
+    }
+
+    public function testTitleTextSupportsHtml(): void
+    {
+        $htmlTitle = Str::of('Your **full name** here, including any middle names.')
+            ->inlineMarkdown()
+            ->toHtmlString();
+
+        $input = Input::make('name')->title($htmlTitle);
+
+        $expected = 'Your <strong>full name</strong> here, including any middle names.';
+
+        $this->assertStringContainsString(
+            $expected,
+            self::minifyRenderField($input),
+            'HTML title text not rendered correctly.'
+        );
+    }
+
+
 }

--- a/tests/Unit/Screen/Fields/InputTest.php
+++ b/tests/Unit/Screen/Fields/InputTest.php
@@ -8,8 +8,8 @@ use Illuminate\Foundation\Testing\Concerns\InteractsWithSession;
 use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Illuminate\Support\MessageBag;
+use Illuminate\Support\Str;
 use Orchid\Screen\Fields\Input;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
 use Throwable;
@@ -213,6 +213,4 @@ class InputTest extends TestFieldsUnitCase
             'HTML title text not rendered correctly.'
         );
     }
-
-
 }


### PR DESCRIPTION
Implemented functionality to render HTML content in both `help()` and `title()` methods of the Input field.

This method accepts a plain text string, or an instance of `Illuminate\Support\HtmlString` or `Illuminate\Contracts\Support\Htmlable`. This allows you to render HTML, or even markdown, in the helper text:

```php
use Illuminate\Support\HtmlString;
use Illuminate\Support\Str;

Input::make('name')
    ->help(new HtmlString('Your <strong>full name</strong> here, including any middle names.'))

Input::make('name')
    ->title(Str::of('Your **full name** here, including any middle names.')->inlineMarkdown()->toHtmlString())


```