### PR TITLE
perf: skip empty login lock lookup

### DIFF
--- a/src/Platform/Http/Controllers/LoginController.php
+++ b/src/Platform/Http/Controllers/LoginController.php
@@ -113,22 +113,24 @@ class LoginController extends Controller
     }
 
     /**
-     * @param Guard $guard
+     * Show the application's login form.
      *
      * @return Factory|View
      */
     public function showLoginForm(Request $request)
     {
-        $user = $request->cookie($this->nameForLock());
+        $lockUserId = $request->cookie($this->nameForLock());
 
         /** @var EloquentUserProvider $provider */
         $provider = $this->guard->getProvider();
 
-        $model = $provider->createModel()->find($user);
+        $lockUser = filled($lockUserId)
+            ? $provider->createModel()->find($lockUserId)
+            : null;
 
         return view('orchid::auth.login', [
-            'isLockUser' => optional($model)->exists ?? false,
-            'lockUser'   => $model,
+            'isLockUser' => optional($lockUser)->exists ?? false,
+            'lockUser'   => $lockUser,
         ]);
     }
 

--- a/tests/Feature/Platform/AuthTest.php
+++ b/tests/Feature/Platform/AuthTest.php
@@ -5,18 +5,55 @@ declare(strict_types=1);
 namespace Orchid\Tests\Feature\Platform;
 
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Orchid\Tests\TestFeatureCase;
 
 class AuthTest extends TestFeatureCase
 {
     public function testRouteDashboardLogin(): void
     {
+        DB::enableQueryLog();
+
         $this->get(route('orchid.login'))
             ->assertOk()
             ->assertSee('type="email"', false)
             ->assertSee('type="password"', false)
             ->assertSee('data-password-target="toggle"', false)
             ->assertSee('aria-label="Show password"', false);
+
+        $this->assertLoginDidNotQueryUsers();
+    }
+
+    public function testRouteDashboardLoginWithEmptyLockCookie(): void
+    {
+        DB::enableQueryLog();
+
+        $this->withCookie($this->lockCookieName(), '')
+            ->get(route('orchid.login'))
+            ->assertOk()
+            ->assertSee('type="email"', false);
+
+        $this->assertLoginDidNotQueryUsers();
+    }
+
+    public function testRouteDashboardLoginWithLockCookie(): void
+    {
+        $user = $this->createAdminUser();
+
+        $this->withCookie($this->lockCookieName(), (string) $user->getKey())
+            ->get(route('orchid.login'))
+            ->assertOk()
+            ->assertSee('value="'.$user->email.'"', false)
+            ->assertSee(__('Use another account'));
+    }
+
+    public function testRouteDashboardLoginWithUnknownLockCookie(): void
+    {
+        $this->withCookie($this->lockCookieName(), '999999')
+            ->get(route('orchid.login'))
+            ->assertOk()
+            ->assertSee('type="email"', false)
+            ->assertDontSee(__('Use another account'));
     }
 
     public function testRouteDashboardLoginAuth(): void
@@ -82,5 +119,18 @@ class AuthTest extends TestFeatureCase
 
         $auth->get(route('orchid.index'))
             ->assertRedirect(route('orchid.login'));
+    }
+
+    private function lockCookieName(): string
+    {
+        return sprintf('%s_%s', Auth::guard()->getName(), '_orchid_lock');
+    }
+
+    private function assertLoginDidNotQueryUsers(): void
+    {
+        $queriesUsers = collect(DB::getQueryLog())
+            ->contains(static fn (array $query) => preg_match('/\bfrom\s+["`]?users["`]?/i', $query['query']) === 1);
+
+        $this->assertFalse($queriesUsers, 'Guest login unexpectedly queried the users table.');
     }
 }

--- a/tests/Feature/Platform/GuardAuthTest.php
+++ b/tests/Feature/Platform/GuardAuthTest.php
@@ -40,6 +40,18 @@ class GuardAuthTest extends TestFeatureCase
             ->assertRedirect(route(config('orchid.index')));
     }
 
+    public function testCustomGuardLoadsLockUser(): void
+    {
+        $user = $this->createAdminUser();
+        $cookie = sprintf('%s_%s', Auth::guard('admin')->getName(), '_orchid_lock');
+
+        $this->withCookie($cookie, (string) $user->getKey())
+            ->get(route('orchid.login'))
+            ->assertOk()
+            ->assertSee('value="'.$user->email.'"', false)
+            ->assertSee(__('Use another account'));
+    }
+
     public function testFailCustomGuard(): void
     {
         $this


### PR DESCRIPTION
## Summary

- skip the user lookup when the login lock cookie is missing or empty
- preserve locked-user resolution for default and custom guards
- clarify the lock user variables and login form docblock

## Tests

- php vendor/bin/phpunit tests/Feature/Platform/AuthTest.php tests/Feature/Platform/GuardAuthTest.php