### PR TITLE
refactor(access): refine permission value object API

### DIFF
--- a/src/Access/PermissionGroup.php
+++ b/src/Access/PermissionGroup.php
@@ -13,27 +13,27 @@ namespace Orchid\Access;
 class PermissionGroup
 {
     /**
-     * @param array<int, array{slug: string, description: string}> $items
+     * @param array<int, array{slug: string, description: string}> $definitions
      */
     public function __construct(
         public string $name,
-        public array $items = []
+        protected array $definitions = []
     ) {}
 
     /**
      * Create a new permission group.
      */
-    public static function group(string $name): static
+    public static function make(string $name): static
     {
         return new static($name);
     }
 
     /**
-     * Register a permission in the group.
+     * Add a permission definition to the group.
      */
-    public function permission(string $slug, string $description): static
+    public function add(string $slug, string $description): static
     {
-        $this->items[] = [
+        $this->definitions[] = [
             'slug'        => $slug,
             'description' => $description,
         ];
@@ -42,18 +42,10 @@ class PermissionGroup
     }
 
     /**
-     * Add a permission definition to the group.
-     */
-    public function addPermission(string $slug, string $description): static
-    {
-        return $this->permission($slug, $description);
-    }
-
-    /**
      * @return array<int, array{slug: string, description: string}>
      */
-    public function items(): array
+    public function definitions(): array
     {
-        return $this->items;
+        return $this->definitions;
     }
 }

--- a/src/Access/Permissions.php
+++ b/src/Access/Permissions.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Casts\Json;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use JsonSerializable;
 use Traversable;
 
 /**
@@ -22,19 +23,19 @@ use Traversable;
  * @implements CastsAttributes<static, mixed>
  * @implements Arrayable<string, bool>
  */
-class Permissions implements Arrayable, CastsAttributes, Countable
+class Permissions implements Arrayable, CastsAttributes, Countable, JsonSerializable
 {
     /**
-     * @param array<string, bool> $items
+     * @param array<string, bool> $states
      */
-    private array $items;
+    private array $states;
 
     /**
-     * @param array<string, mixed> $items
+     * @param array<string, mixed> $states
      */
-    public function __construct(array $items = [])
+    public function __construct(array $states = [])
     {
-        $this->items = static::normalize($items);
+        $this->states = static::normalize($states);
     }
 
     /**
@@ -53,17 +54,17 @@ class Permissions implements Arrayable, CastsAttributes, Countable
     }
 
     /**
-     * Create an allowed permission set from registered permission items.
+     * Create an allowed permission set from registered permission definitions.
      *
-     * @param iterable<array{slug: string}> $items
+     * @param iterable<array{slug: string}> $definitions
      */
-    public static function fromItems(iterable $items): static
+    public static function fromDefinitions(iterable $definitions): static
     {
         $permissions = [];
 
-        foreach ($items as $item) {
-            if (is_array($item) && isset($item['slug'])) {
-                $permissions[$item['slug']] = true;
+        foreach ($definitions as $definition) {
+            if (is_array($definition) && isset($definition['slug'])) {
+                $permissions[$definition['slug']] = true;
             }
         }
 
@@ -75,19 +76,19 @@ class Permissions implements Arrayable, CastsAttributes, Countable
      *
      * @param iterable<string, mixed>|null $permissions
      */
-    public static function fromForm(?iterable $permissions): static
+    public static function fromEncodedForm(?iterable $permissions): static
     {
-        $items = [];
+        $states = [];
 
         foreach ($permissions ?? [] as $permission => $allowed) {
             $permission = base64_decode((string) $permission, true);
 
             if ($permission !== false) {
-                $items[$permission] = $allowed;
+                $states[$permission] = $allowed;
             }
         }
 
-        return static::make($items);
+        return static::make($states);
     }
 
     /**
@@ -117,8 +118,8 @@ class Permissions implements Arrayable, CastsAttributes, Countable
      */
     public function allows(string $permit): bool
     {
-        foreach ($this->items as $permission => $allowed) {
-            if ($allowed && (Str::is($permission, $permit) || Str::is($permit, $permission))) {
+        foreach ($this->states as $permission => $allowed) {
+            if ($allowed && Str::is($permit, $permission)) {
                 return true;
             }
         }
@@ -131,7 +132,7 @@ class Permissions implements Arrayable, CastsAttributes, Countable
      */
     public function isActive(string $permission): bool
     {
-        return array_key_exists($permission, $this->items) && $this->items[$permission];
+        return array_key_exists($permission, $this->states) && $this->states[$permission];
     }
 
     /**
@@ -139,7 +140,15 @@ class Permissions implements Arrayable, CastsAttributes, Countable
      */
     public function count(): int
     {
-        return count(array_filter($this->items));
+        return count(array_filter($this->states));
+    }
+
+    /**
+     * Determine whether no permission states are assigned.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->states === [];
     }
 
     /**
@@ -147,7 +156,15 @@ class Permissions implements Arrayable, CastsAttributes, Countable
      */
     public function toArray(): array
     {
-        return $this->items;
+        return $this->states;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 
     /**

--- a/src/Access/RoleAccess.php
+++ b/src/Access/RoleAccess.php
@@ -30,6 +30,16 @@ trait RoleAccess
     }
 
     /**
+     * Get the number of active permissions assigned to the role.
+     *
+     * @deprecated Use $role->permissions->count() instead.
+     */
+    public function getCountPermissions(): int
+    {
+        return Permissions::make($this->permissions ?? [])->count();
+    }
+
+    /**
      * Override the deleted method to detach the users assigned to the role
      * before deleting the role
      *

--- a/src/Access/StatusAccess.php
+++ b/src/Access/StatusAccess.php
@@ -18,7 +18,7 @@ trait StatusAccess
     {
         $permissions = Permissions::make($this->permissions ?? []);
 
-        return Orchid::getPermission()->transform(
+        return Orchid::permissionGroups()->transform(
             fn ($group) => collect($group)
                 ->sortBy('description')
                 ->map(

--- a/src/Access/UserAccess.php
+++ b/src/Access/UserAccess.php
@@ -60,7 +60,7 @@ trait UserAccess
                 ->pluck('permissions')
                 ->prepend($this->permissions)
                 ->map(fn ($permission) => Permissions::make($permission))
-                ->filter(fn (Permissions $permission) => $permission->toArray() !== []);
+                ->filter(fn (Permissions $permission) => ! $permission->isEmpty());
         }
 
         return $this->cachePermissions

--- a/src/Platform/Commands/AdminCommand.php
+++ b/src/Platform/Commands/AdminCommand.php
@@ -78,7 +78,7 @@ class AdminCommand extends Command
         Orchid::modelClass(User::class)
             ->findOrFail($id)
             ->forceFill([
-                'permissions' => Orchid::getAllowAllPermission(),
+                'permissions' => Orchid::allowedPermissions(),
             ])
             ->save();
 

--- a/src/Platform/Configuration/ManagesPermissions.php
+++ b/src/Platform/Configuration/ManagesPermissions.php
@@ -24,21 +24,13 @@ trait ManagesPermissions
     protected array $removedPermissions = [];
 
     /**
-     * @deprecated Use registerPermission instead.
-     */
-    public function registerPermissions(PermissionGroup $group): static
-    {
-        return $this->registerPermission($group);
-    }
-
-    /**
      * Register a permission group with the dashboard catalog.
      */
-    public function registerPermission(PermissionGroup $group): static
+    public function registerPermissionGroup(PermissionGroup $group): static
     {
         $old = Arr::get($this->registeredPermissions, $group->name, []);
 
-        $this->registeredPermissions[$group->name] = array_merge($old, $group->items());
+        $this->registeredPermissions[$group->name] = array_merge($old, $group->definitions());
 
         return $this;
     }
@@ -50,7 +42,7 @@ trait ManagesPermissions
      *
      * @return Collection<string, Collection<int, array{slug: string, description: string}>>
      */
-    public function getPermission(string|array $groups = []): Collection
+    public function permissionGroups(string|array $groups = []): Collection
     {
         return collect($this->registeredPermissions)
             ->when(! empty($groups), fn (Collection $collection) => $collection->only($groups))
@@ -64,9 +56,9 @@ trait ManagesPermissions
      *
      * @return Permissions Assigned permission states keyed by slug.
      */
-    public function getAllowAllPermission(string|array $groups = []): Permissions
+    public function allowedPermissions(string|array $groups = []): Permissions
     {
-        return Permissions::fromItems($this->getPermission($groups)->collapse());
+        return Permissions::fromDefinitions($this->permissionGroups($groups)->collapse());
     }
 
     /**

--- a/src/Platform/ItemPermission.php
+++ b/src/Platform/ItemPermission.php
@@ -11,15 +11,40 @@ use Orchid\Access\PermissionGroup;
  */
 class ItemPermission extends PermissionGroup
 {
-    #[\Deprecated(message: 'Use Orchid\Access\PermissionGroup instead.')]
+    /**
+     * Backward-compatible alias for PermissionGroup::$name.
+     */
+    public string $group;
+
+    /**
+     * Backward-compatible alias for the permission definitions.
+     *
+     * @var array<int, array{slug: string, description: string}>
+     */
+    public array $items;
+
+    /**
+     * @param array<int, array{slug: string, description: string}> $items
+     *
+     * @psalm-suppress UnsupportedPropertyReferenceUsage Psalm cannot analyze property aliases.
+     */
     public function __construct(string $name, array $items = [])
     {
         parent::__construct($name, $items);
+
+        $this->group = &$this->name;
+        $this->items = &$this->definitions;
     }
 
-    #[\Deprecated(message: 'Use Orchid\Access\PermissionGroup::group() instead.')]
+    #[\Deprecated(message: 'Use Orchid\Access\PermissionGroup::make() instead.')]
     public static function group(string $name): static
     {
-        return parent::group($name);
+        return new static($name);
+    }
+
+    #[\Deprecated(message: 'Use Orchid\Access\PermissionGroup::add() instead.')]
+    public function addPermission(string $slug, string $description): static
+    {
+        return $this->add($slug, $description);
     }
 }

--- a/src/Platform/Models/User.php
+++ b/src/Platform/Models/User.php
@@ -119,7 +119,7 @@ class User extends Authenticatable
             'name'        => $name,
             'email'       => $email,
             'password'    => Hash::make($password),
-            'permissions' => Orchid::getAllowAllPermission(),
+            'permissions' => Orchid::allowedPermissions(),
         ]);
     }
 }

--- a/src/Platform/OrchidServiceProvider.php
+++ b/src/Platform/OrchidServiceProvider.php
@@ -99,7 +99,7 @@ abstract class OrchidServiceProvider extends ServiceProvider
 
         // Register the permissions
         foreach ($permissions as $permission) {
-            $this->orchidSingleton()->registerPermissions($permission);
+            $this->orchidSingleton()->registerPermissionGroup($permission);
         }
 
         return $this;

--- a/src/Platform/Providers/PlatformServiceProvider.php
+++ b/src/Platform/Providers/PlatformServiceProvider.php
@@ -33,21 +33,21 @@ class PlatformServiceProvider extends ServiceProvider
                 ->registerResource('stylesheets', config('orchid.resource.stylesheets'))
                 ->registerResource('scripts', config('orchid.resource.scripts'))
                 ->registerSearch(config('orchid.search', []))
-                ->registerPermissions($this->registerPermissionsMain())
-                ->registerPermissions($this->registerPermissionsSystems());
+                ->registerPermissionGroup($this->registerPermissionsMain())
+                ->registerPermissionGroup($this->registerPermissionsSystems());
         });
     }
 
     protected function registerPermissionsMain(): PermissionGroup
     {
-        return PermissionGroup::group(__('Main'))
-            ->permission('orchid.index', __('Main'));
+        return PermissionGroup::make(__('Main'))
+            ->add('orchid.index', __('Main'));
     }
 
     protected function registerPermissionsSystems(): PermissionGroup
     {
-        return PermissionGroup::group(__('System'))
-            ->permission('orchid.attachment', __('Attachment'));
+        return PermissionGroup::make(__('System'))
+            ->add('orchid.attachment', __('Attachment'));
     }
 
     /**

--- a/src/Support/Facades/Dashboard.php
+++ b/src/Support/Facades/Dashboard.php
@@ -14,8 +14,8 @@ use Orchid\Screen\Screen;
  * Class Dashboard.
  *
  * @method static Collection  getSearch()
- * @method static Collection  getPermission()
- * @method static Permissions getAllowAllPermission()
+ * @method static Collection  permissionGroups()
+ * @method static Permissions allowedPermissions()
  * @method static string      version()
  * @method static string      prefix(string $path = '')
  * @method        static      configure(array $options)

--- a/src/Support/Facades/Orchid.php
+++ b/src/Support/Facades/Orchid.php
@@ -14,8 +14,8 @@ use Orchid\Screen\Screen;
  * Class Orchid.
  *
  * @method static Collection  getSearch()
- * @method static Collection  getPermission()
- * @method static Permissions getAllowAllPermission()
+ * @method static Collection  permissionGroups()
+ * @method static Permissions allowedPermissions()
  * @method static string      version()
  * @method static string      prefix(string $path = '')
  * @method        static      configure(array $options)

--- a/stubs/app/Orchid/Filters/RoleFilter.php
+++ b/stubs/app/Orchid/Filters/RoleFilter.php
@@ -40,9 +40,10 @@ class RoleFilter extends Filter
      */
     public function run(Builder $builder): Builder
     {
-        return $builder->whereHas('roles', function (Builder $query) {
-            $query->where('name', $this->request->get('role'));
-        });
+        return $builder->whereHas(
+            'roles',
+            fn (Builder $query) => $query->where('id', $this->request->get('role'))
+        );
     }
 
     /**
@@ -64,6 +65,8 @@ class RoleFilter extends Filter
      */
     public function value(): string
     {
-        return $this->name().': '.Role::where('name', $this->request->get('role'))->first()->name;
+        $role = Role::find($this->request->get('role'));
+
+        return $this->name().': '.($role?->name ?? '');
     }
 }

--- a/stubs/app/Orchid/PlatformProvider.php
+++ b/stubs/app/Orchid/PlatformProvider.php
@@ -100,9 +100,9 @@ class PlatformProvider extends OrchidServiceProvider
     public function permissions(): array
     {
         return [
-            PermissionGroup::group(__('System'))
-                ->permission('orchid.roles', __('Roles'))
-                ->permission('orchid.users', __('Users')),
+            PermissionGroup::make(__('System'))
+                ->add('orchid.roles', __('Roles'))
+                ->add('orchid.users', __('Users')),
         ];
     }
 }

--- a/stubs/app/Orchid/Screens/Role/RoleEditScreen.php
+++ b/stubs/app/Orchid/Screens/Role/RoleEditScreen.php
@@ -126,7 +126,7 @@ class RoleEditScreen extends Screen
 
         $role->fill($request->input('role'));
 
-        $role->permissions = Permissions::fromForm($request->input('permissions'));
+        $role->permissions = Permissions::fromEncodedForm($request->input('permissions'));
 
         $role->save();
 

--- a/stubs/app/Orchid/Screens/User/UserEditScreen.php
+++ b/stubs/app/Orchid/Screens/User/UserEditScreen.php
@@ -166,7 +166,7 @@ class UserEditScreen extends Screen
 
         $user
             ->fill($request->collect('user')->except(['password', 'permissions', 'roles'])->toArray())
-            ->forceFill(['permissions' => Permissions::fromForm($request->input('permissions'))])
+            ->forceFill(['permissions' => Permissions::fromEncodedForm($request->input('permissions'))])
             ->save();
 
         $user->replaceRoles($request->input('user.roles'));

--- a/tests/Console/ArtisanTest.php
+++ b/tests/Console/ArtisanTest.php
@@ -69,7 +69,7 @@ class ArtisanTest extends TestConsoleCase
 
         $user->refresh();
 
-        $this->assertSame(Orchid::getAllowAllPermission()->toArray(), $user->permissions->toArray());
+        $this->assertSame(Orchid::allowedPermissions()->toArray(), $user->permissions->toArray());
     }
 
     public function testArtisanOrchidInstall(): void

--- a/tests/Unit/FiltersTest.php
+++ b/tests/Unit/FiltersTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Orchid\Tests\Unit;
 
+use App\Orchid\Filters\RoleFilter;
+use Orchid\Platform\Models\Role;
 use Orchid\Platform\Models\User;
 use Orchid\Tests\App\Filters\NameFilter;
 use Orchid\Tests\App\Filters\PatternFilter;
@@ -12,6 +14,26 @@ use Orchid\Tests\TestUnitCase;
 
 class FiltersTest extends TestUnitCase
 {
+    public function testRoleFilterFiltersAndDisplaysSelectedRole(): void
+    {
+        $other = Role::factory()->create(['name' => 'Other role']);
+        $selected = Role::factory()->create(['name' => 'Selected role']);
+        $otherUser = User::factory()->create();
+        $selectedUser = User::factory()->create();
+
+        $otherUser->addRole($other);
+        $selectedUser->addRole($selected);
+
+        request()->merge([
+            'role' => $selected->getKey(),
+        ]);
+
+        $filter = new RoleFilter;
+
+        $this->assertSame([$selectedUser->getKey()], $filter->run(User::query())->pluck('id')->all());
+        $this->assertSame('Roles: Selected role', $filter->value());
+    }
+
     public function testSimpleValue(): void
     {
         request()->merge([

--- a/tests/Unit/PermissionTest.php
+++ b/tests/Unit/PermissionTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Support\Collection;
 use Orchid\Access\PermissionGroup;
 use Orchid\Access\Permissions;
+use Orchid\Platform\ItemPermission;
 use Orchid\Platform\Models\Role;
 use Orchid\Platform\Models\User;
 use Orchid\Platform\Orchid;
@@ -117,12 +118,12 @@ class PermissionTest extends TestUnitCase
     {
         $dashboard = new Orchid;
 
-        $permission = PermissionGroup::group('Test')
-            ->permission('test', 'Test Description');
+        $permission = PermissionGroup::make('Test')
+            ->add('test', 'Test Description');
 
-        $dashboard->registerPermissions($permission);
+        $dashboard->registerPermissionGroup($permission);
 
-        $this->assertEquals(1, $dashboard->getPermission()->count());
+        $this->assertEquals(1, $dashboard->permissionGroups()->count());
     }
 
     /**
@@ -132,31 +133,31 @@ class PermissionTest extends TestUnitCase
     {
         $dashboard = new Orchid;
 
-        $permissionA = PermissionGroup::group('Test-A')
-            ->permission('test_a', 'Test Description A');
+        $permissionA = PermissionGroup::make('Test-A')
+            ->add('test_a', 'Test Description A');
 
-        $permissionB = PermissionGroup::group('Test-B')
-            ->permission('test_b', 'Test Description B');
+        $permissionB = PermissionGroup::make('Test-B')
+            ->add('test_b', 'Test Description B');
 
-        $dashboard->registerPermissions($permissionA);
-        $dashboard->registerPermissions($permissionB);
+        $dashboard->registerPermissionGroup($permissionA);
+        $dashboard->registerPermissionGroup($permissionB);
 
-        $this->assertEquals(['Test-A', 'Test-B'], $dashboard->getPermission()->keys()->toArray());
-        $this->assertEquals(['Test-A'], $dashboard->getPermission(['Test-A'])->keys()->toArray());
+        $this->assertEquals(['Test-A', 'Test-B'], $dashboard->permissionGroups()->keys()->toArray());
+        $this->assertEquals(['Test-A'], $dashboard->permissionGroups(['Test-A'])->keys()->toArray());
     }
 
-    public function testRegisterPermissionMergesItemsIntoExistingGroup(): void
+    public function testRegisterPermissionGroupMergesDefinitionsIntoExistingGroup(): void
     {
         $dashboard = new Orchid;
 
-        $dashboard->registerPermission(
-            PermissionGroup::group('Reports')
-                ->permission('reports.view', 'View reports')
+        $dashboard->registerPermissionGroup(
+            PermissionGroup::make('Reports')
+                ->add('reports.view', 'View reports')
         );
 
-        $dashboard->registerPermission(
-            PermissionGroup::group('Reports')
-                ->permission('reports.export', 'Export reports')
+        $dashboard->registerPermissionGroup(
+            PermissionGroup::make('Reports')
+                ->add('reports.export', 'Export reports')
         );
 
         $this->assertSame([
@@ -168,20 +169,52 @@ class PermissionTest extends TestUnitCase
                 'slug'        => 'reports.export',
                 'description' => 'Export reports',
             ],
-        ], $dashboard->getPermission('Reports')->collapse()->values()->toArray());
+        ], $dashboard->permissionGroups('Reports')->collapse()->values()->toArray());
     }
 
-    public function testGetAllowAllPermissionReturnsPermissionsValueObject(): void
+    public function testLegacyItemPermissionKeepsGroupPropertyAlias(): void
+    {
+        $permission = @ItemPermission::group('System');
+
+        @$permission->addPermission('users.view', 'View users');
+
+        $this->assertSame('System', $permission->group);
+        $this->assertSame('System', $permission->name);
+        $this->assertSame([
+            [
+                'slug'        => 'users.view',
+                'description' => 'View users',
+            ],
+        ], $permission->items);
+
+        $permission->group = 'Users';
+
+        $this->assertSame('Users', $permission->name);
+
+        $permission->name = 'Roles';
+
+        $this->assertSame('Roles', $permission->group);
+    }
+
+    public function testPermissionGroupDoesNotExposeLegacyMethods(): void
+    {
+        $this->assertFalse(method_exists(PermissionGroup::class, 'addPermission'));
+        $this->assertFalse(method_exists(PermissionGroup::class, 'group'));
+        $this->assertFalse(method_exists(PermissionGroup::class, 'permission'));
+        $this->assertFalse(method_exists(PermissionGroup::class, 'items'));
+    }
+
+    public function testAllowedPermissionsReturnsPermissionsValueObject(): void
     {
         $dashboard = new Orchid;
 
-        $dashboard->registerPermissions(
-            PermissionGroup::group('Test')
-                ->permission('test.view', 'View')
-                ->permission('test.update', 'Update')
+        $dashboard->registerPermissionGroup(
+            PermissionGroup::make('Test')
+                ->add('test.view', 'View')
+                ->add('test.update', 'Update')
         );
 
-        $permissions = $dashboard->getAllowAllPermission();
+        $permissions = $dashboard->allowedPermissions();
 
         $this->assertInstanceOf(Permissions::class, $permissions);
         $this->assertSame([
@@ -192,10 +225,10 @@ class PermissionTest extends TestUnitCase
 
     public function testPermissionDescriptionIsNotStoredWithAssignedPermissions(): void
     {
-        $permissions = Permissions::fromItems(
-            PermissionGroup::group('Reports')
-                ->permission('reports.view', 'View reports')
-                ->items()
+        $permissions = Permissions::fromDefinitions(
+            PermissionGroup::make('Reports')
+                ->add('reports.view', 'View reports')
+                ->definitions()
         );
 
         $user = User::factory()->create([
@@ -228,7 +261,8 @@ class PermissionTest extends TestUnitCase
             'access.to.*'           => true,
         ], $user->permissions->toArray());
         $this->assertTrue($user->permissions->allows('access.to.public.data'));
-        $this->assertTrue($user->permissions->allows('access.to.anything'));
+        $this->assertFalse($user->permissions->allows('access.to.anything'));
+        $this->assertTrue($user->permissions->allows('access.to.*'));
         $this->assertTrue($user->permissions->isActive('access.to.public.data'));
         $this->assertFalse($user->permissions->isActive('access.to.secret.data'));
         $this->assertFalse($user->permissions->allows('other.permission'));
@@ -293,6 +327,19 @@ class PermissionTest extends TestUnitCase
         ], $permissions->toArray());
     }
 
+    public function testPermissionsAreJsonSerializable(): void
+    {
+        $permissions = Permissions::make([
+            'reports.view'   => true,
+            'reports.delete' => false,
+        ]);
+
+        $this->assertSame(
+            '{"reports.view":true,"reports.delete":false}',
+            json_encode($permissions)
+        );
+    }
+
     public function testPermissionsIgnoreInvalidInput(): void
     {
         $this->assertSame([], Permissions::make(new \stdClass)->toArray());
@@ -332,7 +379,7 @@ class PermissionTest extends TestUnitCase
         ], $permissions->toArray());
     }
 
-    public function testPermissionsCanCountActiveItems(): void
+    public function testPermissionsReportActiveCountAndEmptyState(): void
     {
         $permissions = Permissions::make([
             'reports.view'   => true,
@@ -342,6 +389,8 @@ class PermissionTest extends TestUnitCase
 
         $this->assertSame(2, $permissions->count());
         $this->assertCount(2, $permissions);
+        $this->assertFalse($permissions->isEmpty());
+        $this->assertTrue(Permissions::make()->isEmpty());
     }
 
     public function testPermissionsAreStoredAsJsonBooleans(): void
@@ -456,9 +505,9 @@ class PermissionTest extends TestUnitCase
         $this->assertSame(1, $role->permissions->count());
     }
 
-    public function testPermissionsCanBeCreatedFromFormInput(): void
+    public function testPermissionsCanBeCreatedFromEncodedFormInput(): void
     {
-        $permissions = Permissions::fromForm([
+        $permissions = Permissions::fromEncodedForm([
             base64_encode('users.edit')   => '1',
             base64_encode('users.delete') => 'false',
             'not-base64'                  => '1',
@@ -476,11 +525,11 @@ class PermissionTest extends TestUnitCase
     public function testIsWasRemovedPermission(): void
     {
         $dashboard = new Orchid;
-        $permission = PermissionGroup::group('Test')
-            ->permission('test', 'Test Description');
-        $dashboard->registerPermissions($permission);
+        $permission = PermissionGroup::make('Test')
+            ->add('test', 'Test Description');
+        $dashboard->registerPermissionGroup($permission);
         $dashboard->removePermission('test');
-        $this->assertEmpty($dashboard->getPermission()->get('Test'));
+        $this->assertEmpty($dashboard->permissionGroups()->get('Test'));
     }
 
     public function testReplacePermission(): void
@@ -719,6 +768,7 @@ class PermissionTest extends TestUnitCase
         $role = $this->createRole();
 
         $this->assertSame(2, $role->permissions->count());
+        $this->assertSame(2, $role->getCountPermissions());
     }
 
     public function testGetStatusPermissionReturnsAllPermissionsWithCorrectActiveFlags(): void
@@ -729,7 +779,7 @@ class PermissionTest extends TestUnitCase
             ],
         ]);
 
-        $expectedPermissions = \Orchid\Support\Facades\Orchid::getPermission()
+        $expectedPermissions = \Orchid\Support\Facades\Orchid::permissionGroups()
             ->map
             ->map(function ($permission) {
                 $permission['active'] = in_array($permission['slug'], [


### PR DESCRIPTION
## Summary

Follow-up to #3110. The permission value objects are already part of `master`; this PR refines their public API for the next major release and removes collection-era naming from the new domain model.

- rename the catalog API around explicit permission groups and definitions
- rename form decoding and registry methods to describe their actual behavior
- make `Permissions` JSON-serializable and expose an explicit empty-state check
- restore one-way wildcard matching so stored wildcard strings do not silently broaden access
- keep the old `ItemPermission` surface only in the deprecated compatibility class
- fix the generated `RoleFilter` to filter and display roles by their selected ID

## Access API

```php
$group = PermissionGroup::make('System')
    ->add('users.view', 'View users')
    ->add('users.edit', 'Edit users');

Orchid::registerPermissionGroup($group);

$groups = Orchid::permissionGroups();
$permissions = Orchid::allowedPermissions();

$permissions->allows('users.*');
$permissions->isActive('users.edit');
$permissions->count();
$permissions->isEmpty();
```

## Renamed API

This targets the next major release, so the new value objects keep a narrow domain API instead of retaining aliases from the recently introduced surface.

| API from #3110 | Refined API |
| --- | --- |
| `PermissionGroup::group()` | `PermissionGroup::make()` |
| `PermissionGroup::permission()` | `PermissionGroup::add()` |
| `PermissionGroup::items()` | `PermissionGroup::definitions()` |
| `Permissions::fromItems()` | `Permissions::fromDefinitions()` |
| `Permissions::fromForm()` | `Permissions::fromEncodedForm()` |
| `registerPermission(s)()` | `registerPermissionGroup()` |
| `getPermission()` | `permissionGroups()` |
| `getAllowAllPermission()` | `allowedPermissions()` |

`ItemPermission` remains deprecated and contains the legacy `group()`, `addPermission()`, `$group`, and `$items` compatibility surface. These aliases are intentionally not exposed by `PermissionGroup`.

## Wildcard behavior

Wildcard matching is directional again:

- assigned `users.edit` allows a requested pattern such as `users.*`
- assigned `users.*` does not implicitly allow the concrete `users.edit` permission

This avoids granting permissions that were never explicitly stored.

## Role filter

The generated `RoleFilter` previously submitted a role ID but queried both users and the display label by role name. It now queries by ID, handles a missing role safely, and has coverage for both the filtered result and displayed label.

## Compatibility and persistence

- `Permissions` now implements `JsonSerializable` in addition to `Arrayable` and `Countable`
- persisted permission JSON remains unchanged; no database migration is required
- `getCountPermissions()` remains available as a deprecated model-level bridge to `Permissions::count()`

## Verification

- Pint passed for all changed PHP files
- targeted suite: **57 tests, 167 assertions**
- full PHPUnit suite: **595 tests, 1624 assertions**
