### PR TITLE
perf: optimize field rendering attributes

### DIFF
--- a/src/Screen/Field.php
+++ b/src/Screen/Field.php
@@ -251,7 +251,7 @@ class Field implements Fieldable, Htmlable
         $lang = $this->get('lang');
 
         collect($this->attributes)
-            ->filter(fn ($value, $key) =>  is_string($value) && $this->shouldTranslate($key))
+            ->filter(fn ($value, $key) => is_string($value) && $this->shouldTranslate($key))
             ->each(function ($value, $key) use ($lang) {
                 $translation = __($value, [], $lang);
                 $this->set($key, is_string($translation) ? $translation : $value);
@@ -277,11 +277,23 @@ class Field implements Fieldable, Htmlable
      */
     protected function getAllowAttributes(): ComponentAttributeBag
     {
-        $allow = array_merge($this->universalAttributes, $this->inlineAttributes);
+        $allow = collect(array_merge($this->universalAttributes, $this->inlineAttributes));
+        [$wildcards, $exact] = $allow->partition(fn ($attribute) => str_contains($attribute, '*'));
+
+        $allowsDataAttributes = $wildcards->contains('data-*');
+        $allowsAriaAttributes = $wildcards->contains('aria-*');
+        $wildcards = $wildcards
+            ->reject(fn ($attribute) => in_array($attribute, ['data-*', 'aria-*'], true))
+            ->values()
+            ->all();
+        $exact = $exact->flip();
 
         $attributes = collect($this->getAttributes())
-            ->filter(fn ($value, $attribute) => Str::is($allow, $attribute))
-            ->toArray();
+            ->filter(fn ($value, $attribute) => $exact->has($attribute)
+                || ($allowsDataAttributes && str_starts_with($attribute, 'data-'))
+                || ($allowsAriaAttributes && str_starts_with($attribute, 'aria-'))
+                || ($wildcards !== [] && Str::is($wildcards, $attribute)))
+            ->all();
 
         return (new ComponentAttributeBag())
             ->merge($attributes);
@@ -294,7 +306,7 @@ class Field implements Fieldable, Htmlable
      */
     protected function getAllowDataAttributes(): ComponentAttributeBag
     {
-        return $this->getAllowAttributes()->filter(fn ($value, $key) => Str::startsWith($key, 'data-'));
+        return $this->getAllowAttributes()->whereStartsWith('data-');
     }
 
     /**

--- a/tests/Unit/Screen/Concerns/HasTranslationsTest.php
+++ b/tests/Unit/Screen/Concerns/HasTranslationsTest.php
@@ -2,6 +2,7 @@
 
 namespace Orchid\Tests\Unit\Screen\Concerns;
 
+use Illuminate\Support\Collection;
 use Orchid\Screen\Concerns\HasTranslations;
 use Orchid\Tests\TestUnitCase;
 
@@ -74,5 +75,21 @@ class HasTranslationsTest extends TestUnitCase
 
         $this->assertFalse($this->field->shouldTranslate('summary'));
         $this->assertCount(2, $this->field->getTranslations());
+    }
+
+    public function testTranslationAttributesCanBeOverridden(): void
+    {
+        $field = new class
+        {
+            use HasTranslations;
+
+            protected function translations(): Collection
+            {
+                return collect(['description']);
+            }
+        };
+
+        $this->assertTrue($field->shouldTranslate('description'));
+        $this->assertFalse($field->shouldTranslate('title'));
     }
 }

--- a/tests/Unit/Screen/Fields/BaseFieldTest.php
+++ b/tests/Unit/Screen/Fields/BaseFieldTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Orchid\Tests\Unit\Screen\Fields;
 
+use Illuminate\Http\Request;
+use Illuminate\View\ComponentAttributeBag;
 use Orchid\Screen\Exceptions\FieldRequiredAttributeException;
 use Orchid\Screen\Field;
 use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
@@ -20,6 +22,8 @@ class BaseFieldTest extends TestFieldsUnitCase
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         $field = new class extends Field
         {
             /**
@@ -68,5 +72,104 @@ class BaseFieldTest extends TestFieldsUnitCase
     public function testNoDisplay(): void
     {
         $this->assertNull($this->field->canSee(false)->render());
+    }
+
+    public function testAllowedAttributesPreserveExactAndWildcardPatterns(): void
+    {
+        $field = new class extends Field
+        {
+            protected $universalAttributes = [
+                'class',
+                'data-*',
+                'aria-*',
+            ];
+
+            protected $inlineAttributes = [
+                'href',
+                'custom-*',
+            ];
+
+            protected $attributes = [
+                'class'           => 'form-control',
+                'href'            => '/dashboard',
+                'data-controller' => 'field',
+                'aria-label'      => 'Field',
+                'custom-option'   => 'enabled',
+                'unknown'         => 'discarded',
+            ];
+
+            public function allowedAttributes(): ComponentAttributeBag
+            {
+                return $this->getAllowAttributes();
+            }
+        };
+
+        $this->assertSame([
+            'class'           => 'form-control',
+            'href'            => '/dashboard',
+            'data-controller' => 'field',
+            'aria-label'      => 'Field',
+            'custom-option'   => 'enabled',
+        ], $field->allowedAttributes()->getAttributes());
+    }
+
+    public function testDataAndAriaAttributesRequireMatchingPatterns(): void
+    {
+        $field = new class extends Field
+        {
+            protected $universalAttributes = ['class'];
+
+            protected $attributes = [
+                'class'           => 'form-control',
+                'data-controller' => 'field',
+                'aria-label'      => 'Field',
+            ];
+
+            public function allowedAttributes(): ComponentAttributeBag
+            {
+                return $this->getAllowAttributes();
+            }
+        };
+
+        $this->assertSame([
+            'class' => 'form-control',
+        ], $field->allowedAttributes()->getAttributes());
+    }
+
+    public function testRenderPreservesDataAttributeOverrides(): void
+    {
+        $this->app->instance('request', Request::create('/'));
+
+        $field = new class extends Field
+        {
+            protected $view = 'orchid::actions.link';
+
+            protected $typeForm = null;
+
+            protected $attributes = [
+                'name'            => 'Dashboard',
+                'href'            => '/dashboard',
+                'turbo'           => true,
+                'data-controller' => 'field',
+            ];
+
+            protected $inlineAttributes = [
+                'href',
+            ];
+
+            protected function getAllowDataAttributes(): ComponentAttributeBag
+            {
+                $this->set('data-resolver', 'custom');
+
+                return parent::getAllowDataAttributes();
+            }
+        };
+
+        $view = $field->render();
+
+        $this->assertEquals([
+            'data-controller' => 'field',
+            'data-resolver'   => 'custom',
+        ], $view->getData()['dataAttributes']->getAttributes());
     }
 }


### PR DESCRIPTION
## Summary

- resolve exact field attributes with keyed lookups while retaining wildcard support
- optimize data and ARIA attribute matching without render-scoped mutable state
- preserve translation and data-attribute extension points with regression coverage

## Tests

- php vendor/bin/pint --test src/Screen/Field.php tests/Unit/Screen/Fields/BaseFieldTest.php tests/Unit/Screen/Concerns/HasTranslationsTest.php
- php vendor/bin/phpunit tests/Unit/Screen/Fields tests/Unit/Screen/Concerns