### PR TITLE
Fix serialization and deserialization for unsaved Eloquent models

### DIFF
--- a/src/Screen/Concerns/ModelStateRetrievable.php
+++ b/src/Screen/Concerns/ModelStateRetrievable.php
@@ -2,6 +2,7 @@
 
 namespace Orchid\Screen\Concerns;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\Attributes\WithoutRelations;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 
@@ -51,6 +52,12 @@ trait ModelStateRetrievable
             $name = $property->getName();
 
             if ($property->isPrivate() || $property->isProtected()) {
+                continue;
+            }
+
+            // Allow full model that are not yet saved
+            if($value instanceof Model && !$value->exists) {
+                $values[$name] = $value;
                 continue;
             }
 

--- a/src/Screen/Concerns/ModelStateRetrievable.php
+++ b/src/Screen/Concerns/ModelStateRetrievable.php
@@ -55,7 +55,7 @@ trait ModelStateRetrievable
                 continue;
             }
 
-            // Allow full model that are not yet saved
+            // Store unsaved models as-is, since they cannot be rehydrated via DB
             if($value instanceof Model && !$value->exists) {
                 $values[$name] = $value;
                 continue;

--- a/src/Screen/Concerns/ModelStateRetrievable.php
+++ b/src/Screen/Concerns/ModelStateRetrievable.php
@@ -56,8 +56,9 @@ trait ModelStateRetrievable
             }
 
             // Store unsaved models as-is, since they cannot be rehydrated via DB
-            if($value instanceof Model && !$value->exists) {
+            if ($value instanceof Model && ! $value->exists) {
                 $values[$name] = $value;
+
                 continue;
             }
 

--- a/tests/Unit/Screen/ScreenSerializeTest.php
+++ b/tests/Unit/Screen/ScreenSerializeTest.php
@@ -141,4 +141,33 @@ class ScreenSerializeTest extends TestUnitCase
         // Ensure the user's name after deserialization does not match the unsaved change
         $this->assertNotSame('Changed Name', $unserializedScreen->user->name);
     }
+
+    /**
+     * Tests serialization and deserialization with the ModelStateRetrievable trait.
+     *
+     * Ensures that an unsaved model is serialized with its attributes intact
+     * and is restored as-is upon deserialization (without DB query).
+     */
+    public function testWithPropertyRetrievableWhenEloquentModelNotSaved(): void
+    {
+        $user = User::factory()->make([
+            'name' => 'Alexandr',
+        ]);
+
+        $this->assertNull($user->getKey());
+
+        $screen = app()->make(SerializeRetrievableScreen::class, ['user' => $user]);
+        $serializedScreen = serialize($screen);
+
+        $this->assertStringContainsString('Alexandr', $serializedScreen);
+
+        DB::enableQueryLog();
+
+        $unserializedScreen = unserialize($serializedScreen);
+
+        $this->assertEquals('Alexandr', $unserializedScreen->user->name);
+        $this->assertCount(0, DB::getQueryLog());
+    }
+
+
 }

--- a/tests/Unit/Screen/ScreenSerializeTest.php
+++ b/tests/Unit/Screen/ScreenSerializeTest.php
@@ -168,6 +168,4 @@ class ScreenSerializeTest extends TestUnitCase
         $this->assertEquals('Alexandr', $unserializedScreen->user->name);
         $this->assertCount(0, DB::getQueryLog());
     }
-
-
 }


### PR DESCRIPTION
- Updated `ModelStateRetrievable` trait to handle unsaved models correctly.
- Added test to validate serialization/deserialization behavior for unsaved models.
