### PR TITLE
Refactor component hashing: switch to `xxh3`

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -287,14 +287,12 @@ class Field implements Fieldable, Htmlable
             return $this;
         }
 
-        $slug = collect([
-            'field',
-            $this->get('lang'),
-            $this->get('name'),
-            sha1(json_encode($this->getAttributes())),
-        ])->implode('-');
+        $generatedId = hash(
+            'xxh3',
+            json_encode($this->getAttributes())
+        );
 
-        return $this->set('id', Str::slug($slug));
+        return $this->set('id', $generatedId);
     }
 
     /**

--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -287,12 +287,19 @@ class Field implements Fieldable, Htmlable
             return $this;
         }
 
-        $generatedId = hash(
+        $hash = hash(
             'xxh3',
             json_encode($this->getAttributes())
         );
 
-        return $this->set('id', $generatedId);
+        $id = collect([
+            'field',
+            $this->get('lang'),
+            $this->get('name'),
+            $hash,
+        ])->implode('-');
+
+        return $this->set('id', Str::slug($id));
     }
 
     /**

--- a/src/Screen/Layout.php
+++ b/src/Screen/Layout.php
@@ -95,7 +95,7 @@ abstract class Layout implements JsonSerializable
      */
     public function getSlug(): string
     {
-        return sha1(json_encode($this));
+        return hash('xxh3', json_encode($this));
     }
 
     /**

--- a/src/Screen/Layouts/Listener.php
+++ b/src/Screen/Layouts/Listener.php
@@ -62,7 +62,7 @@ abstract class Listener extends Layout
      */
     public function getSlug(): string
     {
-        return sha1(static::class);
+        return hash('xxh3', (static::class));
     }
 
     /**


### PR DESCRIPTION
This PR improves performance of UI component hashing by replacing the legacy `sha1` algorithm with the much faster and more modern `xxh3` hash.


### Performance
Benchmarks show `xxh3` is up to 10x faster than `sha1` for short strings and small payloads, making it a better fit for UI-level hashing.

https://php.watch/versions/8.1/xxHash
