### PR TITLE
perf: reduce dashboard loading overhead

### DIFF
--- a/resources/views/components/notification.blade.php
+++ b/resources/views/components/notification.blade.php
@@ -5,7 +5,7 @@
    class="m-auto d-flex align-items-center btn btn-link position-relative px-1 py-0 h-100 link-body-emphasis"
    data-controller="notification"
    data-action="click->notification#fetch"
-   data-notification-count-value="{{ count($notifications) }}"
+   data-notification-count-value="{{ $unreadCount }}"
    data-notification-url-value="{{ route('orchid.notifications.unreadCount') }}"
    data-notification-method-value="post"
    data-notification-interval-value="{{ config('orchid.notifications.interval') }}"

--- a/src/Platform/Components/Notification.php
+++ b/src/Platform/Components/Notification.php
@@ -13,6 +13,8 @@ use Orchid\Platform\Notifications\OrchidMessage;
 
 class Notification extends Component
 {
+    private const COUNT_INDICATOR_THRESHOLD = 10;
+
     /**
      * @var Authenticatable|null
      */
@@ -33,14 +35,16 @@ class Notification extends Component
      */
     public function render()
     {
-        $notifications = $this->user
+        $unreadCount = $this->user
             ->unreadNotifications()
             ->whereIn('type', [OrchidMessage::class, DashboardMessage::class])
-            ->limit(15)
-            ->get();
+            ->reorder()
+            ->limit(self::COUNT_INDICATOR_THRESHOLD)
+            ->pluck('id')
+            ->count();
 
         return view('orchid::components.notification', [
-            'notifications' => $notifications,
+            'unreadCount' => $unreadCount,
         ]);
     }
 

--- a/src/Platform/Http/Controllers/NotificationController.php
+++ b/src/Platform/Http/Controllers/NotificationController.php
@@ -85,7 +85,7 @@ class NotificationController extends Controller
     public function unreadCount(Request $request): array
     {
         $total = $request->user()
-            ->unreadNotifications
+            ->unreadNotifications()
             ->whereIn('type', [OrchidMessage::class, DashboardMessage::class])
             ->count();
 

--- a/stubs/app/Orchid/Screens/Examples/ExampleScreen.php
+++ b/stubs/app/Orchid/Screens/Examples/ExampleScreen.php
@@ -139,6 +139,7 @@ class ExampleScreen extends Screen
                     ->render(fn (Repository $model) => // Please use view('path')
                     "<img src='https://loremflickr.com/500/300?random={$model->get('id')}'
                               alt='sample'
+                              loading='lazy'
                               class='mw-100 d-block img-fluid rounded-1 w-100'>
                             <span class='small text-muted mt-1 mb-0'># {$model->get('id')}</span>"),
 

--- a/tests/Browser/NotificationTest.php
+++ b/tests/Browser/NotificationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Orchid\Tests\Database\Factory\DatabaseNotificationFactory;
+use Orchid\Tests\TestBrowserCase;
+
+class NotificationTest extends TestBrowserCase
+{
+    public function testNotificationBadgeSwitchesToIndicatorForDoubleDigitCounts(): void
+    {
+        $user = $this->createAdminUser();
+
+        DatabaseNotificationFactory::new()
+            ->count(9)
+            ->for($user, 'notifiable')
+            ->create();
+
+        $this->browse(function (Browser $browser) use ($user) {
+            $badge = '[data-notification-target="badge"]';
+
+            $browser
+                ->loginAs($user)
+                ->visitRoute(config('orchid.index'))
+                ->waitFor("{$badge}:not(.d-none)")
+                ->assertSeeIn($badge, '9')
+                ->assertMissing("{$badge} svg");
+
+            DatabaseNotificationFactory::new()
+                ->count(2)
+                ->for($user, 'notifiable')
+                ->create();
+
+            $browser
+                ->refresh()
+                ->waitFor("{$badge} svg")
+                ->assertDontSeeIn($badge, '10');
+        });
+    }
+}

--- a/tests/Database/Factory/DatabaseNotificationFactory.php
+++ b/tests/Database/Factory/DatabaseNotificationFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Database\Factory;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Notifications\DatabaseNotification;
+use Illuminate\Support\Str;
+use Orchid\Platform\Notifications\OrchidMessage;
+
+class DatabaseNotificationFactory extends Factory
+{
+    protected $model = DatabaseNotification::class;
+
+    public function definition(): array
+    {
+        return [
+            'id'      => (string) Str::uuid(),
+            'type'    => OrchidMessage::class,
+            'data'    => [],
+            'read_at' => null,
+        ];
+    }
+}

--- a/tests/Feature/Platform/NotificationTest.php
+++ b/tests/Feature/Platform/NotificationTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Orchid\Tests\Feature\Platform;
 
+use Illuminate\Notifications\DatabaseNotification;
+use Orchid\Platform\Components\Notification;
 use Orchid\Platform\Models\User;
 use Orchid\Platform\Notifications\OrchidMessage;
 use Orchid\Support\Color;
 use Orchid\Tests\App\Notifications\TaskCompleted;
+use Orchid\Tests\Database\Factory\DatabaseNotificationFactory;
 use Orchid\Tests\TestFeatureCase;
 
 class NotificationTest extends TestFeatureCase
@@ -86,6 +89,31 @@ class NotificationTest extends TestFeatureCase
         $response
             ->assertOk()
             ->assertJson(['total' => 1]);
+
+        $this->assertFalse(
+            $user->relationLoaded('unreadNotifications'),
+            'Counting unread notifications must not hydrate the notification relation.',
+        );
+    }
+
+    public function testNotificationBadgeCapsDoubleDigitCountForFrontendIndicator(): void
+    {
+        $user = $this->createAdminUser();
+
+        DatabaseNotificationFactory::new()
+            ->count(11)
+            ->for($user, 'notifiable')
+            ->create();
+
+        $this->actingAs($user);
+
+        DatabaseNotification::retrieved(
+            fn () => $this->fail('Rendering the notification badge must not hydrate notification models.')
+        );
+
+        $view = $this->app->make(Notification::class)->render();
+
+        $this->assertSame(10, $view->getData()['unreadCount']);
     }
 
     private function createNotifyUser(): User


### PR DESCRIPTION
## Summary

- count unread notifications in SQL instead of hydrating the relation
- cap the initial badge query at 10 because the frontend replaces two-digit counts with an indicator
- fetch only notification IDs and remove unnecessary notification ordering
- preserve custom notification relations by avoiding a hard-coded table name
- cover the numeric-to-indicator transition with a Dusk test
- create notification fixtures declaratively through a dedicated test factory
- lazily load example images

## Tests

- php vendor/bin/pint --test src/Platform/Components/Notification.php src/Platform/Http/Controllers/NotificationController.php tests/Feature/Platform/NotificationTest.php tests/Browser/NotificationTest.php tests/Database/Factory/DatabaseNotificationFactory.php
- php vendor/bin/phpunit tests/Feature/Platform/NotificationTest.php
- php vendor/bin/phpunit --testsuite=Browser --filter=NotificationTest --no-coverage