### PR TITLE
Skip empty-string selected values in lazy Select (#3136)

### DIFF
--- a/src/Screen/Fields/Support/ChoicePayload.php
+++ b/src/Screen/Fields/Support/ChoicePayload.php
@@ -266,6 +266,12 @@ final readonly class ChoicePayload implements Stringable
      */
     private function selectedItems(iterable $keys): iterable
     {
+        $keys = collect($keys)->filter(fn ($key): bool => $key !== null && $key !== '')->values();
+
+        if ($keys->isEmpty()) {
+            return [];
+        }
+
         $query = $this->query();
 
         return $query instanceof Builder

--- a/tests/Unit/Screen/Fields/ChoicePayloadTest.php
+++ b/tests/Unit/Screen/Fields/ChoicePayloadTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Orchid\Tests\Unit\Screen\Fields;
+
+use Illuminate\Support\Facades\DB;
+use Orchid\Platform\Models\Role;
+use Orchid\Screen\Fields\Support\ChoicePayload;
+use Orchid\Tests\Unit\Screen\TestFieldsUnitCase;
+
+/**
+ * Class ChoicePayloadTest.
+ */
+class ChoicePayloadTest extends TestFieldsUnitCase
+{
+    public function testSelectedOptionsIgnoresBlankValuesWithoutQuerying(): void
+    {
+        $payload = new ChoicePayload(model: Role::class, name: 'name', key: 'id');
+
+        DB::enableQueryLog();
+
+        $options = $payload->selectedOptions('');
+
+        $this->assertSame([], $options);
+        $this->assertEmpty(DB::getQueryLog());
+
+        DB::disableQueryLog();
+    }
+
+    public function testSelectedOptionsIgnoresNullAmongSelectedValues(): void
+    {
+        $role = Role::factory()->create();
+
+        $payload = new ChoicePayload(model: Role::class, name: 'name', key: 'id');
+
+        $options = $payload->selectedOptions([$role->id, null, '']);
+
+        $this->assertCount(1, $options);
+        $this->assertSame($role->id, $options[0]['id']);
+    }
+}


### PR DESCRIPTION
Fixes #3136.

`ChoicePayload::selectedItems()` runs `whereIn($key, $keys)` unconditionally, even when the incoming selected value is an empty string. That happens for real whenever a lazy `Select` field is redisplayed after a failed validation and `old()` returns `""` for a select the user left empty. On a strict-typed PK column (Postgres bigint, for example) that query blows up instead of just showing no selection. Same bug class as the Matrix/Relation fix in #3040, just resurfaced in the new unified Select field's lazy path.

Filtered out null/empty-string keys before building the query, and skip the query entirely if nothing's left. Added a test asserting no query runs for a blank value (fails before the fix, since the old code always hits the DB), plus one covering a null mixed into a real selected value.

Ran `tests/Unit/Screen/Fields/ChoicePayloadTest.php`, `SelectTest.php`, `SelectWithEnumTest.php`, and `MatrixTest.php` — all green. Also ran Pint on the touched files.
