### PR TITLE
Fix map field not rendering inside an inactive tab (#3097)

### DIFF
--- a/resources/js/controllers/map_controller.js
+++ b/resources/js/controllers/map_controller.js
@@ -64,11 +64,16 @@ export default class extends ApplicationController {
         /**
          * @see https://stackoverflow.com/questions/36246815/data-toggle-tab-does-not-download-leaflet-map/36257493#36257493
          */
-        let tabEl = document.querySelector('a[data-bs-toggle="tab"]');
-        if (tabEl !== null) {
-            tabEl.addEventListener("shown.bs.tab", () =>
-                this.leafletMap.invalidateSize()
+        const tabPane = this.element.closest(".tab-pane");
+        if (tabPane !== null && tabPane.id) {
+            let tabEl = document.querySelector(
+                `a[data-bs-toggle="tab"][data-bs-target="#${tabPane.id}"], a[data-bs-toggle="tab"][href="#${tabPane.id}"]`
             );
+            if (tabEl !== null) {
+                tabEl.addEventListener("shown.bs.tab", () =>
+                    this.leafletMap.invalidateSize()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Closes #3097

The map field's Stimulus controller grabs `document.querySelector('a[data-bs-toggle="tab"]')` on connect, which always returns the first tab-toggle anchor on the page regardless of which tab actually contains the map. With more than one tab (or more than one map), a map inside any tab other than the first one never gets its `shown.bs.tab` listener attached to the right anchor, so `invalidateSize()` is never called when its own tab is activated, and Leaflet renders it at the wrong size since it was initialized while the pane was `display: none`.

This finds the specific tab-pane the map lives in via `closest(".tab-pane")`, then looks up the toggle anchor pointing at that pane's id (`data-bs-target` or `href`) instead of the first one on the page. If the map isn't inside a tab at all, `closest` returns null and nothing is attached, same as before.

There's no existing JS test setup for the Stimulus controllers in this repo (no Jest/Vitest config, no test script in package.json), so I didn't add one. Verified the fix by tracing it against `resources/views/layouts/tabs.blade.php`, where each pane's id is `tab-{sha1($templateSlug.$name)}` and the toggle anchor carries both `data-bs-target="#tab-..."` and `href="#tab-..."` matching that id — so the new selector lines up with the existing markup.
