### PR TITLE
fix(tables): stabilize filtered headers

### DIFF
--- a/resources/sass/core/tables.scss
+++ b/resources/sass/core/tables.scss
@@ -5,7 +5,7 @@
             th {
                 font-weight: 600;
                 font-size: 0.9em;
-                vertical-align: baseline;
+                vertical-align: top;
                 border-top: 0;
                 color: rgba($dark, 0.55);
                 &:first-child {
@@ -27,6 +27,10 @@
                     &:focus {
                         text-decoration: initial !important;
                     }
+                }
+                .table-sort-indicator {
+                    flex: 0 0 1em;
+                    width: 1em;
                 }
                 .dropdown {
                     position: inherit;

--- a/resources/views/partials/layouts/filter.blade.php
+++ b/resources/views/partials/layouts/filter.blade.php
@@ -1,5 +1,5 @@
 <div class="dropdown d-inline-block" data-controller="filter" data-action="click->filter#onMenuClick">
-    <button class="btn btn-sm btn-link dropdown-toggle p-0 me-1"
+    <button class="btn btn-sm btn-link dropdown-toggle p-0"
             type="button"
             data-bs-toggle="dropdown"
             aria-haspopup="true"

--- a/resources/views/partials/layouts/th.blade.php
+++ b/resources/views/partials/layouts/th.blade.php
@@ -1,19 +1,20 @@
 <th @empty(!$width) width="{{$width}}" @endempty class="text-{{$align}}" data-column="{{ $slug }}">
-    <div class="d-inline-flex align-items-center">
-
+    <div class="d-inline-flex align-items-center align-middle flex-nowrap gap-1 text-nowrap">
         @includeWhen($filter !== null, "orchid::partials.layouts.filter", ['filter' => $filter])
 
         @if($sort)
             <a href="{{ $sortUrl }}"
-               class="@if(!is_sort($column)) text-muted @endif">
+               class="d-inline-flex align-items-center gap-1 @if(!is_sort($column)) text-muted @endif">
                 {!! $title !!}
 
                 <x-orchid-popover :content="$popover"/>
 
-                @if(is_sort($column))
-                    @php $sortIcon = get_sort($column) === 'desc' ? 'bs.sort-down' : 'bs.sort-up' @endphp
-                    <x-orchid-icon :path="$sortIcon"/>
-                @endif
+                <span class="table-sort-indicator d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                    @if(is_sort($column))
+                        @php $sortIcon = get_sort($column) === 'desc' ? 'bs.sort-down' : 'bs.sort-up' @endphp
+                        <x-orchid-icon :path="$sortIcon"/>
+                    @endif
+                </span>
             </a>
         @else
             {!! $title !!}
@@ -34,5 +35,3 @@
         </div>
     @endif
 </th>
-
-

--- a/tests/Unit/Screen/TDFilterTest.php
+++ b/tests/Unit/Screen/TDFilterTest.php
@@ -8,6 +8,24 @@ use Orchid\Tests\TestUnitCase;
 
 class TDFilterTest extends TestUnitCase
 {
+    public function testFilterIsRenderedBeforeTheColumnTitle(): void
+    {
+        $view = (string) TD::make('name', 'Column title')
+            ->filter()
+            ->buildTh();
+
+        $titlePosition = strpos($view, 'Column title');
+        $filterPosition = strpos($view, 'data-controller="filter"');
+
+        $this->assertIsInt($titlePosition);
+        $this->assertIsInt($filterPosition);
+        $this->assertLessThan($titlePosition, $filterPosition);
+        $this->assertStringContainsString(
+            'd-inline-flex align-items-center align-middle flex-nowrap gap-1 text-nowrap',
+            $view,
+        );
+    }
+
     public function testTdSimpleFilter(): void
     {
         request()->replace([

--- a/tests/Unit/Screen/TDForTableTest.php
+++ b/tests/Unit/Screen/TDForTableTest.php
@@ -8,6 +8,16 @@ use Orchid\Tests\TestUnitCase;
 
 class TDForTableTest extends TestUnitCase
 {
+    public function testSortIndicatorSpaceIsReserved(): void
+    {
+        $view = (string) TD::make('name')->sort()->buildTh();
+
+        $this->assertStringContainsString(
+            'table-sort-indicator d-inline-flex align-items-center justify-content-center',
+            $view,
+        );
+    }
+
     public function testShowPopover(): void
     {
         $popover = 'Vivamus sagittis lacus vel augue laoreet rutrum faucibus.';


### PR DESCRIPTION
## Proposed Changes

- align table header content consistently when active filters add a second line
- keep filter controls on the left and reserve sort-indicator space to prevent layout shifts
- add regression coverage for filter order and stable sort-indicator markup

## Testing

- `phpunit tests/Unit/Screen/TDFilterTest.php tests/Unit/Screen/TDForTableTest.php`
- 15 tests, 23 assertions
- verified unfiltered, sorted, and active-filter states in the browser