### PR TITLE
Fix magic methods of Dashboard facade

### DIFF
--- a/src/Support/Facades/Dashboard.php
+++ b/src/Support/Facades/Dashboard.php
@@ -12,20 +12,20 @@ use Orchid\Screen\Screen;
 /**
  * Class Dashboard.
  *
- * @method static Collection  getSearch()
- * @method static Collection  getPermission()
- * @method static Collection  getAllowAllPermission()
- * @method static string      version()
- * @method static string      prefix(string $path = '')
- * @method        static      configure(array $options)
- * @method        static      option(string $key, ?string $default = null)
- * @method static mixed       modelClass(string $key, string $default = null)
- * @method static string      model(string $key, string $default = null)
- * @method        static      useModel(string $key, string $custom)
- * @method static bool        checkUpdate()
- * @method static self        setCurrentScreen(Screen $screen, bool $partialRequest = false)
- * @method static Screen|null getCurrentScreen()
- * @method static bool        isPartialRequest()
+ * @method static Collection     getSearch()
+ * @method static Collection     getPermission()
+ * @method static Collection     getAllowAllPermission()
+ * @method static string         version()
+ * @method static string         prefix(string $path = '')
+ * @method static void           configure(array $options)
+ * @method static mixed          option(string $key, ?string $default = null)
+ * @method static mixed          modelClass(string $key, string $default = null)
+ * @method static class-string   model(string $key, string $default = null)
+ * @method static void           useModel(string $key, string $custom)
+ * @method static bool           checkUpdate()
+ * @method static self           setCurrentScreen(Screen $screen, bool $partialRequest = false)
+ * @method static Screen|null    getCurrentScreen()
+ * @method static bool           isPartialRequest()
  */
 class Dashboard extends Facade
 {


### PR DESCRIPTION
## Proposed Changes

`Dashboard` facade's `@method` annotations in PHPDoc comment have been tweaked for better interoperability with static analysis tools such as PHPStan. Some methods had no return types specified, and PHPStan incorrectly recognized them as non-static methods returning `static` (i.e. returning itself).