### PR TITLE
Changed set Turbo scroll behavior to `preserve` by default

### DIFF
--- a/config/platform.php
+++ b/config/platform.php
@@ -263,7 +263,7 @@ return [
         'cache'          => true,
         'prefetch'       => true,
         'refresh-method' => 'replace',
-        'refresh-scroll' => 'reset',
+        'refresh-scroll' => 'preserve',
     ],
 
     /*


### PR DESCRIPTION
Changes the default value of 'refresh-scroll' in the Turbo config to 'preserve',so that scroll position is retained after Turbo-driven page refreshes.

Improves user experience when usage https://github.com/orchidsoftware/platform/pull/2997 or alternatives.
