### PR TITLE
Fix file sorting issue on servers expecting `Content-Type`

### DIFF
--- a/resources/js/controllers/attach_controller.js
+++ b/resources/js/controllers/attach_controller.js
@@ -214,6 +214,7 @@ export default class extends ApplicationController {
                 files: items,
             }),
             headers: {
+                'Content-Type': 'application/json;charset=utf-8',
                 'X-CSRF-Token': document.head.querySelector('meta[name="csrf_token"]').content,
             },
         }).then();


### PR DESCRIPTION
File sorting does not work on certain server types because they expect the `Content-Type: application/json` header from the client.