### PR TITLE
Redraw chart when its modal or accordion pane is shown

### DIFF
--- a/resources/js/controllers/chart_controller.js
+++ b/resources/js/controllers/chart_controller.js
@@ -75,7 +75,10 @@ export default class extends ApplicationController {
         }
 
         if (this.collapse !== null) {
-            this.collapse.removeEventListener("shown.bs.collapse", this.drawEvent);
+            this.collapse.removeEventListener(
+                "shown.bs.collapse",
+                this.drawEvent
+            );
         }
     }
 }

--- a/resources/js/controllers/chart_controller.js
+++ b/resources/js/controllers/chart_controller.js
@@ -36,6 +36,19 @@ export default class extends ApplicationController {
         document.querySelectorAll('a[data-bs-toggle="tab"]').forEach(tabElm => {
             tabElm.addEventListener("shown.bs.tab", this.drawEvent);
         });
+
+        // A chart built while its modal or accordion pane is still hidden gets
+        // drawn at zero size, so only its point markers ever show up. Redraw it
+        // once the container is actually shown.
+        this.modal = this.element.closest(".modal");
+        if (this.modal !== null) {
+            this.modal.addEventListener("shown.bs.modal", this.drawEvent);
+        }
+
+        this.collapse = this.element.closest(".collapse");
+        if (this.collapse !== null) {
+            this.collapse.addEventListener("shown.bs.collapse", this.drawEvent);
+        }
     }
 
     /**
@@ -56,5 +69,13 @@ export default class extends ApplicationController {
         document.querySelectorAll('a[data-bs-toggle="tab"]').forEach(tabElm => {
             tabElm.removeEventListener("shown.bs.tab", this.drawEvent);
         });
+
+        if (this.modal !== null) {
+            this.modal.removeEventListener("shown.bs.modal", this.drawEvent);
+        }
+
+        if (this.collapse !== null) {
+            this.collapse.removeEventListener("shown.bs.collapse", this.drawEvent);
+        }
     }
 }


### PR DESCRIPTION
The chart is constructed at `new Chart(this.data.get("parent"), ...)` in `connect()`, which sizes itself off the container's width at that moment. Inside a modal or an accordion pane that's still `display:none`, that's zero — the SVG comes out with `width="0"` and garbage path coordinates. The existing `shown.bs.tab` listener already redraws it for the tab case, but nothing covers a modal or a collapse, matching what's reported: only the chart that happens to be visible on load renders correctly.

Same fix as the tab one: find the closest `.modal` / `.collapse` ancestor and redraw on `shown.bs.modal` / `shown.bs.collapse`.

Reproduced this outside the app with the actual `frappe-charts` build and a real Bootstrap 5 modal/collapse — confirmed a chart built while hidden renders with `width="0"` and negative/garbage path coordinates, and that firing the same redraw this PR adds fixes both cases (`width` comes back correct and the path matches a chart built while visible). No JS test harness exists in this repo for Stimulus controllers (same as #3130), so that browser check is what I verified against instead of an automated test.

Fixes #3089
