### PR TITLE
Fix map controls overlapping open dropdowns (#3096)

### DIFF
--- a/resources/sass/components/leaflet.scss
+++ b/resources/sass/components/leaflet.scss
@@ -2,3 +2,15 @@
 .leaflet-touch .leaflet-control-zoom-out {
     font-size: $font-size-base;
 }
+
+// Leaflet sets .leaflet-top/.leaflet-bottom to z-index: 1000, the same value
+// Bootstrap uses for .dropdown-menu. This makes the map's zoom controls render
+// on top of an open select/dropdown list. Keep the map controls just below
+// the dropdown layer so they stay above regular content without covering
+// overlays such as dropdowns or modals.
+.osmap-map {
+    .leaflet-top,
+    .leaflet-bottom {
+        z-index: $zindex-dropdown - 1;
+    }
+}


### PR DESCRIPTION
Closes #3096

Leaflet sets `.leaflet-top`/`.leaflet-bottom` to `z-index: 1000`, same as Bootstrap's `.dropdown-menu`. When a select field sits near a Map field, opening the dropdown puts it behind the map's zoom controls instead of on top.

Added a rule scoped to the map's own container (`.osmap-map`) that puts those controls one step below `$zindex-dropdown`, so they stay above the page content but no longer cover open dropdowns. Kept it scoped to the map field rather than touching Leaflet's z-index globally, since other overlays (modals, toasts) sit even higher and shouldn't be affected.

`resources/sass/components/leaflet.scss` is the only file changed — no PHP/JS behavior involved, so there's nothing to unit test here; verified the SCSS compiles and resolves to `z-index: 999` with Bootstrap's default `$zindex-dropdown`.
