### PR TITLE
Avoid invalid image request in Firefox caused by the template.

### DIFF
--- a/resources/js/controllers/attach_controller.js
+++ b/resources/js/controllers/attach_controller.js
@@ -185,11 +185,15 @@ export default class extends ApplicationController {
         preview.querySelectorAll('*').forEach(element => {
             preview.innerHTML = preview.innerHTML
                 .replace(/{id}/gi, attachment.id)
-                .replace(/{url}/gi, attachment.url)
                 .replace(/{original_name}/gi, attachment.original_name)
                 .replace(/{mime}/gi, attachment.mime)
                 .replace(/{name}/gi, this.nameValue);
         });
+
+        const attachImage = preview.querySelector('.attach-image');
+        if (attachImage) {
+            attachImage.src = attachment.url;
+        }
 
         if (replace !== null) {
             this.element.querySelector(`#attachment-${replace}`).outerHTML = pip.outerHTML;

--- a/resources/views/fields/attach.blade.php
+++ b/resources/views/fields/attach.blade.php
@@ -55,7 +55,10 @@
             <input type="hidden" name="{name}" value="{id}">
 
 
-            <img class="attach-image rounded border user-select-none overflow-hidden" src="{url}" title="{original_name}"/>
+            <img class="attach-image rounded border user-select-none overflow-hidden"
+                 alt="Attached Image"
+                 src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+                 title="{original_name}"/>
 
             {{--
                 <object class="attach-image rounded border user-select-none" border="0" data="{url}" type="{mime}" title="test"  load="lazy" controls allowfullscreen autoplay="false">


### PR DESCRIPTION
Firefox is the only browser that processes the contents of <template> tags and attempts to load the image referenced with src="{url}". This results in a 404 response, and because my server is configured with Fail2Ban to block repeated 404 requests, Firefox ends up banning me from my own server.

This issue occurs only in Firefox—Chrome and other browsers ignore the contents of <template> elements as expected.

**Solution:**
I initialized the template’s image with a 1-pixel transparent placeholder and then set the real URL via a query selector instead of performing a string replace on innerHTML. I also added an alt attribute to the image.