### PR TITLE
Support long breadcrumb trails

### DIFF
--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,0 +1,52 @@
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb px-4 mb-2">
+        @foreach ($items as $item)
+            <li
+                @class([
+                    'breadcrumb-item text-truncate',
+                    'active' => $item['current'] ?? false,
+                ])
+            >
+                @isset($item['breadcrumbs'])
+                    <button
+                        class="btn btn-sm border-0 lh-1 link-secondary d-inline-flex align-items-center p-0"
+                        type="button"
+                        data-bs-toggle="dropdown"
+                        data-bs-boundary="viewport"
+                        aria-expanded="false"
+                    >
+                        <x-orchid-icon path="bs.three-dots" aria-hidden="true"/>
+                    </button>
+
+                    <ul class="dropdown-menu dropdown-menu-arrow p-1">
+                        @foreach ($item['breadcrumbs'] as $breadcrumb)
+                            <li>
+                                @if ($breadcrumb->url())
+                                    <a class="dropdown-item rounded-1 px-2 py-2"
+                                       href="{{ $breadcrumb->url() }}"
+                                    >
+                                        {{ $breadcrumb->title() }}
+                                    </a>
+                                @else
+                                    <span class="dropdown-item-text px-2 py-2">
+                                        {{ $breadcrumb->title() }}
+                                    </span>
+                                @endif
+                            </li>
+                        @endforeach
+                    </ul>
+                @else
+                    @if ($item['breadcrumb']->url() && ! $item['current'])
+                        <a class="link-secondary text-decoration-none"
+                           href="{{ $item['breadcrumb']->url() }}"
+                        >
+                            {{ $item['breadcrumb']->title() }}
+                        </a>
+                    @else
+                        {{ $item['breadcrumb']->title() }}
+                    @endif
+                @endif
+            </li>
+        @endforeach
+    </ol>
+</nav>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -46,16 +46,7 @@
 @endsection
 
 @section('workspace')
-    @if(Breadcrumbs::has())
-        <nav aria-label="breadcrumb">
-            <ol class="breadcrumb px-4 mb-2">
-                <x-tabuna-breadcrumbs
-                    class="breadcrumb-item"
-                    active="active"
-                />
-            </ol>
-        </nav>
-    @endif
+    <x-orchid-breadcrumbs/>
 
     <div class="order-last order-md-0 command-bar-wrapper">
         <div class="@hasSection('navbar') @else d-none d-md-block @endif layout d-md-flex align-items-center">

--- a/src/Platform/Components/Breadcrumbs.php
+++ b/src/Platform/Components/Breadcrumbs.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Platform\Components;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Illuminate\View\Component;
+use Tabuna\Breadcrumbs\Crumb;
+use Tabuna\Breadcrumbs\Manager;
+
+class Breadcrumbs extends Component
+{
+    /**
+     * The maximum number of breadcrumbs shown before collapsing into a dropdown.
+     */
+    private const MAX_VISIBLE_WITHOUT_COLLAPSE = 3;
+
+    /**
+     * The number of breadcrumbs kept before the dropdown.
+     */
+    private const ITEMS_BEFORE_DROPDOWN = 1;
+
+    /**
+     * The number of breadcrumbs kept after the dropdown.
+     */
+    private const ITEMS_AFTER_DROPDOWN = 2;
+
+    /**
+     * The prepared breadcrumb items for the view.
+     *
+     * @var Collection<int, array{breadcrumb: Crumb, current: bool}|array{breadcrumbs: Collection<int, Crumb>}>
+     */
+    public Collection $items;
+
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(Manager $manager)
+    {
+        $this->items = $this->resolveBreadcrumbs($manager)
+            ->pipe($this->collapse(...));
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View
+    {
+        return view('orchid::components.breadcrumbs');
+    }
+
+    /**
+     * Determine if the component should be rendered.
+     */
+    public function shouldRender(): bool
+    {
+        return $this->items->isNotEmpty();
+    }
+
+    /**
+     * Resolve the current breadcrumbs from the manager.
+     *
+     * @return Collection<int, Crumb>
+     */
+    private function resolveBreadcrumbs(Manager $manager): Collection
+    {
+        return $manager->has()
+            ? $manager->current()->values()
+            : collect();
+    }
+
+    /**
+     * Collapse the breadcrumbs into a compact representation when necessary.
+     *
+     * @param Collection<int, Crumb> $breadcrumbs
+     *
+     * @return Collection<int, array{breadcrumb: Crumb, current: bool}|array{breadcrumbs: Collection<int, Crumb>}>
+     */
+    private function collapse(Collection $breadcrumbs): Collection
+    {
+        return $breadcrumbs->when(
+            $breadcrumbs->count() <= self::MAX_VISIBLE_WITHOUT_COLLAPSE,
+            fn () => $this->mapAsBreadcrumbs($breadcrumbs),
+            fn () => $this->buildCollapsedItems($breadcrumbs),
+        );
+    }
+
+    /**
+     * Map each crumb into a breadcrumb item, marking the last one as current.
+     *
+     * @param Collection<int, Crumb> $breadcrumbs
+     *
+     * @return Collection<int, array{breadcrumb: Crumb, current: bool}>
+     */
+    private function mapAsBreadcrumbs(Collection $breadcrumbs): Collection
+    {
+        return $breadcrumbs->map(
+            fn (Crumb $breadcrumb, int $index) => $this->makeBreadcrumbItem(
+                $breadcrumb,
+                current: $index === $breadcrumbs->count() - 1
+            )
+        );
+    }
+
+    /**
+     * Build a collapsed list: first item, dropdown of middle items, then the last two.
+     *
+     * @param Collection<int, Crumb> $breadcrumbs
+     *
+     * @return Collection<int, array{breadcrumb: Crumb, current: bool}|array{breadcrumbs: Collection<int, Crumb>}>
+     */
+    private function buildCollapsedItems(Collection $breadcrumbs): Collection
+    {
+        return collect([
+            $this->makeBreadcrumbItem($breadcrumbs->first()),
+            ['breadcrumbs' => $breadcrumbs->slice(self::ITEMS_BEFORE_DROPDOWN, -self::ITEMS_AFTER_DROPDOWN)->values()],
+            $this->makeBreadcrumbItem($breadcrumbs->skip(-self::ITEMS_AFTER_DROPDOWN)->first()),
+            $this->makeBreadcrumbItem($breadcrumbs->last(), current: true),
+        ]);
+    }
+
+    /**
+     * Create a single breadcrumb item.
+     *
+     * @return array{breadcrumb: Crumb, current: bool}
+     */
+    private function makeBreadcrumbItem(Crumb $breadcrumb, bool $current = false): array
+    {
+        return [
+            'breadcrumb' => $breadcrumb,
+            'current'    => $current,
+        ];
+    }
+}

--- a/src/Platform/Providers/FoundationServiceProvider.php
+++ b/src/Platform/Providers/FoundationServiceProvider.php
@@ -12,6 +12,7 @@ use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Events\RequestReceived;
 use Laravel\Scout\ScoutServiceProvider;
 use Orchid\Icons\IconServiceProvider;
+use Orchid\Platform\Components\Breadcrumbs;
 use Orchid\Platform\Components\Notification;
 use Orchid\Platform\Components\Stream;
 use Orchid\Platform\Orchid;
@@ -129,6 +130,7 @@ class FoundationServiceProvider extends ServiceProvider
             );
 
         Blade::component('orchid-popover', Popover::class);
+        Blade::component('orchid-breadcrumbs', Breadcrumbs::class);
         Blade::component('orchid-notification', Notification::class);
         Blade::component('orchid-stream', Stream::class);
     }


### PR DESCRIPTION
## Summary

- replace the direct `x-tabuna-breadcrumbs` rendering with a dedicated Orchid breadcrumb component
- keep short breadcrumb trails unchanged while collapsing the middle of trails longer than three items into a dropdown
- preserve the first item and the final two items so users retain both hierarchy context and the current destination
- render linked and non-linked crumbs appropriately, mark the current item, and provide breadcrumb navigation semantics

## Why

Long breadcrumb trails currently render every item inline. On narrower layouts this consumes significant horizontal space and makes the page hierarchy difficult to scan. Collapsing only the middle section keeps the most useful context visible without losing access to intermediate destinations.

## Implementation

The new `orchid-breadcrumbs` Blade component reads the current trail from the breadcrumb manager and prepares one of two representations:

- up to three crumbs: render the complete trail
- more than three crumbs: render the first crumb, a dropdown containing the middle crumbs, and the final two crumbs

The component does not render when no breadcrumbs are registered. The dashboard now delegates breadcrumb presentation to this component, and the component is registered through `FoundationServiceProvider`.



<img width="1558" height="378" alt="localhost_8000_admin_examples_breadcrumbs_navigation_patterns_hierarchy_current" src="https://github.com/user-attachments/assets/d77ea3e1-4daf-4bbb-ba13-f0791b6b72b0" />


<img width="1558" height="378" alt="localhost_8000_admin_examples_breadcrumbs_navigation_patterns_hierarchy_current (1)" src="https://github.com/user-attachments/assets/66c76e93-e252-4f98-9bb2-465eb8ba0d78" />



## Verification

- `php -l src/Platform/Components/Breadcrumbs.php`
- `php -l src/Platform/Providers/FoundationServiceProvider.php`
- `pint --test src/Platform/Components/Breadcrumbs.php src/Platform/Providers/FoundationServiceProvider.php`
- verified that the branch contains exactly one commit on top of `master`
