### PR TITLE
Fix password visibility toggle

### DIFF
--- a/resources/js/controllers/password_controller.js
+++ b/resources/js/controllers/password_controller.js
@@ -15,14 +15,14 @@ export default class extends ApplicationController {
         let type = "password";
 
         if (currentType === "text") {
-            this.iconLockTarget.classList.add("none");
-            this.iconShowTarget.classList.remove("none");
+            this.iconLockTarget.classList.add("d-none");
+            this.iconShowTarget.classList.remove("d-none");
         }
 
         if (currentType === "password") {
             type = "text";
-            this.iconLockTarget.classList.remove("none");
-            this.iconShowTarget.classList.add("none");
+            this.iconLockTarget.classList.remove("d-none");
+            this.iconShowTarget.classList.add("d-none");
         }
 
         this.passwordTarget.setAttribute("type", type);

--- a/resources/views/fields/password.blade.php
+++ b/resources/views/fields/password.blade.php
@@ -8,7 +8,7 @@
             <x-orchid-icon path="bs.eye" class="small me-2"/>
         </span>
 
-        <span data-password-target="iconLock" class="none">
+        <span data-password-target="iconLock" class="d-none">
             <x-orchid-icon path="bs.eye-slash" class="small me-2"/>
         </span>
     </div>


### PR DESCRIPTION
## Summary
- replace the obsolete none class with Bootstrap d-none in the password field
- keep the show/hide icon state in sync with the controller toggle logic

## Tests
- node --check resources/js/controllers/password_controller.js
- git diff --check