### PR TITLE
Add static method to create multiple repository elements from an array

### DIFF
--- a/src/Screen/Repository.php
+++ b/src/Screen/Repository.php
@@ -68,4 +68,11 @@ class Repository extends \Illuminate\Config\Repository implements Countable
     {
         return $this->count() === 0;
     }
+
+    public static function elements(array $items): array
+    {
+        return collect($items)
+            ->map(fn ($item) => new self($item))
+            ->all();
+    }
 }

--- a/stubs/app/Orchid/Screens/Examples/ExampleScreen.php
+++ b/stubs/app/Orchid/Screens/Examples/ExampleScreen.php
@@ -57,14 +57,13 @@ class ExampleScreen extends Screen
                     'labels' => ['12am-3am', '3am-6am', '6am-9am', '9am-12pm', '12pm-3pm', '3pm-6pm', '6pm-9pm'],
                 ],
             ],
-            'table'   => [
-                new Repository(['id' => 100, 'name' => self::TEXT_EXAMPLE, 'price' => 10.24, 'created_at' => '01.01.2020']),
-                new Repository(['id' => 200, 'name' => self::TEXT_EXAMPLE, 'price' => 65.9, 'created_at' => '01.01.2020']),
-                new Repository(['id' => 300, 'name' => self::TEXT_EXAMPLE, 'price' => 754.2, 'created_at' => '01.01.2020']),
-                new Repository(['id' => 400, 'name' => self::TEXT_EXAMPLE, 'price' => 0.1, 'created_at' => '01.01.2020']),
-                new Repository(['id' => 500, 'name' => self::TEXT_EXAMPLE, 'price' => 0.15, 'created_at' => '01.01.2020']),
-
-            ],
+            'table'   => Repository::elements([
+                ['id' => 100, 'name' => self::TEXT_EXAMPLE, 'price' => 10.24, 'created_at' => '01.01.2020'],
+                ['id' => 200, 'name' => self::TEXT_EXAMPLE, 'price' => 65.9, 'created_at' => '01.01.2020'],
+                ['id' => 300, 'name' => self::TEXT_EXAMPLE, 'price' => 754.2, 'created_at' => '01.01.2020'],
+                ['id' => 400, 'name' => self::TEXT_EXAMPLE, 'price' => 0.1, 'created_at' => '01.01.2020'],
+                ['id' => 500, 'name' => self::TEXT_EXAMPLE, 'price' => 0.15, 'created_at' => '01.01.2020'],
+            ]),
             'metrics' => [
                 'sales'    => ['value' => number_format(6851), 'diff' => 10.08],
                 'visitors' => ['value' => number_format(24668), 'diff' => -30.76],


### PR DESCRIPTION
Fixes #

## Proposed Changes

This pull request introduces a new static helper method to the `Repository` class to simplify the creation of multiple `Repository` objects from arrays. The `ExampleScreen` is updated to use this new method, resulting in cleaner and more maintainable code.


* Added a static `elements` method to the `Repository` class, which converts an array of item data into an array of `Repository` instances.
* Updated the `ExampleScreen` to use `Repository::elements` for constructing the `table` data, replacing multiple explicit `new Repository(...)` calls with a more concise approach.
