### PR TITLE
Extract shared upload helper

### DIFF
--- a/resources/js/controllers/attach_controller.js
+++ b/resources/js/controllers/attach_controller.js
@@ -1,5 +1,6 @@
 import ApplicationController from "./application_controller";
 import Sortable from "sortablejs";
+import { uploadFile } from "../helpers/upload";
 
 export default class extends ApplicationController {
     static values = {
@@ -100,26 +101,17 @@ export default class extends ApplicationController {
     }
 
     upload(file) {
-        let data = new FormData();
-        data.append("file", file);
-        data.append("storage", this.storageValue);
-        data.append("group", this.groupValue);
-        data.append("path", this.pathValue);
-        data.append("sort", this.countValue + 1);
-
         this.loadingValue = this.loadingValue + 1;
         this.element.ariaBusy = "true";
 
-        fetch(this.uploadUrlValue, {
-            method: "POST",
-            body: data,
-            headers: {
-                "X-CSRF-Token": document.head.querySelector(
-                    'meta[name="csrf_token"]'
-                ).content,
+        uploadFile(this.uploadUrlValue, file, {
+            data: {
+                storage: this.storageValue,
+                group: this.groupValue,
+                path: this.pathValue,
+                sort: this.countValue + 1,
             },
         })
-            .then(response => response.json())
             .then(attachment => {
                 this.element.ariaBusy = "false";
                 this.loadingValue = this.loadingValue - 1;

--- a/resources/js/controllers/cropper_controller.js
+++ b/resources/js/controllers/cropper_controller.js
@@ -1,6 +1,7 @@
 import ApplicationController from "./application_controller";
 import Cropper from "cropperjs";
 import { Modal } from "bootstrap";
+import { uploadFile } from "../helpers/upload";
 
 export default class extends ApplicationController {
     static values = {
@@ -128,22 +129,17 @@ export default class extends ApplicationController {
                 fillColor: this.data.get("fill-color"),
             })
             .toBlob(blob => {
-                const formData = new FormData();
-
-                formData.append("file", blob);
-                formData.append("storage", this.data.get("storage"));
-                formData.append("group", this.data.get("groups"));
-                formData.append("path", this.data.get("path"));
-                formData.append(
-                    "acceptedFiles",
-                    this.data.get("accepted-files")
-                );
-
                 let element = this.element;
-                window.axios
-                    .post(this.prefix("/files"), formData)
-                    .then(response => {
-                        let image = response.data.url;
+                uploadFile(this.prefix("/files"), blob, {
+                    data: {
+                        storage: this.data.get("storage"),
+                        group: this.data.get("groups"),
+                        path: this.data.get("path"),
+                        acceptedFiles: this.data.get("accepted-files"),
+                    },
+                })
+                    .then(data => {
+                        let image = data.url;
                         let targetValue = this.data.get("target");
 
                         element.querySelector(".cropper-preview").src = image;
@@ -154,7 +150,7 @@ export default class extends ApplicationController {
                             .querySelector(".cropper-remove")
                             .classList.remove("none");
                         element.querySelector(".cropper-path").value =
-                            response.data[targetValue];
+                            data[targetValue];
 
                         // add event for listener
                         element

--- a/resources/js/controllers/markdown_controller.js
+++ b/resources/js/controllers/markdown_controller.js
@@ -22,6 +22,7 @@ import {
     placeholder,
 } from "@codemirror/view";
 import ApplicationController from "./application_controller";
+import { uploadFile } from "../helpers/upload";
 
 const markdownHighlightStyle = HighlightStyle.define([
     { tag: tags.heading1, class: "cm-md-token-heading-1" },
@@ -312,13 +313,9 @@ export default class extends ApplicationController {
             return;
         }
 
-        const formData = new FormData();
-        formData.append("file", file);
-
-        axios
-            .post(this.prefix("/files"), formData)
-            .then(response => {
-                this.#insertText(`![](${response.data.url})`);
+        uploadFile(this.prefix("/files"), file)
+            .then(data => {
+                this.#insertText(`![](${data.url})`);
                 event.target.value = null;
             })
             .catch(error => {

--- a/resources/js/controllers/picture_controller.js
+++ b/resources/js/controllers/picture_controller.js
@@ -1,4 +1,5 @@
 import ApplicationController from "./application_controller";
+import { uploadFile } from "../helpers/upload";
 
 export default class extends ApplicationController {
     /**
@@ -48,19 +49,17 @@ export default class extends ApplicationController {
         reader.readAsDataURL(event.target.files[0]);
 
         reader.onloadend = () => {
-            const formData = new FormData();
-
-            formData.append("file", event.target.files[0]);
-            formData.append("storage", this.data.get("storage"));
-            formData.append("group", this.data.get("groups"));
-            formData.append("path", this.data.get("path"));
-            formData.append("acceptedFiles", this.data.get("accepted-files"));
-
             let element = this.element;
-            window.axios
-                .post(this.prefix("/files"), formData)
-                .then(response => {
-                    let image = response.data.url;
+            uploadFile(this.prefix("/files"), event.target.files[0], {
+                data: {
+                    storage: this.data.get("storage"),
+                    group: this.data.get("groups"),
+                    path: this.data.get("path"),
+                    acceptedFiles: this.data.get("accepted-files"),
+                },
+            })
+                .then(data => {
+                    let image = data.url;
                     let targetValue = this.data.get("target");
 
                     element.querySelector(".picture-preview").src = image;
@@ -71,7 +70,7 @@ export default class extends ApplicationController {
                         .querySelector(".picture-remove")
                         .classList.remove("none");
                     element.querySelector(".picture-path").value =
-                        response.data[targetValue];
+                        data[targetValue];
 
                     // add event for listener
                     element

--- a/resources/js/controllers/quill_controller.js
+++ b/resources/js/controllers/quill_controller.js
@@ -1,5 +1,6 @@
 import ApplicationController from "./application_controller";
 import Quill from "quill";
+import { uploadFile } from "../helpers/upload";
 
 export default class extends ApplicationController {
     /**
@@ -173,17 +174,14 @@ export default class extends ApplicationController {
      * @param {File} file
      */
     saveToServer(file) {
-        const formData = new FormData();
-        formData.append("image", file);
-
-        if (this.data.get("groups")) {
-            formData.append("group", this.data.get("groups"));
-        }
-
-        axios
-            .post(this.prefix("/files"), formData)
-            .then(response => {
-                this.insertToEditor(response.data.url);
+        uploadFile(this.prefix("/files"), file, {
+            field: "image",
+            data: {
+                group: this.data.get("groups"),
+            },
+        })
+            .then(data => {
+                this.insertToEditor(data.url);
             })
             .catch(error => {
                 this.alert("Validation error", "Quill image upload failed");

--- a/resources/js/helpers/upload.js
+++ b/resources/js/helpers/upload.js
@@ -1,0 +1,23 @@
+/**
+ * Uploads a file to the Orchid file endpoint.
+ *
+ * @param {string} url Upload endpoint URL.
+ * @param {File} file File selected by the user.
+ * @param {{field?: string, data?: Object}} options Upload options.
+ * @returns {Promise<Object>}
+ */
+export function uploadFile(url, file, options = {}) {
+    const form = new FormData();
+    const field = options.field ?? "file";
+    const data = options.data ?? {};
+
+    form.append(field, file);
+
+    Object.entries(data).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && value !== "") {
+            form.append(key, value);
+        }
+    });
+
+    return axios.post(url, form).then(response => response.data);
+}


### PR DESCRIPTION
## Summary
- add a shared uploadFile helper for multipart file uploads
- reuse it in Attach, Cropper, Markdown, Picture, and Quill controllers
- keep non-upload FormData/fetch flows unchanged

## Tests
- node --check resources/js/helpers/upload.js
- node --check resources/js/controllers/attach_controller.js
- node --check resources/js/controllers/cropper_controller.js
- node --check resources/js/controllers/markdown_controller.js
- node --check resources/js/controllers/picture_controller.js
- node --check resources/js/controllers/quill_controller.js
- git diff --check